### PR TITLE
Recover existing wallets after secure-storage loss

### DIFF
--- a/integration_test/regtest_custom_endpoint_no_fallback_test.dart
+++ b/integration_test/regtest_custom_endpoint_no_fallback_test.dart
@@ -127,7 +127,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -137,6 +137,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_fallback_endpoint_test.dart
+++ b/integration_test/regtest_fallback_endpoint_test.dart
@@ -123,7 +123,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -133,6 +133,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_import_sync_test.dart
+++ b/integration_test/regtest_import_sync_test.dart
@@ -127,7 +127,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -137,6 +137,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_mempool_receive_history_test.dart
+++ b/integration_test/regtest_mempool_receive_history_test.dart
@@ -841,7 +841,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -851,6 +851,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_multi_account_send_test.dart
+++ b/integration_test/regtest_multi_account_send_test.dart
@@ -602,7 +602,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -612,6 +612,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_shield_transparent_retry_test.dart
+++ b/integration_test/regtest_shield_transparent_retry_test.dart
@@ -647,7 +647,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -657,6 +657,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_shield_transparent_test.dart
+++ b/integration_test/regtest_shield_transparent_test.dart
@@ -575,7 +575,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -585,6 +585,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_slow_height_fallback_test.dart
+++ b/integration_test/regtest_slow_height_fallback_test.dart
@@ -213,7 +213,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -223,6 +223,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_tex_send_test.dart
+++ b/integration_test/regtest_tex_send_test.dart
@@ -527,7 +527,7 @@ Future<void> _cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
@@ -537,6 +537,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();

--- a/integration_test/regtest_voting_test.dart
+++ b/integration_test/regtest_voting_test.dart
@@ -249,10 +249,11 @@ Future<void> _cleanupE2eWalletState() async {
       DateTime.now().isBefore(deadline)) {
     await Future<void>.delayed(const Duration(milliseconds: 100));
   }
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
   await AppSecureStore.instance.deleteAll();
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
+  if (dbName == null) return;
   for (final name in [
     dbName,
     '$dbName-shm',

--- a/integration_test/support/desktop_regtest_flow.dart
+++ b/integration_test/support/desktop_regtest_flow.dart
@@ -369,7 +369,7 @@ Future<void> cleanupDesktopRegtestWallet() async {
     torDirectory: '',
   );
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
   await storage.deleteAll();
 
   final preferences = await SharedPreferences.getInstance();
@@ -382,6 +382,7 @@ Future<void> cleanupDesktopRegtestWallet() async {
 
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
+  if (dbName == null) return;
   for (final name in [
     dbName,
     '$dbName-shm',

--- a/integration_test/support/mobile_regtest_flow.dart
+++ b/integration_test/support/mobile_regtest_flow.dart
@@ -245,7 +245,7 @@ Future<void> cleanupE2eWalletState() async {
   }
 
   final storage = AppSecureStore.instance;
-  final dbName = await getWalletDbName();
+  final dbName = await readWalletDbName();
 
   logE2e('cleaning regtest wallet state');
   await stopRustWorkForCleanup();
@@ -265,6 +265,7 @@ Future<void> cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
+  if (dbName == null) return;
   final votingCache = Directory('${supportDir.path}/$dbName.voting-cache');
   if (await votingCache.exists()) await votingCache.delete(recursive: true);
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -62,6 +62,7 @@ import 'src/features/onboarding/lost_password_screen.dart';
 import 'src/features/onboarding/shared/onboarding_flow_args.dart';
 import 'src/features/onboarding/shared/set_password_screen.dart';
 import 'src/features/onboarding/storage_unavailable_screen.dart';
+import 'src/features/onboarding/wallet_recovery_screen.dart';
 import 'src/features/onboarding/mobile/mobile_unlock_screen.dart';
 import 'src/features/onboarding/unlock_screen.dart';
 import 'src/features/onboarding/welcome.dart';
@@ -361,6 +362,11 @@ String? appRedirect({
   required AppBootstrapState bootstrap,
   required GoRouterState state,
 }) {
+  if (bootstrap.walletRecovery != null) {
+    return state.matchedLocation == '/wallet-recovery'
+        ? null
+        : '/wallet-recovery';
+  }
   final walletAsync = ref.read(walletProvider);
   final security = ref.read(appSecurityProvider);
   final isStorageUnavailable = state.matchedLocation == '/storage-unavailable';
@@ -394,7 +400,7 @@ String? appRedirect({
     'requiresUnlock=$requiresUnlock, isOnboarding=$isOnboarding',
   );
 
-  if (isStorageUnavailable) {
+  if (isStorageUnavailable || state.matchedLocation == '/wallet-recovery') {
     if (!hasWallet) return '/welcome';
     return requiresUnlock ? '/unlock' : '/home';
   }
@@ -436,6 +442,7 @@ List<RouteBase> appAuthRoutes(
   GoRoute(
     path: '/',
     redirect: (_, _) {
+      if (bootstrap.walletRecovery != null) return '/wallet-recovery';
       if (bootstrap.hasBlockingFailure) return '/storage-unavailable';
       final walletAsync = ref.read(walletProvider);
       final security = ref.read(appSecurityProvider);
@@ -451,6 +458,10 @@ List<RouteBase> appAuthRoutes(
   GoRoute(
     path: '/storage-unavailable',
     builder: (_, _) => const StorageUnavailableScreen(),
+  ),
+  GoRoute(
+    path: '/wallet-recovery',
+    builder: (_, _) => const WalletRecoveryScreen(),
   ),
   GoRoute(path: '/unlock', builder: (_, _) => unlockScreen),
   GoRoute(

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart' show kDebugMode, visibleForTesting;
 import 'package:flutter/material.dart' show ThemeMode;
@@ -12,8 +13,9 @@ import 'core/config/rpc_endpoint_config.dart';
 import 'core/config/swap_remote_enable_config.dart';
 import 'core/config/zcash_explorer.dart';
 import 'core/storage/app_secure_store.dart';
-import 'core/storage/wallet_paths.dart';
 import 'core/storage/secure_storage_diagnostics.dart';
+import 'core/storage/wallet_paths.dart';
+import 'core/storage/wallet_recovery.dart';
 import 'providers/account_models.dart';
 import 'rust/api/sync.dart' as rust_sync;
 import 'rust/api/wallet.dart' as rust_wallet;
@@ -63,6 +65,7 @@ class AppBootstrapState {
     this.syncKeepAwakePromptSeen = false,
     this.failureKind,
     this.failureMessage,
+    this.walletRecovery,
   });
 
   final String initialLocation;
@@ -86,6 +89,7 @@ class AppBootstrapState {
   final bool passwordRotationRecoveryFailed;
   final AppBootstrapFailureKind? failureKind;
   final String? failureMessage;
+  final WalletRecoveryState? walletRecovery;
 
   bool get hasWallet => initialAccountState.hasAccounts;
   bool get requiresUnlock => hasWallet && !isUnlocked;
@@ -121,6 +125,21 @@ class AppBootstrapState {
     failureKind: failureKind,
     failureMessage: failureMessage,
   );
+
+  static AppBootstrapState recovery(WalletRecoveryState recovery) =>
+      AppBootstrapState(
+        initialLocation: '/wallet-recovery',
+        initialAccountState: const AccountState(),
+        initialSyncSnapshot: AppSyncSnapshot.empty,
+        network: recovery.network,
+        rpcEndpointConfig: defaultRpcEndpointConfig(recovery.network),
+        themeMode: ThemeMode.system,
+        privacyModeEnabled: false,
+        isPasswordConfigured: recovery.isPasswordConfigured,
+        isUnlocked: false,
+        passwordRotationRecoveryFailed: false,
+        walletRecovery: recovery,
+      );
 }
 
 class AppSyncSnapshot {
@@ -223,7 +242,6 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       StorageBootstrapStage.started,
     );
     await ensureIosSecureStoreAccessibilityMigrated();
-    await storage.ensureWalletDbName();
     await _applyE2eBootstrapOverrides(storage);
     var passwordRotationRecoveryFailed = false;
     try {
@@ -258,11 +276,56 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       key: kSyncKeepAwakePromptSeenKey,
       label: 'sync keep-awake prompt seen flag',
     );
-    final isPasswordConfigured = await storage.isPasswordConfigured();
+    var isPasswordConfigured = await storage.isPasswordConfigured();
     final isUnlocked = storage.hasSessionPassword;
-    final dbPath = await _getDbPath();
-    final databaseExists = rust_wallet.walletExists(dbPath: dbPath);
-    if (databaseExists) {
+    final storedAccounts = await _readStoredAccounts(storage);
+    final storedActiveUuid = await storage.readString(_activeAccountKey);
+    final dbName = await storage.readPlain(kWalletDbNameKey);
+    final support = await getWalletSupportDirectory();
+    final dbPath = isWalletDbFileName(dbName)
+        ? '${support.path}${Platform.pathSeparator}$dbName'
+        : null;
+    final hasExistingDb =
+        dbPath != null &&
+        await FileSystemEntity.type(dbPath, followLinks: false) ==
+            FileSystemEntityType.file;
+    final interruptedRecovery = await storage.readPlain(
+      kWalletRecoveryPendingKey,
+    );
+    var canResumeEmptySetup = false;
+    if (!hasExistingDb ||
+        !isPasswordConfigured ||
+        interruptedRecovery != null) {
+      final candidates = await findWalletRecoveryCandidates(network: network);
+      canResumeEmptySetup =
+          interruptedRecovery == kWalletSetupPendingValue &&
+          (dbName == null ? candidates.isEmpty : hasExistingDb) &&
+          storedAccounts.isEmpty &&
+          storedActiveUuid == null &&
+          candidates.every((candidate) => candidate.isEmptyDatabase);
+      if (canResumeEmptySetup) {
+        // No native account exists yet. Keep the unused file and credentials;
+        // explicit setup may safely resume after another password entry.
+        isPasswordConfigured = false;
+      }
+      final hasWalletEvidence =
+          candidates.isNotEmpty ||
+          dbName != null ||
+          storedAccounts.isNotEmpty ||
+          storedActiveUuid != null ||
+          isPasswordConfigured ||
+          interruptedRecovery != null;
+      if (hasWalletEvidence && !canResumeEmptySetup) {
+        return AppBootstrapState.recovery(
+          WalletRecoveryState(
+            candidates: candidates,
+            network: network,
+            isPasswordConfigured: isPasswordConfigured,
+          ),
+        );
+      }
+    }
+    if (hasExistingDb && !canResumeEmptySetup) {
       try {
         log('bootstrap: ensuring wallet DB migrations before startup snapshot');
         await rust_wallet.ensureWalletDbMigrated(
@@ -280,21 +343,19 @@ Future<AppBootstrapState> loadAppBootstrap() async {
         );
       }
     }
-    final storedAccounts = await _readStoredAccounts(storage);
     final storedAccountsByUuid = {
       for (final account in storedAccounts) account.uuid: account,
     };
-    final storedActiveUuid = await storage.readString(_activeAccountKey);
     await SecureStorageDiagnostics.instance.bootstrap(
       StorageBootstrapStage.metadata,
       passwordConfigured: isPasswordConfigured,
-      databaseExists: databaseExists,
+      databaseExists: hasExistingDb,
       storedAccountCount: storedAccounts.length,
     );
 
     var rustAccounts = <AccountInfo>[];
     final rustAddressesByUuid = <String, String>{};
-    if (rust_wallet.walletExists(dbPath: dbPath)) {
+    if (hasExistingDb && !canResumeEmptySetup) {
       try {
         final listed = await rust_wallet.listAccounts(
           dbPath: dbPath,
@@ -322,6 +383,21 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       }
     }
 
+    if (hasExistingDb &&
+        !canResumeEmptySetup &&
+        (rustAccounts.isEmpty ||
+            storedAccounts.any(
+              (stored) => !rustAccounts.any((a) => a.uuid == stored.uuid),
+            ))) {
+      return AppBootstrapState.recovery(
+        WalletRecoveryState(
+          candidates: await findWalletRecoveryCandidates(network: network),
+          network: network,
+          isPasswordConfigured: isPasswordConfigured,
+        ),
+      );
+    }
+
     final accounts = rustAccounts.isNotEmpty ? rustAccounts : storedAccounts;
     final activeAccountUuid = _resolveActiveUuid(storedActiveUuid, accounts);
     final activeAddress = !isUnlocked || activeAccountUuid == null
@@ -330,10 +406,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     final hasWallet = accounts.isNotEmpty;
     var initialSyncSnapshot = AppSyncSnapshot.empty;
 
-    if (isUnlocked &&
-        hasWallet &&
-        activeAccountUuid != null &&
-        rust_wallet.walletExists(dbPath: dbPath)) {
+    if (isUnlocked && hasWallet && activeAccountUuid != null && hasExistingDb) {
       initialSyncSnapshot = await _loadInitialSyncSnapshot(
         dbPath: dbPath,
         network: network,
@@ -581,10 +654,6 @@ String? _resolveActiveUuid(
     return storedActiveUuid;
   }
   return accounts.first.uuid;
-}
-
-Future<String> _getDbPath() async {
-  return getWalletDbPath();
 }
 
 Future<AppSyncSnapshot> _loadInitialSyncSnapshot({

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -278,7 +278,15 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     );
     var isPasswordConfigured = await storage.isPasswordConfigured();
     final isUnlocked = storage.hasSessionPassword;
-    final storedAccounts = await _readStoredAccounts(storage);
+    var storedAccounts = <AccountInfo>[];
+    var hasDamagedAccountMetadata = false;
+    try {
+      storedAccounts = await _readStoredAccounts(storage);
+    } on FormatException {
+      hasDamagedAccountMetadata = true;
+    } on TypeError {
+      hasDamagedAccountMetadata = true;
+    }
     final storedActiveUuid = await storage.readString(_activeAccountKey);
     final dbName = await storage.readPlain(kWalletDbNameKey);
     final support = await getWalletSupportDirectory();
@@ -295,16 +303,20 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     var canResumeEmptySetup = false;
     if (!hasExistingDb ||
         !isPasswordConfigured ||
+        hasDamagedAccountMetadata ||
         interruptedRecovery != null) {
       final candidates = await findWalletRecoveryCandidates(network: network);
       canResumeEmptySetup =
           interruptedRecovery == kWalletSetupPendingValue &&
-          (dbName == null ? candidates.isEmpty : hasExistingDb) &&
+          !hasDamagedAccountMetadata &&
+          (dbName == null
+              ? candidates.isEmpty
+              : dbPath != null && (hasExistingDb || candidates.isEmpty)) &&
           storedAccounts.isEmpty &&
           storedActiveUuid == null &&
           candidates.every((candidate) => candidate.isEmptyDatabase);
       if (canResumeEmptySetup) {
-        // No native account exists yet. Keep the unused file and credentials;
+        // No native account exists yet. Keep the locator and credentials;
         // explicit setup may safely resume after another password entry.
         isPasswordConfigured = false;
       }
@@ -312,6 +324,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
           candidates.isNotEmpty ||
           dbName != null ||
           storedAccounts.isNotEmpty ||
+          hasDamagedAccountMetadata ||
           storedActiveUuid != null ||
           isPasswordConfigured ||
           interruptedRecovery != null;

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -212,6 +212,12 @@ class AppSecureStore {
       return existing;
     }
 
+    return createWalletDbName();
+  }
+
+  /// Allocate a name only for an explicit new-wallet operation.
+  /// Startup and reads must never replace a missing pointer with a new name.
+  Future<String> createWalletDbName() async {
     final suffix = _randomHex(12);
     final dbName = 'zcash_wallet_$suffix.db';
     await writePlain(kWalletDbNameKey, dbName);
@@ -394,6 +400,20 @@ class AppSecureStore {
         _checkSessionGeneration(generation);
         return _mnemonicStorage.write(key: key, value: payload);
       });
+      final saved = await _runStorageOperation(
+        'read account mnemonic after write "$accountUuid"',
+        () {
+          _checkSessionGeneration(generation);
+          return _mnemonicStorage.read(key: key);
+        },
+      );
+      _checkSessionGeneration(generation);
+      if (saved != payload) {
+        throw const SecureStorageUnavailableException(
+          operation: 'verify saved account mnemonic',
+          cause: 'The stored recovery material did not match the write.',
+        );
+      }
     });
   }
 

--- a/lib/src/core/storage/wallet_paths.dart
+++ b/lib/src/core/storage/wallet_paths.dart
@@ -30,8 +30,32 @@ Future<Directory> getWalletSupportDirectory() async {
   return dir;
 }
 
+Future<String?> readWalletDbName() async {
+  final name = await AppSecureStore.instance.readPlain(kWalletDbNameKey);
+  if (name == null || name.isEmpty) return null;
+  if (!isWalletDbFileName(name)) {
+    throw StateError('The wallet database connection needs to be recovered.');
+  }
+  return name;
+}
+
 Future<String> getWalletDbName() async {
-  return AppSecureStore.instance.ensureWalletDbName();
+  final name = await readWalletDbName();
+  if (name == null) {
+    throw StateError('The wallet database connection needs to be recovered.');
+  }
+  return name;
+}
+
+/// DB pointers are basenames inside the app support directory, never paths.
+bool isWalletDbFileName(String? name) =>
+    name != null &&
+    RegExp(r'^zcash_wallet(?:_[a-zA-Z0-9_-]+)?\.db$').hasMatch(name);
+
+Future<String> createWalletDbPath() async {
+  final dir = await getWalletSupportDirectory();
+  final name = await AppSecureStore.instance.createWalletDbName();
+  return '${dir.path}${Platform.pathSeparator}$name';
 }
 
 Future<String> getWalletDbPath() async {

--- a/lib/src/core/storage/wallet_recovery.dart
+++ b/lib/src/core/storage/wallet_recovery.dart
@@ -1,0 +1,333 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../security/software_wallet_secret.dart';
+import '../../providers/account_models.dart';
+import '../../rust/api/sync.dart' as rust_sync;
+import '../../rust/api/wallet.dart' as rust_wallet;
+import 'app_secure_store.dart';
+import 'wallet_paths.dart';
+
+const kWalletRecoveryPendingKey = 'zcash_wallet_recovery_pending';
+const kWalletSetupPendingValue = 'onboarding';
+
+class WalletRecoveryCandidate {
+  const WalletRecoveryCandidate({
+    required this.path,
+    required this.fileName,
+    required this.network,
+    required this.accounts,
+    this.error,
+    this.isEmptyDatabase = false,
+  });
+
+  final String path;
+  final String fileName;
+  final String network;
+  final List<rust_wallet.AccountInfo> accounts;
+  final String? error;
+  final bool isEmptyDatabase;
+
+  bool get canInspect => error == null && accounts.isNotEmpty;
+}
+
+class WalletRecoveryState {
+  const WalletRecoveryState({
+    required this.candidates,
+    required this.network,
+    required this.isPasswordConfigured,
+  });
+
+  final List<WalletRecoveryCandidate> candidates;
+  final String network;
+  final bool isPasswordConfigured;
+}
+
+/// Discover only recognized files in the current application's directory.
+/// A malformed or unreadable candidate remains visible as an error; it must
+/// never make an existing installation look empty.
+Future<List<WalletRecoveryCandidate>> findWalletRecoveryCandidates({
+  required String network,
+}) async {
+  final directory = await getWalletSupportDirectory();
+  final names = <String>{};
+  await for (final entry in directory.list(followLinks: false)) {
+    final name = entry.uri.pathSegments.last;
+    if (isWalletDbFileName(name)) {
+      names.add(name);
+    } else if ((name.endsWith('-wal') || name.endsWith('-shm')) &&
+        isWalletDbFileName(name.substring(0, name.length - 4))) {
+      names.add(name.substring(0, name.length - 4));
+    }
+  }
+  final candidates = <WalletRecoveryCandidate>[];
+  for (final name in names.toList()..sort()) {
+    final file = File('${directory.path}${Platform.pathSeparator}$name');
+    List<rust_wallet.AccountInfo> accounts = const [];
+    String? error;
+    var isEmptyDatabase = false;
+    try {
+      if (await FileSystemEntity.type(file.path, followLinks: false) !=
+          FileSystemEntityType.file) {
+        throw StateError(
+          'The original wallet database is missing or is not a regular file.',
+        );
+      }
+      accounts = await rust_wallet.inspectWalletForRecovery(
+        dbPath: file.path,
+        network: network,
+      );
+      if (accounts.isEmpty) {
+        isEmptyDatabase = true;
+        error = 'No wallet accounts were found in this file.';
+      }
+    } catch (_) {
+      error =
+          'This wallet file could not be read. Keep the original file and try again.';
+    }
+    candidates.add(
+      WalletRecoveryCandidate(
+        path: file.path,
+        fileName: file.uri.pathSegments.last,
+        network: network,
+        accounts: accounts,
+        error: error,
+        isEmptyDatabase: isEmptyDatabase,
+      ),
+    );
+  }
+  return candidates;
+}
+
+/// A recovery session never writes the DB. It verifies every account before
+/// committing the existing file's locator and reconstructed account metadata.
+/// Partial proofs stay in this session and are shown as recovery progress.
+class WalletRecoverySession {
+  WalletRecoverySession({required this.candidate, AppSecureStore? store})
+    : _store = store ?? AppSecureStore.instance;
+
+  final WalletRecoveryCandidate candidate;
+  final AppSecureStore _store;
+  final _softwareSecrets = <String, SoftwareWalletSecret>{};
+  final _hardwareKeys = <String, String>{};
+  bool _authenticated = false;
+  bool _committing = false;
+
+  bool get hasEstablishedPassword => _authenticated;
+
+  bool isVerified(String uuid) =>
+      _softwareSecrets.containsKey(uuid) || _hardwareKeys.containsKey(uuid);
+
+  bool get canReconnect =>
+      candidate.canInspect &&
+      candidate.accounts.every((a) => isVerified(a.uuid));
+
+  Future<bool> unlockExistingSecrets(String password) async {
+    _authenticated = false;
+    _store.clearSessionPassword();
+    if (!await _store.verifyPassword(password)) return false;
+    _authenticated = true;
+    for (final account in candidate.accounts.where((a) => !a.isHardware)) {
+      SoftwareWalletSecret? secret;
+      try {
+        secret = await _store.readAccountSoftwareWalletSecret(
+          account.uuid,
+          requireUnlockedSession: true,
+        );
+      } on SecureStorageUnavailableException {
+        rethrow;
+      } catch (_) {
+        // Missing or damaged account secrets require recovery material.
+        // Do not replace them until the supplied key matches this DB account.
+        continue;
+      }
+      if (secret != null) await verifySoftwareSecret(account.uuid, secret);
+    }
+    return true;
+  }
+
+  Future<bool> verifySoftwareSecret(
+    String uuid,
+    SoftwareWalletSecret secret,
+  ) async {
+    final account = candidate.accounts.where((a) => a.uuid == uuid).firstOrNull;
+    if (account == null || account.isHardware) return false;
+    final matches = await rust_wallet.verifyRecoveryMnemonic(
+      dbPath: candidate.path,
+      network: candidate.network,
+      accountUuid: uuid,
+      mnemonic: secret.mnemonic,
+      bip39Passphrase: secret.bip39Passphrase,
+    );
+    if (matches) _softwareSecrets[uuid] = secret;
+    return matches;
+  }
+
+  Future<bool> verifyHardwareKey(String uuid, String ufvk) async {
+    final account = candidate.accounts.where((a) => a.uuid == uuid).firstOrNull;
+    if (account == null || !account.isHardware) return false;
+    final matches = await rust_wallet.verifyRecoveryHardwareKey(
+      dbPath: candidate.path,
+      network: candidate.network,
+      accountUuid: uuid,
+      ufvk: ufvk,
+    );
+    if (matches) _hardwareKeys[uuid] = ufvk;
+    return matches;
+  }
+
+  Future<void> reconnect({String? newPassword}) async {
+    if (_committing) {
+      throw StateError('Wallet recovery is already in progress.');
+    }
+    if (!canReconnect) {
+      throw StateError('Verify every account before reconnecting this wallet.');
+    }
+    _committing = true;
+    try {
+      final support = await getWalletSupportDirectory();
+      if (!isWalletDbFileName(candidate.fileName) ||
+          candidate.path !=
+              '${support.path}${Platform.pathSeparator}${candidate.fileName}' ||
+          await FileSystemEntity.type(candidate.path, followLinks: false) !=
+              FileSystemEntityType.file) {
+        throw StateError(
+          'This wallet file is no longer in the app data folder.',
+        );
+      }
+      if (rust_sync.isSyncRunning()) {
+        throw StateError(
+          'Wallet sync is still running. Try recovery again after it stops.',
+        );
+      }
+      final passwordConfigured = await _store.isPasswordConfigured();
+      if (passwordConfigured &&
+          (!_authenticated || !_store.hasSessionPassword)) {
+        throw StateError(
+          'Unlock with your existing password before reconnecting.',
+        );
+      }
+      if (!passwordConfigured && newPassword == null) {
+        throw StateError(
+          'Set a password after verifying your recovery material.',
+        );
+      }
+      // Inspect and prove again at commit time; the selected file may have
+      // changed while the user was entering recovery material.
+      final current = await rust_wallet.inspectWalletForRecovery(
+        dbPath: candidate.path,
+        network: candidate.network,
+      );
+      final expected = candidate.accounts.map((a) => a.uuid).toSet();
+      if (current.length != expected.length ||
+          !current.every((a) => expected.contains(a.uuid))) {
+        throw StateError('This wallet file changed. Retry recovery.');
+      }
+      for (final account in current) {
+        final verified = account.isHardware
+            ? await rust_wallet.verifyRecoveryHardwareKey(
+                dbPath: candidate.path,
+                network: candidate.network,
+                accountUuid: account.uuid,
+                ufvk: _hardwareKeys[account.uuid] ?? '',
+              )
+            : await rust_wallet.verifyRecoveryMnemonic(
+                dbPath: candidate.path,
+                network: candidate.network,
+                accountUuid: account.uuid,
+                mnemonic: _softwareSecrets[account.uuid]?.mnemonic ?? '',
+                bip39Passphrase:
+                    _softwareSecrets[account.uuid]?.bip39Passphrase ?? '',
+              );
+        if (!verified) {
+          throw StateError('An account no longer matches this wallet file.');
+        }
+      }
+
+      final storedByUuid = <String, Map<String, dynamic>>{};
+      final stored = await _store.readString('zcash_accounts');
+      if (stored != null) {
+        try {
+          for (final item in jsonDecode(stored) as List<dynamic>) {
+            final value = Map<String, dynamic>.from(item as Map);
+            if (value['uuid'] case final String uuid) {
+              storedByUuid[uuid] = value;
+            }
+          }
+        } on FormatException {
+          // Account presentation metadata can be reconstructed from the DB.
+        } on TypeError {
+          // Retain the original until the verified replacement is committed.
+        }
+      }
+      final accounts = current.indexed.map((entry) {
+        final (index, account) = entry;
+        return AccountInfo.fromJson({
+          ...?storedByUuid[account.uuid],
+          'uuid': account.uuid,
+          'name': storedByUuid[account.uuid]?['name'] ?? account.name,
+          'order': index,
+          'isHardware': account.isHardware,
+          'isSeedAnchor': account.isSeedAnchor,
+        });
+      }).toList();
+      final active = await _store.readString('zcash_active_account');
+      final activeUuid = expected.contains(active)
+          ? active!
+          : accounts.first.uuid;
+      final encodedAccounts = jsonEncode(
+        accounts.map((a) => a.toJson()).toList(),
+      );
+
+      // A crash during credential or metadata writes must return to recovery,
+      // including when an otherwise valid old pointer is still present.
+      await _store.writePlain(kWalletRecoveryPendingKey, candidate.fileName);
+      if (!passwordConfigured) {
+        await _store.configurePassword(newPassword!);
+        _authenticated = true;
+      }
+      for (final entry in _softwareSecrets.entries) {
+        await _store.writeAccountMnemonic(
+          entry.key,
+          entry.value.mnemonic,
+          bip39Passphrase: entry.value.bip39Passphrase,
+        );
+        final saved = await _store.readAccountSoftwareWalletSecret(
+          entry.key,
+          requireUnlockedSession: true,
+        );
+        if (saved?.mnemonic != entry.value.mnemonic ||
+            saved?.bip39Passphrase != entry.value.bip39Passphrase) {
+          throw StateError(
+            'A recovered account could not be saved. Retry recovery.',
+          );
+        }
+      }
+      await _store.writeString('zcash_wallet_network', candidate.network);
+      await _store.writeString('zcash_accounts', encodedAccounts);
+      await _store.writeString('zcash_active_account', activeUuid);
+      await _store.writePlain(kWalletDbNameKey, candidate.fileName);
+      if (await _store.readPlain(kWalletDbNameKey) != candidate.fileName ||
+          await _store.readString('zcash_wallet_network') !=
+              candidate.network ||
+          await _store.readString('zcash_accounts') != encodedAccounts ||
+          await _store.readString('zcash_active_account') != activeUuid) {
+        throw StateError(
+          'The wallet connection could not be saved. Retry recovery.',
+        );
+      }
+      await _store.delete(kWalletRecoveryPendingKey);
+      // Re-enter through the ordinary unlock flow after bootstrap reload.
+      _store.clearSessionPassword();
+    } finally {
+      _committing = false;
+    }
+  }
+
+  void dispose() {
+    _softwareSecrets.clear();
+    _hardwareKeys.clear();
+    _authenticated = false;
+    _store.clearSessionPassword();
+  }
+}

--- a/lib/src/core/storage/wallet_recovery.dart
+++ b/lib/src/core/storage/wallet_recovery.dart
@@ -248,27 +248,34 @@ class WalletRecoverySession {
       final stored = await _store.readString('zcash_accounts');
       if (stored != null) {
         try {
-          for (final item in jsonDecode(stored) as List<dynamic>) {
-            final value = Map<String, dynamic>.from(item as Map);
-            if (value['uuid'] case final String uuid) {
-              storedByUuid[uuid] = value;
+          final decoded = jsonDecode(stored);
+          if (decoded is List) {
+            for (final item in decoded) {
+              if (item is Map<String, dynamic> && item['uuid'] is String) {
+                storedByUuid[item['uuid'] as String] = item;
+              }
             }
           }
         } on FormatException {
           // Account presentation metadata can be reconstructed from the DB.
-        } on TypeError {
-          // Retain the original until the verified replacement is committed.
         }
       }
       final accounts = current.indexed.map((entry) {
         final (index, account) = entry;
+        final storedAccount = storedByUuid[account.uuid];
         return AccountInfo.fromJson({
-          ...?storedByUuid[account.uuid],
           'uuid': account.uuid,
-          'name': storedByUuid[account.uuid]?['name'] ?? account.name,
+          'name': storedAccount?['name'] is String
+              ? storedAccount!['name']
+              : account.name,
           'order': index,
           'isHardware': account.isHardware,
           'isSeedAnchor': account.isSeedAnchor,
+          'profilePictureId': storedAccount?['profilePictureId'] is String
+              ? storedAccount!['profilePictureId']
+              : null,
+          'walletLinkSourceAccountUuid':
+              storedAccount?['walletLinkSourceAccountUuid'],
         });
       }).toList();
       final active = await _store.readString('zcash_active_account');
@@ -282,8 +289,16 @@ class WalletRecoverySession {
       // A crash during credential or metadata writes must return to recovery,
       // including when an otherwise valid old pointer is still present.
       await _store.writePlain(kWalletRecoveryPendingKey, candidate.fileName);
+      if (await _store.readPlain(kWalletRecoveryPendingKey) !=
+          candidate.fileName) {
+        throw StateError('Wallet recovery could not be started. Try again.');
+      }
       if (!passwordConfigured) {
         await _store.configurePassword(newPassword!);
+        if (!await _store.verifyPasswordOnly(newPassword)) {
+          _store.clearSessionPassword();
+          throw StateError('The recovered wallet password could not be saved.');
+        }
         _authenticated = true;
       }
       for (final entry in _softwareSecrets.entries) {
@@ -317,6 +332,9 @@ class WalletRecoverySession {
         );
       }
       await _store.delete(kWalletRecoveryPendingKey);
+      if (await _store.readPlain(kWalletRecoveryPendingKey) != null) {
+        throw StateError('Wallet recovery could not be completed. Try again.');
+      }
       // Re-enter through the ordinary unlock flow after bootstrap reload.
       _store.clearSessionPassword();
     } finally {

--- a/lib/src/features/onboarding/create/customise_account_screen.dart
+++ b/lib/src/features/onboarding/create/customise_account_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../app_bootstrap.dart';
 import '../../../core/account_name_policy.dart';
 import '../../../core/storage/linux_keyring_coordinator.dart';
 import '../../../core/theme/app_theme.dart';
@@ -152,7 +153,7 @@ class _CustomiseAccountScreenState
         await securityNotifier.preparePasswordSetup(pendingPassword);
         passwordPrepared = true;
         await createAccount();
-        securityNotifier.commitPasswordSetup();
+        await securityNotifier.commitPasswordSetup();
         passwordCommitted = true;
         clearCustomisedAccountDraft(ref, args.flow);
         router.go('/home');
@@ -167,6 +168,10 @@ class _CustomiseAccountScreenState
             'password rollback failed: $rollbackError\n$rollbackStack',
           );
         }
+      }
+      if (securityNotifier.requiresWalletSetupRecovery) {
+        await ref.read(appBootstrapRetryProvider)();
+        return;
       }
       rethrow;
     }

--- a/lib/src/features/onboarding/mobile/mobile_customise_account_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_customise_account_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../app_bootstrap.dart';
 import '../../../core/account_name_policy.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
@@ -209,7 +210,7 @@ class _MobileCustomiseAccountScreenState
         await securityNotifier.preparePasswordSetup(pendingPassword);
         passwordPrepared = true;
         await createAccount();
-        securityNotifier.commitPasswordSetup();
+        await securityNotifier.commitPasswordSetup();
         passwordCommitted = true;
         clearCustomisedAccountDraft(ref, args.flow);
         router.go('/onboarding/biometrics');
@@ -224,6 +225,10 @@ class _MobileCustomiseAccountScreenState
             '$rollbackError\n$rollbackStack',
           );
         }
+      }
+      if (securityNotifier.requiresWalletSetupRecovery) {
+        await ref.read(appBootstrapRetryProvider)();
+        return;
       }
       rethrow;
     }

--- a/lib/src/features/onboarding/mobile/mobile_passcode_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_passcode_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../app_bootstrap.dart';
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../core/theme/app_theme.dart';
@@ -163,7 +164,7 @@ class _MobilePasscodeScreenState extends ConsumerState<MobilePasscodeScreen> {
           }
         });
 
-        securityNotifier.commitPasswordSetup();
+        await securityNotifier.commitPasswordSetup();
         passwordCommitted = true;
         if (args.flow == SetPasswordFlow.importKeystone) {
           ref.read(keystoneOnboardingProvider.notifier).resetScan();
@@ -193,6 +194,10 @@ class _MobilePasscodeScreenState extends ConsumerState<MobilePasscodeScreen> {
             '$rollbackError\n$rollbackStack',
           );
         }
+      }
+      if (securityNotifier.requiresWalletSetupRecovery) {
+        await ref.read(appBootstrapRetryProvider)();
+        return;
       }
       log('MobilePasscode._submit: ERROR: $e\n$st');
       if (!mounted) return;

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../app_bootstrap.dart';
 import '../../../core/security/password_policy.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
@@ -164,7 +165,7 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
           },
         );
 
-        securityNotifier.commitPasswordSetup();
+        await securityNotifier.commitPasswordSetup();
         passwordCommitted = true;
         if (args.flow == SetPasswordFlow.importKeystone) {
           ref.read(keystoneOnboardingProvider.notifier).resetScan();
@@ -197,6 +198,10 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
             '$rollbackError\n$rollbackStack',
           );
         }
+      }
+      if (securityNotifier.requiresWalletSetupRecovery) {
+        await ref.read(appBootstrapRetryProvider)();
+        return;
       }
       log('SetPasswordScreen._submit: ERROR: $e\n$st');
       if (!mounted) return;

--- a/lib/src/features/onboarding/wallet_recovery_screen.dart
+++ b/lib/src/features/onboarding/wallet_recovery_screen.dart
@@ -1,0 +1,520 @@
+import 'package:flutter/material.dart' show Scaffold;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app_bootstrap.dart';
+import '../../core/layout/app_form_factor.dart';
+import '../../core/security/password_policy.dart';
+import '../../core/security/software_wallet_secret.dart';
+import '../../core/storage/wallet_recovery.dart';
+import '../../core/theme/app_theme.dart';
+import '../../core/widgets/app_button.dart';
+import '../../core/widgets/app_text_field.dart';
+import '../../core/widgets/password_text_field.dart';
+import '../../rust/api/keystone.dart' as rust_keystone;
+import '../../rust/api/wallet.dart' as rust_wallet;
+import '../../services/qr_scanner.dart';
+import '../keystone/widgets/keystone_qr_scanner_card.dart';
+import 'mobile/passcode_widgets.dart';
+
+const _mobile = kAppFormFactor == AppFormFactor.mobile;
+
+class WalletRecoveryScreen extends ConsumerStatefulWidget {
+  const WalletRecoveryScreen({super.key});
+
+  @override
+  ConsumerState<WalletRecoveryScreen> createState() =>
+      _WalletRecoveryScreenState();
+}
+
+class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
+  final _password = TextEditingController();
+  final _confirmation = TextEditingController();
+  final _mnemonic = TextEditingController();
+  final _passphrase = TextEditingController();
+  WalletRecoverySession? _session;
+  String? _editingAccount;
+  String? _scanningAccount;
+  String? _error;
+  bool _busy = false;
+  bool _authenticated = false;
+  String _passcode = '';
+  String? _newPasscode;
+
+  WalletRecoveryState get _recovery =>
+      ref.read(appBootstrapProvider).walletRecovery!;
+
+  @override
+  void dispose() {
+    _session?.dispose();
+    _password.dispose();
+    _confirmation.dispose();
+    _mnemonic.dispose();
+    _passphrase.dispose();
+    super.dispose();
+  }
+
+  void _select(WalletRecoveryCandidate candidate) {
+    _session?.dispose();
+    setState(() {
+      _session = WalletRecoverySession(candidate: candidate);
+      _authenticated = !_recovery.isPasswordConfigured;
+      _error = null;
+      _editingAccount = null;
+      _scanningAccount = null;
+      _passcode = '';
+      _newPasscode = null;
+    });
+  }
+
+  Future<void> _unlock() async {
+    if (_busy || _session == null) return;
+    final password = _mobile ? _passcode : _password.text;
+    if (!isWalletPasswordValid(password)) {
+      setState(() => _error = validateRequiredWalletPassword(password));
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final valid = await _session!.unlockExistingSecrets(password);
+      if (!mounted) return;
+      setState(() {
+        _authenticated = valid;
+        if (!valid) {
+          _error = _mobile
+              ? 'Incorrect passcode. Try again.'
+              : 'Incorrect password. Try again.';
+        }
+      });
+    } catch (_) {
+      if (mounted) {
+        setState(
+          () => _error =
+              'Your saved recovery material could not be read. Try again.',
+        );
+      }
+    } finally {
+      _password.clear();
+      if (mounted) {
+        setState(() {
+          _busy = false;
+          _passcode = '';
+        });
+      }
+    }
+  }
+
+  Future<void> _verifyPhrase(String uuid) async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final verified = await _session!.verifySoftwareSecret(
+        uuid,
+        SoftwareWalletSecret(
+          mnemonic: _mnemonic.text.trim().split(RegExp(r'\s+')).join(' '),
+          bip39Passphrase: _passphrase.text,
+        ),
+      );
+      if (!mounted) return;
+      setState(() {
+        if (verified) {
+          _editingAccount = null;
+          _mnemonic.clear();
+          _passphrase.clear();
+        } else {
+          _error =
+              'This recovery phrase and passphrase do not match the selected account.';
+        }
+      });
+    } catch (_) {
+      if (mounted) {
+        setState(
+          () => _error =
+              'Check your recovery phrase and passphrase, then try again.',
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _verifyKeystone(ScanResult result) async {
+    final uuid = _scanningAccount;
+    if (_busy || uuid == null) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final accounts = await rust_keystone.decodeAccountsFromCbor(
+        cbor: result.data,
+      );
+      var matched = false;
+      for (final account in accounts) {
+        if (await _session!.verifyHardwareKey(uuid, account.ufvk)) {
+          matched = true;
+          break;
+        }
+      }
+      if (!mounted) return;
+      setState(() {
+        if (matched) {
+          _scanningAccount = null;
+        } else {
+          _error =
+              'This Keystone QR does not match the selected wallet account.';
+        }
+      });
+    } catch (_) {
+      if (mounted) {
+        setState(
+          () => _error = 'Scan the Zcash account QR from your Keystone again.',
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _reconnect() async {
+    if (_busy || _session?.canReconnect != true) return;
+    String? newPassword;
+    if (!_recovery.isPasswordConfigured && !_session!.hasEstablishedPassword) {
+      newPassword = _mobile ? _newPasscode : _password.text;
+      final policy = validateRequiredWalletPassword(newPassword ?? '');
+      if (policy != null) {
+        setState(() => _error = policy);
+        return;
+      }
+      if (!_mobile && newPassword != _confirmation.text) {
+        setState(() => _error = 'Passwords do not match.');
+        return;
+      }
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      await _session!.reconnect(newPassword: newPassword);
+      _password.clear();
+      _confirmation.clear();
+      _newPasscode = null;
+      await ref.read(appBootstrapRetryProvider)();
+    } catch (_) {
+      if (mounted) {
+        setState(
+          () => _error =
+              'The wallet could not be reconnected. Your original file is still in place. Try again.',
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  void _enterDigit(String digit) {
+    if (_busy || _passcode.length >= 6) return;
+    setState(() => _passcode += digit);
+    if (_passcode.length != 6) return;
+    if (!_authenticated) {
+      _unlock();
+    } else if (_newPasscode == null) {
+      setState(() {
+        _newPasscode = _passcode;
+        _passcode = '';
+      });
+    } else if (_newPasscode == _passcode) {
+      _reconnect();
+    } else {
+      setState(() {
+        _newPasscode = null;
+        _passcode = '';
+        _error = 'Passcodes do not match. Try again.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final recovery = ref.watch(appBootstrapProvider).walletRecovery;
+    if (recovery == null) return const SizedBox.shrink();
+    final colors = context.colors;
+    return Scaffold(
+      backgroundColor: colors.background.ground,
+      body: SafeArea(
+        child: ColoredBox(
+          color: colors.background.ground,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return SingleChildScrollView(
+                padding: const EdgeInsets.all(AppSpacing.md),
+                child: Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 480),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          'Recover your wallet',
+                          style: AppTypography.headlineLarge.copyWith(
+                            color: colors.text.primary,
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.sm),
+                        Text(
+                          'Vizor found signs of an existing wallet. Verify your recovery material to reconnect it.',
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.secondary,
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.md),
+                        if (_session == null)
+                          ..._candidateList(recovery)
+                        else
+                          ..._selectedWallet(),
+                        if (_error != null) ...[
+                          const SizedBox(height: AppSpacing.sm),
+                          Semantics(
+                            liveRegion: true,
+                            child: Text(
+                              _error!,
+                              style: AppTypography.bodyMedium.copyWith(
+                                color: colors.text.secondary,
+                              ),
+                            ),
+                          ),
+                        ],
+                        const SizedBox(height: AppSpacing.md),
+                        AppButton(
+                          variant: AppButtonVariant.ghost,
+                          onPressed: _busy
+                              ? null
+                              : () async {
+                                  _session?.dispose();
+                                  _session = null;
+                                  await ref.read(appBootstrapRetryProvider)();
+                                },
+                          child: const Text('Search again'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _candidateList(WalletRecoveryState recovery) => [
+    if (recovery.candidates.isEmpty)
+      Text(
+        'No wallet file was found in this app’s data folder. Restore a preserved copy of your wallet file to that folder, then search again.',
+        style: AppTypography.bodyMedium.copyWith(
+          color: context.colors.text.secondary,
+        ),
+      ),
+    for (final candidate in recovery.candidates) ...[
+      Text(
+        candidate.fileName,
+        style: AppTypography.bodyMedium.copyWith(
+          color: context.colors.text.primary,
+        ),
+      ),
+      const SizedBox(height: AppSpacing.xs),
+      if (candidate.error != null)
+        Text(
+          candidate.error!,
+          style: AppTypography.bodySmall.copyWith(
+            color: context.colors.text.secondary,
+          ),
+        )
+      else
+        AppButton(
+          onPressed: _busy ? null : () => _select(candidate),
+          variant: AppButtonVariant.secondary,
+          child: const Text('Recover this wallet'),
+        ),
+      const SizedBox(height: AppSpacing.md),
+    ],
+  ];
+
+  List<Widget> _selectedWallet() {
+    final session = _session!;
+    if (!_authenticated) {
+      return [
+        Text(
+          _mobile
+              ? 'Enter your existing passcode.'
+              : 'Enter your existing password.',
+          style: AppTypography.bodyMedium.copyWith(
+            color: context.colors.text.primary,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        if (_mobile)
+          ..._passcodeEntry()
+        else ...[
+          PasswordTextField(
+            label: 'Password',
+            controller: _password,
+            enabled: !_busy,
+            onSubmitted: (_) => _unlock(),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          AppButton(
+            onPressed: _busy ? null : _unlock,
+            child: Text(_busy ? 'Checking' : 'Continue'),
+          ),
+        ],
+      ];
+    }
+    return [
+      for (final entry in session.candidate.accounts.indexed) ...[
+        Text(
+          'Account ${entry.$1 + 1}',
+          style: AppTypography.headlineSmall.copyWith(
+            color: context.colors.text.primary,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          session.isVerified(entry.$2.uuid)
+              ? 'Recovery material verified'
+              : entry.$2.isHardware
+              ? 'Reconnect your hardware wallet to verify this account.'
+              : 'Recovery phrase needed',
+          style: AppTypography.bodyMedium.copyWith(
+            color: context.colors.text.secondary,
+          ),
+        ),
+        if (!session.isVerified(entry.$2.uuid)) ..._accountRecovery(entry.$2),
+        const SizedBox(height: AppSpacing.md),
+      ],
+      if (session.canReconnect) ...[
+        if (!_recovery.isPasswordConfigured &&
+            !session.hasEstablishedPassword) ...[
+          Text(
+            _mobile
+                ? (_newPasscode == null
+                      ? 'Set a new passcode'
+                      : 'Confirm your passcode')
+                : 'Set a new password',
+            style: AppTypography.headlineSmall.copyWith(
+              color: context.colors.text.primary,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          if (_mobile)
+            ..._passcodeEntry()
+          else ...[
+            PasswordTextField(
+              label: 'New password',
+              controller: _password,
+              enabled: !_busy,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            PasswordTextField(
+              label: 'Confirm password',
+              controller: _confirmation,
+              enabled: !_busy,
+            ),
+          ],
+          const SizedBox(height: AppSpacing.sm),
+        ],
+        if (!_mobile ||
+            _recovery.isPasswordConfigured ||
+            session.hasEstablishedPassword)
+          AppButton(
+            onPressed: _busy ? null : _reconnect,
+            child: Text(_busy ? 'Reconnecting' : 'Reconnect wallet'),
+          ),
+      ],
+    ];
+  }
+
+  List<Widget> _accountRecovery(rust_wallet.AccountInfo account) => [
+    const SizedBox(height: AppSpacing.sm),
+    if (account.isHardware && _scanningAccount != account.uuid)
+      AppButton(
+        variant: AppButtonVariant.secondary,
+        onPressed: _busy
+            ? null
+            : () => setState(() => _scanningAccount = account.uuid),
+        child: const Text('Scan Keystone QR'),
+      )
+    else if (account.isHardware)
+      KeystoneQrScannerCard(
+        expectedUrType: 'zcash-accounts',
+        decoding: _busy,
+        error: _error,
+        onProgress: (_) {},
+        onDecodeError: (_) => setState(
+          () => _error = 'Scan the Zcash account QR from your Keystone.',
+        ),
+        onComplete: _verifyKeystone,
+        unavailableMessage:
+            'Connect a camera to scan your Keystone account QR.',
+      )
+    else if (_editingAccount != account.uuid)
+      AppButton(
+        variant: AppButtonVariant.secondary,
+        onPressed: _busy
+            ? null
+            : () {
+                _mnemonic.clear();
+                _passphrase.clear();
+                setState(() => _editingAccount = account.uuid);
+              },
+        child: const Text('Enter recovery phrase'),
+      )
+    else ...[
+      AppTextField(
+        label: 'Recovery phrase',
+        controller: _mnemonic,
+        minLines: 3,
+        maxLines: 6,
+        enabled: !_busy,
+        autocorrect: false,
+        enableSuggestions: false,
+      ),
+      const SizedBox(height: AppSpacing.sm),
+      PasswordTextField(
+        label: 'BIP39 passphrase (optional)',
+        controller: _passphrase,
+        enabled: !_busy,
+      ),
+      const SizedBox(height: AppSpacing.sm),
+      AppButton(
+        onPressed: _busy ? null : () => _verifyPhrase(account.uuid),
+        child: Text(_busy ? 'Verifying' : 'Verify recovery phrase'),
+      ),
+    ],
+  ];
+
+  List<Widget> _passcodeEntry() => [
+    PasscodeDots(length: 6, filled: _passcode.length),
+    const SizedBox(height: AppSpacing.sm),
+    PasscodeNumpad(
+      onDigit: (digit) => _enterDigit('$digit'),
+      enabled: !_busy,
+      canDelete: _passcode.isNotEmpty && !_busy,
+      onBackspace: () {
+        if (!_busy && _passcode.isNotEmpty) {
+          setState(
+            () => _passcode = _passcode.substring(0, _passcode.length - 1),
+          );
+        }
+      },
+    ),
+  ];
+}

--- a/lib/src/features/onboarding/wallet_recovery_screen.dart
+++ b/lib/src/features/onboarding/wallet_recovery_screen.dart
@@ -280,6 +280,16 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
   bool get _isMobilePasscodeStage =>
       _mobile && _session != null && (!_authenticated || _needsNewCredential);
 
+  String _regularStageKey(WalletRecoveryState recovery) {
+    if (_session == null) {
+      return recovery.candidates.isEmpty ? 'empty' : 'candidate';
+    }
+    if (!_authenticated) return 'password';
+    if (!_session!.canReconnect) return 'accounts';
+    if (_needsNewCredential) return 'new-credential';
+    return 'ready';
+  }
+
   @override
   Widget build(BuildContext context) {
     final recovery = ref.watch(appBootstrapProvider).walletRecovery;
@@ -314,7 +324,12 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
         children: [
           _RecoveryHeader(title: _title(recovery), body: _subtitle(recovery)),
           const SizedBox(height: AppSpacing.base),
-          Expanded(child: SingleChildScrollView(child: _regularBody(recovery))),
+          Expanded(
+            child: SingleChildScrollView(
+              key: ValueKey('desktop-${_regularStageKey(recovery)}'),
+              child: _regularBody(recovery),
+            ),
+          ),
         ],
       ),
     );
@@ -326,6 +341,7 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
       child: Align(
         alignment: Alignment.topCenter,
         child: SingleChildScrollView(
+          key: ValueKey('mobile-${_regularStageKey(recovery)}'),
           padding: const EdgeInsets.symmetric(
             horizontal: AppSpacing.sm,
             vertical: AppSpacing.md,

--- a/lib/src/features/onboarding/wallet_recovery_screen.dart
+++ b/lib/src/features/onboarding/wallet_recovery_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' show Scaffold;
+import 'package:flutter/material.dart' show Colors, Scaffold;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -9,13 +9,16 @@ import '../../core/security/software_wallet_secret.dart';
 import '../../core/storage/wallet_recovery.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_button.dart';
+import '../../core/widgets/app_icon.dart';
 import '../../core/widgets/app_text_field.dart';
 import '../../core/widgets/password_text_field.dart';
 import '../../rust/api/keystone.dart' as rust_keystone;
 import '../../rust/api/wallet.dart' as rust_wallet;
 import '../../services/qr_scanner.dart';
 import '../keystone/widgets/keystone_qr_scanner_card.dart';
+import 'mobile/mobile_passcode_screen.dart' show kMobilePasscodeLength;
 import 'mobile/passcode_widgets.dart';
+import 'shared/onboarding_auth_shell.dart';
 
 const _mobile = kAppFormFactor == AppFormFactor.mobile;
 
@@ -33,9 +36,14 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
   final _mnemonic = TextEditingController();
   final _passphrase = TextEditingController();
   WalletRecoverySession? _session;
+  String? _selectedCandidatePath;
   String? _editingAccount;
   String? _scanningAccount;
-  String? _error;
+  String? _passwordError;
+  String? _phraseError;
+  String? _newPasswordError;
+  String? _confirmationError;
+  String? _stageError;
   bool _busy = false;
   bool _authenticated = false;
   String _passcode = '';
@@ -58,8 +66,9 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
     _session?.dispose();
     setState(() {
       _session = WalletRecoverySession(candidate: candidate);
+      _selectedCandidatePath = candidate.path;
       _authenticated = !_recovery.isPasswordConfigured;
-      _error = null;
+      _clearErrors();
       _editingAccount = null;
       _scanningAccount = null;
       _passcode = '';
@@ -71,12 +80,13 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
     if (_busy || _session == null) return;
     final password = _mobile ? _passcode : _password.text;
     if (!isWalletPasswordValid(password)) {
-      setState(() => _error = validateRequiredWalletPassword(password));
+      setState(() => _passwordError = validateRequiredWalletPassword(password));
       return;
     }
     setState(() {
       _busy = true;
-      _error = null;
+      _passwordError = null;
+      _stageError = null;
     });
     try {
       final valid = await _session!.unlockExistingSecrets(password);
@@ -84,7 +94,7 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
       setState(() {
         _authenticated = valid;
         if (!valid) {
-          _error = _mobile
+          _passwordError = _mobile
               ? 'Incorrect passcode. Try again.'
               : 'Incorrect password. Try again.';
         }
@@ -92,7 +102,7 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
     } catch (_) {
       if (mounted) {
         setState(
-          () => _error =
+          () => _passwordError =
               'Your saved recovery material could not be read. Try again.',
         );
       }
@@ -111,7 +121,8 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
     if (_busy) return;
     setState(() {
       _busy = true;
-      _error = null;
+      _phraseError = null;
+      _stageError = null;
     });
     try {
       final verified = await _session!.verifySoftwareSecret(
@@ -128,14 +139,15 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
           _mnemonic.clear();
           _passphrase.clear();
         } else {
-          _error =
-              'This recovery phrase and passphrase do not match the selected account.';
+          final accountName = _accountName(uuid);
+          _phraseError =
+              "This phrase doesn't match $accountName. Check the words and passphrase.";
         }
       });
     } catch (_) {
       if (mounted) {
         setState(
-          () => _error =
+          () => _phraseError =
               'Check your recovery phrase and passphrase, then try again.',
         );
       }
@@ -149,7 +161,7 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
     if (_busy || uuid == null) return;
     setState(() {
       _busy = true;
-      _error = null;
+      _stageError = null;
     });
     try {
       final accounts = await rust_keystone.decodeAccountsFromCbor(
@@ -167,14 +179,15 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
         if (matched) {
           _scanningAccount = null;
         } else {
-          _error =
+          _stageError =
               'This Keystone QR does not match the selected wallet account.';
         }
       });
     } catch (_) {
       if (mounted) {
         setState(
-          () => _error = 'Scan the Zcash account QR from your Keystone again.',
+          () => _stageError =
+              'Scan the Zcash account QR from your Keystone again.',
         );
       }
     } finally {
@@ -189,17 +202,19 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
       newPassword = _mobile ? _newPasscode : _password.text;
       final policy = validateRequiredWalletPassword(newPassword ?? '');
       if (policy != null) {
-        setState(() => _error = policy);
+        setState(() => _newPasswordError = policy);
         return;
       }
       if (!_mobile && newPassword != _confirmation.text) {
-        setState(() => _error = 'Passwords do not match.');
+        setState(() => _confirmationError = 'Passwords do not match.');
         return;
       }
     }
     setState(() {
       _busy = true;
-      _error = null;
+      _newPasswordError = null;
+      _confirmationError = null;
+      _stageError = null;
     });
     try {
       await _session!.reconnect(newPassword: newPassword);
@@ -210,8 +225,8 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
     } catch (_) {
       if (mounted) {
         setState(
-          () => _error =
-              'The wallet could not be reconnected. Your original file is still in place. Try again.',
+          () => _stageError =
+              "Couldn't reconnect. Your original wallet file is unchanged. Try again.",
         );
       }
     } finally {
@@ -221,7 +236,11 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
 
   void _enterDigit(String digit) {
     if (_busy || _passcode.length >= 6) return;
-    setState(() => _passcode += digit);
+    setState(() {
+      _passcode += digit;
+      _passwordError = null;
+      _newPasswordError = null;
+    });
     if (_passcode.length != 6) return;
     if (!_authenticated) {
       _unlock();
@@ -236,285 +255,896 @@ class _WalletRecoveryScreenState extends ConsumerState<WalletRecoveryScreen> {
       setState(() {
         _newPasscode = null;
         _passcode = '';
-        _error = 'Passcodes do not match. Try again.';
+        _newPasswordError = 'Passcodes do not match. Try again.';
       });
     }
   }
+
+  void _clearErrors() {
+    _passwordError = null;
+    _phraseError = null;
+    _newPasswordError = null;
+    _confirmationError = null;
+    _stageError = null;
+  }
+
+  String _accountName(String uuid) => _session!.candidate.accounts
+      .firstWhere((account) => account.uuid == uuid)
+      .name;
+
+  bool get _needsNewCredential =>
+      _session?.canReconnect == true &&
+      !_recovery.isPasswordConfigured &&
+      !_session!.hasEstablishedPassword;
+
+  bool get _isMobilePasscodeStage =>
+      _mobile && _session != null && (!_authenticated || _needsNewCredential);
 
   @override
   Widget build(BuildContext context) {
     final recovery = ref.watch(appBootstrapProvider).walletRecovery;
     if (recovery == null) return const SizedBox.shrink();
-    final colors = context.colors;
+
     return Scaffold(
-      backgroundColor: colors.background.ground,
+      backgroundColor: _mobile
+          ? context.colors.background.ground
+          : Colors.transparent,
       body: SafeArea(
-        child: ColoredBox(
-          color: colors.background.ground,
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              return SingleChildScrollView(
-                padding: const EdgeInsets.all(AppSpacing.md),
-                child: Center(
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 480),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text(
-                          'Recover your wallet',
-                          style: AppTypography.headlineLarge.copyWith(
-                            color: colors.text.primary,
-                          ),
-                        ),
-                        const SizedBox(height: AppSpacing.sm),
-                        Text(
-                          'Vizor found signs of an existing wallet. Verify your recovery material to reconnect it.',
-                          style: AppTypography.bodyMedium.copyWith(
-                            color: colors.text.secondary,
-                          ),
-                        ),
-                        const SizedBox(height: AppSpacing.md),
-                        if (_session == null)
-                          ..._candidateList(recovery)
-                        else
-                          ..._selectedWallet(),
-                        if (_error != null) ...[
-                          const SizedBox(height: AppSpacing.sm),
-                          Semantics(
-                            liveRegion: true,
-                            child: Text(
-                              _error!,
-                              style: AppTypography.bodyMedium.copyWith(
-                                color: colors.text.secondary,
-                              ),
-                            ),
-                          ),
-                        ],
-                        const SizedBox(height: AppSpacing.md),
-                        AppButton(
-                          variant: AppButtonVariant.ghost,
-                          onPressed: _busy
-                              ? null
-                              : () async {
-                                  _session?.dispose();
-                                  _session = null;
-                                  await ref.read(appBootstrapRetryProvider)();
-                                },
-                          child: const Text('Search again'),
-                        ),
-                      ],
-                    ),
-                  ),
+        child: _mobile
+            ? (_isMobilePasscodeStage
+                  ? _mobilePasscodeContent()
+                  : _mobileRegularContent(recovery))
+            : OnboardingAuthShell(card: _desktopCard(recovery)),
+      ),
+    );
+  }
+
+  Widget _desktopCard(WalletRecoveryState recovery) {
+    return OnboardingAuthCard(
+      width: 396,
+      height: 600,
+      borderRadius: AppSpacing.md,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.xl,
+        AppSpacing.md,
+        AppSpacing.lg,
+      ),
+      child: Column(
+        children: [
+          _RecoveryHeader(title: _title(recovery), body: _subtitle(recovery)),
+          const SizedBox(height: AppSpacing.base),
+          Expanded(child: SingleChildScrollView(child: _regularBody(recovery))),
+        ],
+      ),
+    );
+  }
+
+  Widget _mobileRegularContent(WalletRecoveryState recovery) {
+    return ColoredBox(
+      color: context.colors.background.ground,
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.sm,
+            vertical: AppSpacing.md,
+          ),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _RecoveryHeader(
+                  title: _title(recovery),
+                  body: _subtitle(recovery),
                 ),
-              );
-            },
+                const SizedBox(height: AppSpacing.base),
+                _regularBody(recovery),
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 
-  List<Widget> _candidateList(WalletRecoveryState recovery) => [
-    if (recovery.candidates.isEmpty)
-      Text(
-        'No wallet file was found in this app’s data folder. Restore a preserved copy of your wallet file to that folder, then search again.',
-        style: AppTypography.bodyMedium.copyWith(
-          color: context.colors.text.secondary,
-        ),
-      ),
-    for (final candidate in recovery.candidates) ...[
-      Text(
-        candidate.fileName,
-        style: AppTypography.bodyMedium.copyWith(
-          color: context.colors.text.primary,
-        ),
-      ),
-      const SizedBox(height: AppSpacing.xs),
-      if (candidate.error != null)
-        Text(
-          candidate.error!,
-          style: AppTypography.bodySmall.copyWith(
-            color: context.colors.text.secondary,
-          ),
-        )
-      else
-        AppButton(
-          onPressed: _busy ? null : () => _select(candidate),
-          variant: AppButtonVariant.secondary,
-          child: const Text('Recover this wallet'),
-        ),
-      const SizedBox(height: AppSpacing.md),
-    ],
-  ];
+  Widget _mobilePasscodeContent() {
+    final colors = context.colors;
+    final enteringExistingPasscode = !_authenticated;
+    final confirming = !enteringExistingPasscode && _newPasscode != null;
+    final title = enteringExistingPasscode
+        ? 'Enter your passcode'
+        : confirming
+        ? 'Confirm passcode'
+        : 'Create passcode';
+    final subtitle = enteringExistingPasscode
+        ? 'Use the passcode you set for this wallet.'
+        : confirming
+        ? 'Re-enter your passcode.'
+        : '6 digits';
+    final error = enteringExistingPasscode ? _passwordError : _newPasswordError;
 
-  List<Widget> _selectedWallet() {
-    final session = _session!;
-    if (!_authenticated) {
-      return [
-        Text(
-          _mobile
-              ? 'Enter your existing passcode.'
-              : 'Enter your existing password.',
-          style: AppTypography.bodyMedium.copyWith(
-            color: context.colors.text.primary,
-          ),
+    return ColoredBox(
+      color: colors.background.ground,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.md,
         ),
-        const SizedBox(height: AppSpacing.sm),
-        if (_mobile)
-          ..._passcodeEntry()
-        else ...[
-          PasswordTextField(
-            label: 'Password',
-            controller: _password,
-            enabled: !_busy,
-            onSubmitted: (_) => _unlock(),
-          ),
-          const SizedBox(height: AppSpacing.sm),
-          AppButton(
-            onPressed: _busy ? null : _unlock,
-            child: Text(_busy ? 'Checking' : 'Continue'),
-          ),
-        ],
-      ];
-    }
-    return [
-      for (final entry in session.candidate.accounts.indexed) ...[
-        Text(
-          'Account ${entry.$1 + 1}',
-          style: AppTypography.headlineSmall.copyWith(
-            color: context.colors.text.primary,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.xs),
-        Text(
-          session.isVerified(entry.$2.uuid)
-              ? 'Recovery material verified'
-              : entry.$2.isHardware
-              ? 'Reconnect your hardware wallet to verify this account.'
-              : 'Recovery phrase needed',
-          style: AppTypography.bodyMedium.copyWith(
-            color: context.colors.text.secondary,
-          ),
-        ),
-        if (!session.isVerified(entry.$2.uuid)) ..._accountRecovery(entry.$2),
-        const SizedBox(height: AppSpacing.md),
-      ],
-      if (session.canReconnect) ...[
-        if (!_recovery.isPasswordConfigured &&
-            !session.hasEstablishedPassword) ...[
-          Text(
-            _mobile
-                ? (_newPasscode == null
-                      ? 'Set a new passcode'
-                      : 'Confirm your passcode')
-                : 'Set a new password',
-            style: AppTypography.headlineSmall.copyWith(
-              color: context.colors.text.primary,
+        child: Column(
+          children: [
+            Expanded(
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Semantics(
+                      header: true,
+                      child: Text(
+                        title,
+                        textAlign: TextAlign.center,
+                        style: AppTypography.displayLarge.copyWith(
+                          color: colors.text.accent,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 320),
+                      child: Text(
+                        subtitle,
+                        textAlign: TextAlign.center,
+                        style: AppTypography.bodyMediumStrong.copyWith(
+                          color: colors.text.primary,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.md),
+                    SizedBox(
+                      height: kPasscodePromptDigitsHeight,
+                      child: PasscodePromptField(
+                        length: kMobilePasscodeLength,
+                        filled: _passcode.length,
+                        error: error,
+                        minGap: 0,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
-          ),
-          const SizedBox(height: AppSpacing.sm),
-          if (_mobile)
-            ..._passcodeEntry()
-          else ...[
-            PasswordTextField(
-              label: 'New password',
-              controller: _password,
+            PasscodeNumpad(
+              onDigit: (digit) => _enterDigit('$digit'),
               enabled: !_busy,
+              canDelete: _passcode.isNotEmpty && !_busy,
+              onBackspace: () {
+                if (_busy || _passcode.isEmpty) return;
+                setState(() {
+                  _passcode = _passcode.substring(0, _passcode.length - 1);
+                  _passwordError = null;
+                  _newPasswordError = null;
+                });
+              },
             ),
-            const SizedBox(height: AppSpacing.sm),
-            PasswordTextField(
-              label: 'Confirm password',
-              controller: _confirmation,
-              enabled: !_busy,
-            ),
+            const SizedBox(height: AppSpacing.md),
           ],
-          const SizedBox(height: AppSpacing.sm),
-        ],
-        if (!_mobile ||
-            _recovery.isPasswordConfigured ||
-            session.hasEstablishedPassword)
-          AppButton(
-            onPressed: _busy ? null : _reconnect,
-            child: Text(_busy ? 'Reconnecting' : 'Reconnect wallet'),
-          ),
-      ],
-    ];
+        ),
+      ),
+    );
   }
 
-  List<Widget> _accountRecovery(rust_wallet.AccountInfo account) => [
-    const SizedBox(height: AppSpacing.sm),
-    if (account.isHardware && _scanningAccount != account.uuid)
-      AppButton(
-        variant: AppButtonVariant.secondary,
+  Widget _regularBody(WalletRecoveryState recovery) {
+    if (_session == null) return _candidateContent(recovery);
+    if (!_authenticated) return _desktopPasswordContent();
+    if (!_session!.canReconnect) return _accountVerificationContent();
+    if (_needsNewCredential) return _desktopNewPasswordContent();
+    return _readyContent();
+  }
+
+  Widget _candidateContent(WalletRecoveryState recovery) {
+    if (recovery.candidates.isEmpty) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _primaryAction(
+            label: _busy ? 'Searching...' : 'Search again',
+            onPressed: _busy ? null : _restart,
+          ),
+        ],
+      );
+    }
+
+    final selectable = recovery.candidates
+        .where((candidate) => candidate.canInspect)
+        .toList();
+    final selected = _selectedCandidate(recovery);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final entry in recovery.candidates.indexed) ...[
+          _CandidateRow(
+            candidate: entry.$2,
+            networkLabel: _networkLabel(entry.$2.network),
+            accountCount: _accountCount(entry.$2.accounts.length),
+            selected: selected?.path == entry.$2.path,
+            showSelection: selectable.length > 1,
+            onSelect: entry.$2.canInspect
+                ? () => setState(() => _selectedCandidatePath = entry.$2.path)
+                : null,
+          ),
+          if (entry.$1 != recovery.candidates.length - 1) _rowDivider(),
+        ],
+        if (_stageError != null) ...[
+          const SizedBox(height: AppSpacing.md),
+          _StageError(message: _stageError!),
+        ],
+        const SizedBox(height: AppSpacing.base),
+        if (selected != null)
+          _primaryAction(
+            label: 'Recover this wallet',
+            onPressed: _busy ? null : () => _select(selected),
+          )
+        else
+          _primaryAction(
+            label: _busy ? 'Searching...' : 'Search again',
+            onPressed: _busy ? null : _restart,
+          ),
+        if (selected != null) ...[
+          const SizedBox(height: AppSpacing.s),
+          _secondaryAction(label: 'Search again', onPressed: _restart),
+        ],
+      ],
+    );
+  }
+
+  Widget _desktopPasswordContent() {
+    final candidate = _session!.candidate;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _WalletMeta(
+          text:
+              '${_networkLabel(candidate.network)} · ${_accountCount(candidate.accounts.length)}',
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Center(
+          child: SizedBox(
+            width: 256,
+            child: _RecoveryFieldBlock(
+              child: PasswordTextField(
+                label: 'Password',
+                hintText: 'Password',
+                showLabel: false,
+                surface: AppTextFieldSurface.secondary,
+                leadingSlotWidth: 32,
+                inputHorizontalPadding: AppSpacing.s,
+                controller: _password,
+                enabled: !_busy,
+                showVisibilityToggle: false,
+                messageText: _passwordError,
+                tone: _passwordError == null
+                    ? AppTextFieldTone.neutral
+                    : AppTextFieldTone.destructive,
+                onChanged: (_) => setState(() => _passwordError = null),
+                onSubmitted: (_) => _unlock(),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.base),
+        _primaryAction(
+          label: _busy ? 'Checking...' : 'Continue',
+          onPressed: _busy ? null : _unlock,
+        ),
+        const SizedBox(height: AppSpacing.s),
+        _secondaryAction(label: 'Start over', onPressed: _restart),
+      ],
+    );
+  }
+
+  Widget _accountVerificationContent() {
+    final session = _session!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final entry in session.candidate.accounts.indexed) ...[
+          _AccountRow(
+            account: entry.$2,
+            verified: session.isVerified(entry.$2.uuid),
+            child: session.isVerified(entry.$2.uuid)
+                ? null
+                : _accountRecovery(entry.$2),
+          ),
+          if (entry.$1 != session.candidate.accounts.length - 1) _rowDivider(),
+        ],
+        if (_stageError != null && _scanningAccount == null) ...[
+          const SizedBox(height: AppSpacing.md),
+          _StageError(message: _stageError!),
+        ],
+        const SizedBox(height: AppSpacing.base),
+        _secondaryAction(label: 'Start over', onPressed: _restart),
+      ],
+    );
+  }
+
+  Widget _desktopNewPasswordContent() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Center(
+          child: SizedBox(
+            width: 256,
+            child: Column(
+              children: [
+                _RecoveryFieldBlock(
+                  child: PasswordTextField(
+                    label: 'New password',
+                    hintText: 'Min. 8 characters and symbols',
+                    controller: _password,
+                    enabled: !_busy,
+                    showVisibilityToggle: false,
+                    messageText: _newPasswordError,
+                    tone: _newPasswordError == null
+                        ? AppTextFieldTone.neutral
+                        : AppTextFieldTone.destructive,
+                    onChanged: (_) => setState(() {
+                      _newPasswordError = null;
+                      _confirmationError = null;
+                    }),
+                    onSubmitted: (_) => _reconnect(),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.s),
+                _RecoveryFieldBlock(
+                  child: PasswordTextField(
+                    label: 'Confirm password',
+                    hintText: 'Confirm password',
+                    controller: _confirmation,
+                    enabled: !_busy,
+                    showVisibilityToggle: false,
+                    messageText: _confirmationError,
+                    tone: _confirmationError == null
+                        ? AppTextFieldTone.neutral
+                        : AppTextFieldTone.destructive,
+                    onChanged: (_) => setState(() => _confirmationError = null),
+                    onSubmitted: (_) => _reconnect(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (_stageError != null) ...[
+          const SizedBox(height: AppSpacing.md),
+          _StageError(message: _stageError!),
+        ],
+        const SizedBox(height: AppSpacing.base),
+        _primaryAction(
+          label: _busy ? 'Reconnecting...' : 'Reconnect wallet',
+          onPressed: _busy ? null : _reconnect,
+        ),
+        const SizedBox(height: AppSpacing.s),
+        _secondaryAction(label: 'Start over', onPressed: _restart),
+      ],
+    );
+  }
+
+  Widget _readyContent() {
+    final session = _session!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final entry in session.candidate.accounts.indexed) ...[
+          _AccountRow(account: entry.$2, verified: true),
+          if (entry.$1 != session.candidate.accounts.length - 1) _rowDivider(),
+        ],
+        if (_stageError != null) ...[
+          const SizedBox(height: AppSpacing.md),
+          _StageError(message: _stageError!),
+        ],
+        const SizedBox(height: AppSpacing.base),
+        _primaryAction(
+          label: _busy ? 'Reconnecting...' : 'Reconnect wallet',
+          onPressed: _busy ? null : _reconnect,
+        ),
+        const SizedBox(height: AppSpacing.s),
+        _secondaryAction(label: 'Start over', onPressed: _restart),
+      ],
+    );
+  }
+
+  Widget _accountRecovery(rust_wallet.AccountInfo account) {
+    if (account.isHardware && _scanningAccount != account.uuid) {
+      return _inlineAction(
+        label: 'Scan Keystone QR',
         onPressed: _busy
             ? null
-            : () => setState(() => _scanningAccount = account.uuid),
-        child: const Text('Scan Keystone QR'),
-      )
-    else if (account.isHardware)
-      KeystoneQrScannerCard(
+            : () => setState(() {
+                _scanningAccount = account.uuid;
+                _stageError = null;
+              }),
+      );
+    }
+    if (account.isHardware) {
+      return KeystoneQrScannerCard(
         expectedUrType: 'zcash-accounts',
         decoding: _busy,
-        error: _error,
+        error: _stageError,
         onProgress: (_) {},
         onDecodeError: (_) => setState(
-          () => _error = 'Scan the Zcash account QR from your Keystone.',
+          () => _stageError = 'Scan the Zcash account QR from your Keystone.',
         ),
         onComplete: _verifyKeystone,
         unavailableMessage:
             'Connect a camera to scan your Keystone account QR.',
-      )
-    else if (_editingAccount != account.uuid)
-      AppButton(
-        variant: AppButtonVariant.secondary,
+      );
+    }
+    if (_editingAccount != account.uuid) {
+      return _inlineAction(
+        label: 'Enter recovery phrase',
         onPressed: _busy
             ? null
             : () {
                 _mnemonic.clear();
                 _passphrase.clear();
-                setState(() => _editingAccount = account.uuid);
+                setState(() {
+                  _editingAccount = account.uuid;
+                  _phraseError = null;
+                });
               },
-        child: const Text('Enter recovery phrase'),
-      )
-    else ...[
-      AppTextField(
-        label: 'Recovery phrase',
-        controller: _mnemonic,
-        minLines: 3,
-        maxLines: 6,
-        enabled: !_busy,
-        autocorrect: false,
-        enableSuggestions: false,
-      ),
-      const SizedBox(height: AppSpacing.sm),
-      PasswordTextField(
-        label: 'BIP39 passphrase (optional)',
-        controller: _passphrase,
-        enabled: !_busy,
-      ),
-      const SizedBox(height: AppSpacing.sm),
-      AppButton(
-        onPressed: _busy ? null : () => _verifyPhrase(account.uuid),
-        child: Text(_busy ? 'Verifying' : 'Verify recovery phrase'),
-      ),
-    ],
-  ];
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _RecoveryFieldBlock(
+          child: AppTextField(
+            label: 'Recovery phrase',
+            controller: _mnemonic,
+            minLines: 3,
+            maxLines: 6,
+            enabled: !_busy,
+            autocorrect: false,
+            enableSuggestions: false,
+            messageText: _phraseError,
+            tone: _phraseError == null
+                ? AppTextFieldTone.neutral
+                : AppTextFieldTone.destructive,
+            onChanged: (_) => setState(() => _phraseError = null),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.s),
+        PasswordTextField(
+          label: 'BIP39 passphrase (optional)',
+          controller: _passphrase,
+          enabled: !_busy,
+          onChanged: (_) => setState(() => _phraseError = null),
+        ),
+        const SizedBox(height: AppSpacing.s),
+        _primaryAction(
+          label: _busy ? 'Verifying...' : 'Verify recovery phrase',
+          onPressed: _busy ? null : () => _verifyPhrase(account.uuid),
+        ),
+      ],
+    );
+  }
 
-  List<Widget> _passcodeEntry() => [
-    PasscodeDots(length: 6, filled: _passcode.length),
-    const SizedBox(height: AppSpacing.sm),
-    PasscodeNumpad(
-      onDigit: (digit) => _enterDigit('$digit'),
-      enabled: !_busy,
-      canDelete: _passcode.isNotEmpty && !_busy,
-      onBackspace: () {
-        if (!_busy && _passcode.isNotEmpty) {
-          setState(
-            () => _passcode = _passcode.substring(0, _passcode.length - 1),
-          );
-        }
-      },
+  Widget _primaryAction({
+    required String label,
+    required VoidCallback? onPressed,
+  }) => Center(
+    child: AppButton(
+      onPressed: onPressed,
+      minWidth: _mobile ? null : 196,
+      expand: _mobile,
+      child: Text(label),
     ),
-  ];
+  );
+
+  Widget _secondaryAction({
+    required String label,
+    required VoidCallback? onPressed,
+  }) => Center(
+    child: AppButton(
+      variant: AppButtonVariant.ghost,
+      size: AppButtonSize.large,
+      onPressed: _busy ? null : onPressed,
+      minWidth: _mobile ? null : 196,
+      expand: _mobile,
+      child: Text(label),
+    ),
+  );
+
+  Widget _inlineAction({
+    required String label,
+    required VoidCallback? onPressed,
+  }) => Center(
+    child: AppButton(
+      variant: AppButtonVariant.secondary,
+      size: _mobile ? AppButtonSize.large : AppButtonSize.mediumLarge,
+      onPressed: onPressed,
+      minWidth: _mobile ? null : 196,
+      expand: _mobile,
+      child: Text(label),
+    ),
+  );
+
+  Widget _rowDivider() => Padding(
+    padding: const EdgeInsets.symmetric(vertical: AppSpacing.s),
+    child: SizedBox(
+      height: 1,
+      child: ColoredBox(color: context.colors.border.subtle),
+    ),
+  );
+
+  WalletRecoveryCandidate? _selectedCandidate(WalletRecoveryState recovery) {
+    final selectable = recovery.candidates.where(
+      (candidate) => candidate.canInspect,
+    );
+    if (selectable.isEmpty) return null;
+    return selectable.firstWhere(
+      (candidate) => candidate.path == _selectedCandidatePath,
+      orElse: () => selectable.first,
+    );
+  }
+
+  Future<void> _restart() async {
+    if (_busy) return;
+    _session?.dispose();
+    setState(() {
+      _session = null;
+      _selectedCandidatePath = null;
+      _authenticated = false;
+      _editingAccount = null;
+      _scanningAccount = null;
+      _passcode = '';
+      _newPasscode = null;
+      _password.clear();
+      _confirmation.clear();
+      _mnemonic.clear();
+      _passphrase.clear();
+      _clearErrors();
+    });
+    await ref.read(appBootstrapRetryProvider)();
+  }
+
+  String _title(WalletRecoveryState recovery) {
+    if (_session == null) {
+      return recovery.candidates.isEmpty ? 'No wallet found' : 'Wallet found';
+    }
+    if (!_authenticated) {
+      return _mobile ? 'Enter your passcode' : 'Enter your password';
+    }
+    if (!_session!.canReconnect) return 'Verify accounts';
+    if (_needsNewCredential) {
+      return _mobile ? 'Create passcode' : 'New password';
+    }
+    return 'Reconnect wallet';
+  }
+
+  String _subtitle(WalletRecoveryState recovery) {
+    if (_session == null) {
+      return recovery.candidates.isEmpty
+          ? "Restore your backup copy to Vizor's data folder, then search again."
+          : 'Vizor found a wallet from a previous setup. Verify it to keep using it.';
+    }
+    if (!_authenticated) {
+      return _mobile
+          ? 'Use the passcode you set for this wallet.'
+          : 'Use the password you set for this wallet.';
+    }
+    if (!_session!.canReconnect) {
+      return 'Add the missing recovery details for each account.';
+    }
+    if (_needsNewCredential) {
+      return _mobile
+          ? '6 digits'
+          : 'Choose a password to protect this wallet on this device.';
+    }
+    return 'All accounts are verified. Your original wallet file stays unchanged.';
+  }
+
+  String _accountCount(int count) =>
+      '$count ${count == 1 ? 'account' : 'accounts'}';
+
+  String _networkLabel(String network) => switch (network.toLowerCase()) {
+    'main' || 'mainnet' => 'Zcash mainnet',
+    'test' || 'testnet' => 'Zcash testnet',
+    'regtest' => 'Local regtest',
+    _ => network,
+  };
+}
+
+class _RecoveryHeader extends StatelessWidget {
+  const _RecoveryHeader({required this.title, required this.body});
+
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      children: [
+        ExcludeSemantics(
+          child: Image.asset(
+            'assets/illustrations/welcome_badge.png',
+            width: 50,
+            height: 50,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.base),
+        Semantics(
+          header: true,
+          child: SizedBox(
+            width: _mobile ? 320 : 348,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: Alignment.center,
+              child: Text(
+                title,
+                maxLines: 1,
+                softWrap: false,
+                textAlign: TextAlign.center,
+                style: AppTypography.displayMedium.copyWith(
+                  color: colors.text.accent,
+                  height: _mobile ? null : 48 / 45,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 348),
+          child: Text(
+            body,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: AppTypography.bodyMediumStrong.copyWith(
+              color: colors.text.accent,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CandidateRow extends StatelessWidget {
+  const _CandidateRow({
+    required this.candidate,
+    required this.networkLabel,
+    required this.accountCount,
+    required this.selected,
+    required this.showSelection,
+    required this.onSelect,
+  });
+
+  final WalletRecoveryCandidate candidate;
+  final String networkLabel;
+  final String accountCount;
+  final bool selected;
+  final bool showSelection;
+  final VoidCallback? onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '$networkLabel · $accountCount',
+                    style: AppTypography.bodyLarge.copyWith(
+                      color: colors.text.primary,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xxs),
+                  Semantics(
+                    label: 'Wallet file ${candidate.fileName}',
+                    child: ExcludeSemantics(
+                      child: Text(
+                        candidate.fileName,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.codeSmall.copyWith(
+                          color: colors.text.muted,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (candidate.error != null)
+              AppIcon(
+                AppIcons.warningCircle,
+                size: AppIconSize.medium,
+                color: colors.icon.destructive,
+              )
+            else if (selected && showSelection)
+              _RecoveryStatus(icon: AppIcons.checkCircle, label: 'Selected')
+            else if (showSelection)
+              AppButton(
+                variant: AppButtonVariant.secondary,
+                size: _mobile ? AppButtonSize.large : AppButtonSize.mediumLarge,
+                onPressed: onSelect,
+                child: const Text('Select'),
+              ),
+          ],
+        ),
+        if (candidate.error != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          _StageError(message: candidate.error!),
+        ],
+      ],
+    );
+  }
+}
+
+class _AccountRow extends StatelessWidget {
+  const _AccountRow({
+    required this.account,
+    required this.verified,
+    this.child,
+  });
+
+  final rust_wallet.AccountInfo account;
+  final bool verified;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 44),
+          child: Row(
+            children: [
+              if (account.isHardware) ...[
+                AppIcon(AppIcons.keystone, size: 20, color: colors.icon.accent),
+                const SizedBox(width: AppSpacing.xs),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      account.name,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.bodyLarge.copyWith(
+                        color: colors.text.primary,
+                      ),
+                    ),
+                    Text(
+                      account.isHardware
+                          ? 'Keystone account'
+                          : 'Software account',
+                      style: AppTypography.bodySmall.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              _RecoveryStatus(
+                icon: verified
+                    ? AppIcons.checkCircle
+                    : account.isHardware
+                    ? AppIcons.keystone
+                    : AppIcons.key,
+                label: verified
+                    ? 'Verified'
+                    : account.isHardware
+                    ? 'Keystone needed'
+                    : 'Phrase needed',
+                positive: verified,
+              ),
+            ],
+          ),
+        ),
+        if (child != null) ...[const SizedBox(height: AppSpacing.s), child!],
+      ],
+    );
+  }
+}
+
+class _RecoveryStatus extends StatelessWidget {
+  const _RecoveryStatus({
+    required this.icon,
+    required this.label,
+    this.positive = false,
+  });
+
+  final String icon;
+  final String label;
+  final bool positive;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final color = positive ? colors.text.positiveStrong : colors.text.secondary;
+    return Semantics(
+      label: label,
+      child: ExcludeSemantics(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AppIcon(icon, size: AppIconSize.medium, color: color),
+            const SizedBox(width: AppSpacing.xxs),
+            Text(
+              label,
+              style: AppTypography.labelMedium.copyWith(color: color),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WalletMeta extends StatelessWidget {
+  const _WalletMeta({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: TextAlign.center,
+      style: AppTypography.bodySmall.copyWith(
+        color: context.colors.text.secondary,
+      ),
+    );
+  }
+}
+
+class _RecoveryFieldBlock extends StatelessWidget {
+  const _RecoveryFieldBlock({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(padding: const EdgeInsets.only(bottom: 20), child: child);
+  }
+}
+
+class _StageError extends StatelessWidget {
+  const _StageError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      liveRegion: true,
+      child: Text(
+        message,
+        maxLines: 3,
+        overflow: TextOverflow.ellipsis,
+        textAlign: TextAlign.center,
+        style: AppTypography.bodyMediumStrong.copyWith(
+          color: context.colors.text.destructive,
+        ),
+      ),
+    );
+  }
 }

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -19,6 +19,7 @@ import '../core/security/software_wallet_secret.dart';
 import '../core/storage/app_secure_store.dart';
 import '../core/storage/linux_keyring_coordinator.dart';
 import '../core/storage/wallet_paths.dart';
+import '../core/storage/wallet_recovery.dart';
 import '../features/swap/providers/swap_activity_store.dart';
 import '../features/migration/services/ironwood_migration_background_credential_store.dart';
 import '../features/migration/services/ironwood_migration_operation_registry.dart';
@@ -168,7 +169,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   Future<String> _createAccount({String? name}) async {
     try {
-      final dbPath = await _getDbPath();
+      final dbPath = await _getDbPathForAccountCreation();
       final endpoint = ref.read(rpcEndpointProvider);
       final network = endpoint.networkName;
 
@@ -265,7 +266,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     String profilePictureId = kDefaultProfilePictureId,
   }) async {
     try {
-      final dbPath = await _getDbPath();
+      final dbPath = await _getDbPathForAccountCreation();
       final endpoint = ref.read(rpcEndpointProvider);
       final network = endpoint.networkName;
 
@@ -375,7 +376,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     List<int> additionalAccountIndices = const [],
   }) async {
     try {
-      final dbPath = await _getDbPath();
+      final dbPath = await _getDbPathForAccountCreation();
       final endpoint = ref.read(rpcEndpointProvider);
       final network = (state.value?.accounts ?? const <AccountInfo>[]).isEmpty
           ? endpoint.networkName
@@ -482,10 +483,12 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     int? birthdayHeight,
   }) async {
     try {
-      final dbPath = await _getDbPath();
       final endpoint = ref.read(rpcEndpointProvider);
       final accounts = state.value?.accounts ?? const <AccountInfo>[];
       final isFirstWalletAccount = accounts.isEmpty;
+      // First-wallet discovery is network-only; Rust ignores the DB path in
+      // that branch. Do not allocate or persist a DB name for this preview.
+      final dbPath = isFirstWalletAccount ? '' : await _getDbPath();
       final network = isFirstWalletAccount
           ? endpoint.networkName
           : await _getNetwork();
@@ -1269,7 +1272,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         profilePictureId,
       );
       final prev = state.value ?? const AccountState();
-      final dbPath = await _getDbPath();
+      final dbPath = await _getDbPathForAccountCreation();
       final network = await _getNetwork();
 
       final result = await rust_wallet.importHardwareAccount(
@@ -1341,7 +1344,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         current: prev,
       );
 
-      final dbPath = await _getDbPath();
+      final dbPath = await _getDbPathForAccountCreation();
       if (prev.accounts.isEmpty) {
         await _deleteExistingDb(dbPath);
         await _storage.writeString(_networkKey, normalizedNetwork);
@@ -1601,6 +1604,37 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       log('removeAccount: failed to get next active address: $e');
       return null;
     }
+  }
+
+  Future<String> _getDbPathForAccountCreation() async {
+    if ((state.value?.accounts ?? const <AccountInfo>[]).isEmpty) {
+      final network = await _getNetwork();
+      final existingName = await readWalletDbName();
+      if (existingName != null) {
+        final path = await getWalletDbPath();
+        final type = await FileSystemEntity.type(path, followLinks: false);
+        if (type == FileSystemEntityType.file) {
+          final accounts = await rust_wallet.inspectWalletForRecovery(
+            dbPath: path,
+            network: network,
+          );
+          if (accounts.isEmpty) return path;
+        } else if (type == FileSystemEntityType.notFound &&
+            (await findWalletRecoveryCandidates(network: network)).isEmpty) {
+          return path;
+        }
+        throw StateError(
+          'Recover the existing wallet before creating another.',
+        );
+      }
+      if ((await findWalletRecoveryCandidates(network: network)).isNotEmpty) {
+        throw StateError(
+          'Recover the existing wallet before creating another.',
+        );
+      }
+      return createWalletDbPath();
+    }
+    return getWalletDbPath();
   }
 
   Future<String> _getDbPath() async {

--- a/lib/src/providers/app_security_provider.dart
+++ b/lib/src/providers/app_security_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -6,6 +8,7 @@ import '../core/security/password_policy.dart';
 import '../core/storage/app_secure_store.dart';
 import '../core/storage/linux_keyring_coordinator.dart';
 import '../core/storage/wallet_paths.dart';
+import '../core/storage/wallet_recovery.dart';
 import '../features/migration/models/ironwood_migration_phases.dart';
 import '../rust/api/sync.dart' as rust_sync;
 import '../rust/api/wallet.dart' as rust_wallet;
@@ -76,6 +79,30 @@ final passwordChangePreflightProvider = Provider<PasswordChangePreflight>((
   };
 });
 
+/// A failed import may already have committed an account in Rust. Only an
+/// inspectable, account-free database permits removing its setup password.
+final passwordSetupRollbackSafetyProvider = Provider<Future<bool> Function()>((
+  ref,
+) {
+  return () async {
+    final network = ref.read(rpcEndpointProvider).networkName;
+    if (await readWalletDbName() == null) {
+      return (await findWalletRecoveryCandidates(network: network)).isEmpty;
+    }
+    final path = await getWalletDbPath();
+    final type = await FileSystemEntity.type(path, followLinks: false);
+    if (type == FileSystemEntityType.notFound) {
+      return (await findWalletRecoveryCandidates(network: network)).isEmpty;
+    }
+    if (type != FileSystemEntityType.file) return false;
+    final accounts = await rust_wallet.inspectWalletForRecovery(
+      dbPath: path,
+      network: network,
+    );
+    return accounts.isEmpty;
+  };
+});
+
 class AppSecurityState {
   const AppSecurityState({
     required this.isPasswordConfigured,
@@ -108,6 +135,9 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
   int _unlockRequestGeneration = 0;
   int _confirmRequestGeneration = 0;
   int? _pendingUnlockSessionGeneration;
+  bool _requiresWalletSetupRecovery = false;
+
+  bool get requiresWalletSetupRecovery => _requiresWalletSetupRecovery;
 
   @override
   AppSecurityState build() {
@@ -134,7 +164,7 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
 
   Future<void> _configurePassword(String password) async {
     await preparePasswordSetup(password);
-    commitPasswordSetup();
+    await commitPasswordSetup();
   }
 
   Future<void> preparePasswordSetup(String password) => ref
@@ -145,8 +175,17 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
     final lifecycleGeneration = _lifecycleGeneration;
     final requestGeneration = _unlockRequestGeneration;
     final sessionGeneration = _store.sessionGeneration;
-    if (state.isPasswordConfigured) {
-      throw StateError('Password is already configured.');
+    if (_requiresWalletSetupRecovery) {
+      throw StateError('Recover the existing wallet before continuing setup.');
+    }
+    if (state.isPasswordConfigured || await _store.isPasswordConfigured()) {
+      final canResumeEmptySetup =
+          await _store.readPlain(kWalletRecoveryPendingKey) ==
+              kWalletSetupPendingValue &&
+          await ref.read(passwordSetupRollbackSafetyProvider)();
+      if (!canResumeEmptySetup) {
+        throw StateError('Password is already configured.');
+      }
     }
     if (_isPasswordSetupPrepared) {
       throw StateError('Password setup is already pending.');
@@ -160,6 +199,18 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
     // is still delayed until commit so the router never sees half-completed
     // onboarding.
     await _store.configurePassword(password);
+    try {
+      // Establish recovery before the first native DB mutation. A later
+      // keyring failure must not prevent recording the incomplete setup.
+      await _store.writePlain(
+        kWalletRecoveryPendingKey,
+        kWalletSetupPendingValue,
+      );
+    } catch (_) {
+      // The caller has not started account creation yet.
+      await _store.clearPasswordConfiguration();
+      rethrow;
+    }
     _isPasswordSetupPrepared = true;
     _passwordSetupSessionGeneration = _store.sessionGeneration;
     if (_store.enforcesSessionGeneration &&
@@ -178,9 +229,13 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
     }
   }
 
-  void commitPasswordSetup() {
+  Future<void> commitPasswordSetup() async {
     if (!_isPasswordSetupPrepared) {
       throw StateError('Password setup was not prepared.');
+    }
+    await _store.delete(kWalletRecoveryPendingKey);
+    if (await _store.readPlain(kWalletRecoveryPendingKey) != null) {
+      throw StateError('Wallet setup could not be saved. Retry recovery.');
     }
     final sessionGeneration = _passwordSetupSessionGeneration;
     _isPasswordSetupPrepared = false;
@@ -201,9 +256,38 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
 
   Future<void> _rollbackPasswordSetup() async {
     if (!_isPasswordSetupPrepared) return;
+    var canRollback = false;
+    try {
+      canRollback = await ref.read(passwordSetupRollbackSafetyProvider)();
+    } catch (_) {
+      // An unreadable database is not evidence that no account was created.
+    }
+    if (canRollback) {
+      await _store.clearPasswordConfiguration();
+      final name = await readWalletDbName();
+      if (name != null &&
+          await FileSystemEntity.type(
+                await getWalletDbPath(),
+                followLinks: false,
+              ) ==
+              FileSystemEntityType.notFound) {
+        // An explicit setup attempt allocated a name but never created a DB.
+        // Do not leave that unused locator looking like a missing wallet.
+        await _store.delete(kWalletDbNameKey);
+      }
+      // Keep the setup marker so a restart can distinguish this unused DB
+      // from a wallet whose password configuration was unexpectedly lost.
+      _isPasswordSetupPrepared = false;
+      _passwordSetupSessionGeneration = null;
+      return;
+    }
+
+    _requiresWalletSetupRecovery = true;
     _isPasswordSetupPrepared = false;
     _passwordSetupSessionGeneration = null;
-    await _store.clearPasswordConfiguration();
+    _store.clearSessionPassword();
+    // Keep the verifier, any saved signing material, and the marker written
+    // before account creation. No further keyring write is needed to recover.
   }
 
   Future<bool> unlock(String password) async {
@@ -328,6 +412,7 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
     _confirmRequestGeneration++;
     _isPasswordSetupPrepared = false;
     _passwordSetupSessionGeneration = null;
+    _requiresWalletSetupRecovery = false;
     _store.clearSessionPassword();
     state = const AppSecurityState(
       isPasswordConfigured: false,

--- a/lib/src/providers/app_security_provider.dart
+++ b/lib/src/providers/app_security_provider.dart
@@ -194,23 +194,21 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
     if (error != null) {
       throw ArgumentError(error);
     }
-    // Persist the verifier and open the secure-storage session before account
-    // creation/import writes the encrypted mnemonic. Publishing provider state
-    // is still delayed until commit so the router never sees half-completed
-    // onboarding.
-    await _store.configurePassword(password);
-    try {
-      // Establish recovery before the first native DB mutation. A later
-      // keyring failure must not prevent recording the incomplete setup.
-      await _store.writePlain(
-        kWalletRecoveryPendingKey,
-        kWalletSetupPendingValue,
-      );
-    } catch (_) {
-      // The caller has not started account creation yet.
-      await _store.clearPasswordConfiguration();
-      rethrow;
+    // Establish recovery before the verifier, session, or native account
+    // creation/import can write anything. Read back the marker so a rejected
+    // or silently dropped write never leaves a verifier without recovery
+    // evidence.
+    await _store.writePlain(
+      kWalletRecoveryPendingKey,
+      kWalletSetupPendingValue,
+    );
+    if (await _store.readPlain(kWalletRecoveryPendingKey) !=
+        kWalletSetupPendingValue) {
+      // No verifier has been written, and a partial credential write below
+      // remains recoverable.
+      throw StateError('Wallet setup recovery marker could not be saved.');
     }
+    await _store.configurePassword(password);
     _isPasswordSetupPrepared = true;
     _passwordSetupSessionGeneration = _store.sessionGeneration;
     if (_store.enforcesSessionGeneration &&

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -234,6 +234,43 @@ Future<List<AccountInfo>> listAccounts({
   network: network,
 );
 
+/// Read an existing recovery candidate without migrations or file creation.
+Future<List<AccountInfo>> inspectWalletForRecovery({
+  required String dbPath,
+  required String network,
+}) => RustLib.instance.api.crateApiWalletInspectWalletForRecovery(
+  dbPath: dbPath,
+  network: network,
+);
+
+/// Verify a software recovery secret against one account's full viewing key.
+Future<bool> verifyRecoveryMnemonic({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required String mnemonic,
+  required String bip39Passphrase,
+}) => RustLib.instance.api.crateApiWalletVerifyRecoveryMnemonic(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  mnemonic: mnemonic,
+  bip39Passphrase: bip39Passphrase,
+);
+
+/// Verify a hardware recovery key independently obtained from the device.
+Future<bool> verifyRecoveryHardwareKey({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required String ufvk,
+}) => RustLib.instance.api.crateApiWalletVerifyRecoveryHardwareKey(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  ufvk: ufvk,
+);
+
 Future<AccountExportMetadata> getAccountExportMetadata({
   required String dbPath,
   required String network,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 903176846;
+  int get rustContentHash => -1164138748;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -777,6 +777,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<void> crateApiSimpleInitApp();
 
+  Future<List<AccountInfo>> crateApiWalletInspectWalletForRecovery({
+    required String dbPath,
+    required String network,
+  });
+
   bool crateApiVotingIsLastMoment({
     required BigInt nowSeconds,
     required BigInt ceremonyStartSeconds,
@@ -1289,6 +1294,21 @@ abstract class RustLibApi extends BaseApi {
   });
 
   bool crateApiWalletValidateMnemonic({required String mnemonic});
+
+  Future<bool> crateApiWalletVerifyRecoveryHardwareKey({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String ufvk,
+  });
+
+  Future<bool> crateApiWalletVerifyRecoveryMnemonic({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String mnemonic,
+    required String bip39Passphrase,
+  });
 
   Future<String> crateApiVotingVoteCommitmentWireJson({
     required VoteCommitmentWire commitment,
@@ -5913,6 +5933,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "init_app", argNames: []);
 
   @override
+  Future<List<AccountInfo>> crateApiWalletInspectWalletForRecovery({
+    required String dbPath,
+    required String network,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 112,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_account_info,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletInspectWalletForRecoveryConstMeta,
+        argValues: [dbPath, network],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletInspectWalletForRecoveryConstMeta =>
+      const TaskConstMeta(
+        debugName: "inspect_wallet_for_recovery",
+        argNames: ["dbPath", "network"],
+      );
+
+  @override
   bool crateApiVotingIsLastMoment({
     required BigInt nowSeconds,
     required BigInt ceremonyStartSeconds,
@@ -5928,7 +5983,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
           )!;
         },
         codec: SseCodec(
@@ -5956,7 +6011,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
           )!;
         },
         codec: SseCodec(
@@ -5996,7 +6051,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -6039,7 +6094,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
           )!;
         },
         codec: SseCodec(
@@ -6065,7 +6120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
           )!;
         },
         codec: SseCodec(
@@ -6091,7 +6146,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
           )!;
         },
         codec: SseCodec(
@@ -6119,7 +6174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -6154,7 +6209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
           )!;
         },
         codec: SseCodec(
@@ -6188,7 +6243,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },
@@ -6222,7 +6277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 122,
             port: port_,
           );
         },
@@ -6263,7 +6318,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -6306,7 +6361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6372,7 +6427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 125,
             port: port_,
           );
         },
@@ -6442,7 +6497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6513,7 +6568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6563,7 +6618,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 128,
           )!;
         },
         codec: SseCodec(
@@ -6594,7 +6649,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6627,7 +6682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6667,7 +6722,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6706,7 +6761,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6742,7 +6797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6780,7 +6835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6833,7 +6888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6889,7 +6944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
             port: port_,
           );
         },
@@ -6934,7 +6989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 137,
             port: port_,
           );
         },
@@ -6994,7 +7049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
             port: port_,
           );
         },
@@ -7054,7 +7109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -7113,7 +7168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -7158,7 +7213,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -7191,7 +7246,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
             port: port_,
           );
         },
@@ -7232,7 +7287,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -7291,7 +7346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -7353,7 +7408,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -7401,7 +7456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
             port: port_,
           );
         },
@@ -7460,7 +7515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -7524,7 +7579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -7563,7 +7618,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
             port: port_,
           );
         },
@@ -7593,7 +7648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
           )!;
         },
         codec: SseCodec(
@@ -7626,7 +7681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
             port: port_,
           );
         },
@@ -7663,7 +7718,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
             port: port_,
           );
         },
@@ -7698,7 +7753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
             port: port_,
           );
         },
@@ -7740,7 +7795,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
             port: port_,
           );
         },
@@ -7775,7 +7830,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7816,7 +7871,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7865,7 +7920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -7903,7 +7958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7944,7 +7999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -8005,7 +8060,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -8070,7 +8125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
           )!;
         },
         codec: SseCodec(
@@ -8100,7 +8155,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
           )!;
         },
         codec: SseCodec(
@@ -8144,7 +8199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -8191,7 +8246,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
           )!;
         },
         codec: SseCodec(
@@ -8221,7 +8276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
           )!;
         },
         codec: SseCodec(
@@ -8256,7 +8311,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
             port: port_,
           );
         },
@@ -8289,7 +8344,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -8330,7 +8385,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
             port: port_,
           );
         },
@@ -8384,7 +8439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
             port: port_,
           );
         },
@@ -8434,7 +8489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 169,
+              funcId: 170,
               port: port_,
             );
           },
@@ -8475,7 +8530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 170,
+              funcId: 171,
               port: port_,
             );
           },
@@ -8507,7 +8562,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 172,
             port: port_,
           );
         },
@@ -8534,7 +8589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 173,
           )!;
         },
         codec: SseCodec(
@@ -8560,7 +8615,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 174,
             port: port_,
           );
         },
@@ -8607,7 +8662,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 175,
             port: port_,
           );
         },
@@ -8680,7 +8735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 176,
             port: port_,
           );
         },
@@ -8747,7 +8802,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 177,
             port: port_,
           );
         },
@@ -8803,7 +8858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 178,
             port: port_,
           );
         },
@@ -8848,7 +8903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 179,
             port: port_,
           );
         },
@@ -8895,7 +8950,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 179,
+            funcId: 180,
             port: port_,
           );
         },
@@ -8934,7 +8989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 181,
             port: port_,
           );
         },
@@ -8963,7 +9018,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 181,
+            funcId: 182,
           )!;
         },
         codec: SseCodec(
@@ -8990,7 +9045,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 182,
+            funcId: 183,
           )!;
         },
         codec: SseCodec(
@@ -9026,7 +9081,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 183,
+            funcId: 184,
             port: port_,
           );
         },
@@ -9065,7 +9120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 184,
+            funcId: 185,
             port: port_,
           );
         },
@@ -9106,7 +9161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 185,
+            funcId: 186,
             port: port_,
           );
         },
@@ -9154,7 +9209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 186,
+            funcId: 187,
             port: port_,
           );
         },
@@ -9208,7 +9263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 187,
+            funcId: 188,
             port: port_,
           );
         },
@@ -9258,7 +9313,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 188,
+            funcId: 189,
             port: port_,
           );
         },
@@ -9292,7 +9347,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 189,
+            funcId: 190,
             port: port_,
           );
         },
@@ -9323,7 +9378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 190,
+            funcId: 191,
           )!;
         },
         codec: SseCodec(
@@ -9344,6 +9399,92 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<bool> crateApiWalletVerifyRecoveryHardwareKey({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String ufvk,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_String(ufvk, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 192,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_bool,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletVerifyRecoveryHardwareKeyConstMeta,
+        argValues: [dbPath, network, accountUuid, ufvk],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletVerifyRecoveryHardwareKeyConstMeta =>
+      const TaskConstMeta(
+        debugName: "verify_recovery_hardware_key",
+        argNames: ["dbPath", "network", "accountUuid", "ufvk"],
+      );
+
+  @override
+  Future<bool> crateApiWalletVerifyRecoveryMnemonic({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String mnemonic,
+    required String bip39Passphrase,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_String(mnemonic, serializer);
+          sse_encode_String(bip39Passphrase, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 193,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_bool,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletVerifyRecoveryMnemonicConstMeta,
+        argValues: [dbPath, network, accountUuid, mnemonic, bip39Passphrase],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletVerifyRecoveryMnemonicConstMeta =>
+      const TaskConstMeta(
+        debugName: "verify_recovery_mnemonic",
+        argNames: [
+          "dbPath",
+          "network",
+          "accountUuid",
+          "mnemonic",
+          "bip39Passphrase",
+        ],
+      );
+
+  @override
   Future<String> crateApiVotingVoteCommitmentWireJson({
     required VoteCommitmentWire commitment,
   }) {
@@ -9355,7 +9496,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 191,
+            funcId: 194,
             port: port_,
           );
         },
@@ -9386,7 +9527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 192,
+            funcId: 195,
           )!;
         },
         codec: SseCodec(
@@ -9412,7 +9553,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 193,
+            funcId: 196,
           )!;
         },
         codec: SseCodec(
@@ -9458,7 +9599,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 194,
+            funcId: 197,
             port: port_,
           );
         },
@@ -9506,7 +9647,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 195,
+            funcId: 198,
           )!;
         },
         codec: SseCodec(
@@ -9540,7 +9681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 196,
+            funcId: 199,
             port: port_,
           );
         },
@@ -9577,7 +9718,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 197,
+            funcId: 200,
             port: port_,
           );
         },

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -935,6 +935,62 @@ pub fn list_accounts(db_path: String, network: String) -> Result<Vec<AccountInfo
     })
 }
 
+/// Read an existing recovery candidate without migrations or file creation.
+pub fn inspect_wallet_for_recovery(
+    db_path: String,
+    network: String,
+) -> Result<Vec<AccountInfo>, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        Ok(keys::inspect_wallet_for_recovery(&db_path, network)?
+            .into_iter()
+            .map(|a| AccountInfo {
+                uuid: a.uuid,
+                name: a.name,
+                unified_address: a.unified_address,
+                is_seed_anchor: a.is_seed_anchor,
+                is_hardware: a.is_hardware,
+            })
+            .collect())
+    })
+}
+
+/// Verify a software recovery secret against one account's full viewing key.
+pub fn verify_recovery_mnemonic(
+    db_path: String,
+    network: String,
+    account_uuid: String,
+    mnemonic: String,
+    bip39_passphrase: String,
+) -> Result<bool, String> {
+    catch(|| {
+        keys::verify_recovery_mnemonic(
+            &db_path,
+            keys::parse_network(&network)?,
+            &account_uuid,
+            &mnemonic,
+            &bip39_passphrase,
+        )
+    })
+}
+
+/// Verify a hardware recovery key independently obtained from the device.
+pub fn verify_recovery_hardware_key(
+    db_path: String,
+    network: String,
+    account_uuid: String,
+    ufvk: String,
+) -> Result<bool, String> {
+    catch(|| {
+        keys::verify_recovery_hardware_key(
+            &db_path,
+            keys::parse_network(&network)?,
+            &account_uuid,
+            &ufvk,
+        )
+    })
+}
+
 pub fn get_account_export_metadata(
     db_path: String,
     network: String,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 903176846;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1164138748;
 
 // Section: executor
 
@@ -4435,6 +4435,41 @@ fn wire__crate__api__simple__init_app_impl(
         },
     )
 }
+fn wire__crate__api__wallet__inspect_wallet_for_recovery_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "inspect_wallet_for_recovery",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::wallet::inspect_wallet_for_recovery(api_db_path, api_network)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__voting__is_last_moment_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -7695,6 +7730,90 @@ fn wire__crate__api__wallet__validate_mnemonic_impl(
                     Result::<_, ()>::Ok(crate::api::wallet::validate_mnemonic(api_mnemonic))?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__wallet__verify_recovery_hardware_key_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "verify_recovery_hardware_key",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_ufvk = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::verify_recovery_hardware_key(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                        api_ufvk,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet__verify_recovery_mnemonic_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "verify_recovery_mnemonic",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
+            let api_bip39_passphrase = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::verify_recovery_mnemonic(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                        api_mnemonic,
+                        api_bip39_passphrase,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -11814,73 +11933,76 @@ fn pde_ffi_dispatcher_primary_impl(
 109 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
 110 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
 111 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__voting__precompute_delegation_proof_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__voting__preflight_voting_helpers_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__voting__prepare_committed_share_delivery_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__sync__prepare_pczt_for_keystone_batch_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__voting__prepare_voting_participation_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-148 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-151 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-152 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__sync__run_payment_link_claim_sync_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-173 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
-176 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
-178 => wire__crate__api__voting__submit_prepared_shares_to_helpers_impl(port, ptr, rust_vec_len, data_len),
-179 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-183 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
-184 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
-185 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
-186 => wire__crate__api__voting__track_pending_shares_impl(port, ptr, rust_vec_len, data_len),
-187 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-188 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-189 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-191 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-194 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
-196 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-197 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__wallet__inspect_wallet_for_recovery_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__sync__keystone_migration_proof_status_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__voting__list_pending_share_rounds_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__sync__migrate_orchard_to_ironwood_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__sync__migrate_orchard_to_ironwood_immediately_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__sync__migrate_orchard_to_ironwood_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__keystone__pczt_spend_nullifiers_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__voting__precompute_delegation_proof_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__voting__precompute_snapshot_bundles_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__voting__preflight_voting_helpers_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__voting__prepare_committed_share_delivery_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__sync__prepare_orchard_migration_batch_pczt_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__sync__prepare_orchard_migration_immediate_pczt_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__sync__prepare_orchard_migration_outbox_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__sync__prepare_pczt_for_keystone_batch_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__voting__prepare_voting_participation_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__network_privacy__quiesce_network_privacy_direct_requests_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__sync__reconcile_orchard_migration_outbox_receipt_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+149 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+152 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+153 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__voting__resolve_voting_config_from_attempts_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__sync__retain_proposal_lock_until_expiry_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__sync__retire_unbroadcast_orchard_migration_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__sync__run_payment_link_claim_sync_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__network_privacy__start_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__network_privacy__stop_tor_update_relay_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__sync__store_and_broadcast_pczts_with_keystone_signatures_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+176 => wire__crate__api__sync__store_and_broadcast_signed_pczts_for_proposal_impl(port, ptr, rust_vec_len, data_len),
+177 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+178 => wire__crate__api__voting__store_keystone_signatures_batch_impl(port, ptr, rust_vec_len, data_len),
+179 => wire__crate__api__voting__submit_prepared_shares_to_helpers_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+184 => wire__crate__api__network_privacy__tor_http_download_impl(port, ptr, rust_vec_len, data_len),
+185 => wire__crate__api__network_privacy__tor_http_get_impl(port, ptr, rust_vec_len, data_len),
+186 => wire__crate__api__network_privacy__tor_http_post_impl(port, ptr, rust_vec_len, data_len),
+187 => wire__crate__api__voting__track_pending_shares_impl(port, ptr, rust_vec_len, data_len),
+188 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+189 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+190 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+192 => wire__crate__api__wallet__verify_recovery_hardware_key_impl(port, ptr, rust_vec_len, data_len),
+193 => wire__crate__api__wallet__verify_recovery_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+194 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+197 => wire__crate__api__voting__warm_pir_proof_cache_impl(port, ptr, rust_vec_len, data_len),
+199 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+200 => wire__crate__api__keystone__zcash_sign_batch_round_message_counts_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -11929,45 +12051,45 @@ fn pde_ffi_dispatcher_sync_impl(
         93 => wire__crate__api__sync__get_pczt_txid_impl(ptr, rust_vec_len, data_len),
         99 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
         106 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        113 => {
+        113 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        114 => {
             wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len)
         }
-        115 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        116 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        117 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
-        119 => {
+        116 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        118 => wire__crate__api__network_privacy__is_tor_enabled_impl(ptr, rust_vec_len, data_len),
+        120 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        127 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        149 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        160 => {
+        128 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        150 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        161 => {
             wire__crate__api__voting__select_pir_snapshot_endpoint_impl(ptr, rust_vec_len, data_len)
         }
-        161 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
-        163 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
+        162 => wire__crate__api__sync__set_active_sync_account_impl(ptr, rust_vec_len, data_len),
+        164 => wire__crate__api__network_privacy__set_network_privacy_dormant_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        164 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        172 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        181 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
+        165 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        173 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        182 => wire__crate__api__network_privacy__tor_http_begin_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        182 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
+        183 => wire__crate__api__network_privacy__tor_http_cancel_request_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        190 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        192 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
-        193 => {
+        191 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        195 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        196 => {
             wire__crate__api__sync__warm_orchard_proving_key_cache_impl(ptr, rust_vec_len, data_len)
         }
-        195 => {
+        198 => {
             wire__crate__api__voting__warm_voting_proving_caches_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -25,8 +25,9 @@ use zip32::fingerprint::SeedFingerprint;
 use crate::wallet::{
     db::{
         open_readonly_conn_with_timeout, open_wallet_db_for_read_with_timeout,
-        open_wallet_db_with_timeout, with_wallet_db_write_lock, WalletDatabase,
-        ACCOUNT_MUTATION_DB_BUSY_TIMEOUT, READ_DB_BUSY_TIMEOUT, WALLET_DB_BUSY_TIMEOUT,
+        open_wallet_db_readonly_with_timeout, open_wallet_db_with_timeout,
+        with_wallet_db_write_lock, WalletDatabase, ACCOUNT_MUTATION_DB_BUSY_TIMEOUT,
+        READ_DB_BUSY_TIMEOUT, WALLET_DB_BUSY_TIMEOUT,
     },
     network::WalletNetwork,
 };
@@ -604,7 +605,36 @@ pub fn existing_software_seed_account_state(
 /// List all accounts in the wallet database.
 pub fn list_accounts(db_path: &str, network: WalletNetwork) -> Result<Vec<AccountInfo>, String> {
     let db = open_wallet_db_for_read(db_path, network)?;
+    list_accounts_from_db(&db, network, true)
+}
 
+/// Inspect a recovery candidate without creating, migrating, or writing it.
+/// Receive addresses are deliberately not hydrated during locked startup.
+pub fn inspect_wallet_for_recovery(
+    db_path: &str,
+    network: WalletNetwork,
+) -> Result<Vec<AccountInfo>, String> {
+    let conn = open_readonly_conn_with_timeout(db_path, Some(READ_DB_BUSY_TIMEOUT))?;
+    let check: String = conn
+        .query_row("PRAGMA quick_check(1)", [], |row| row.get(0))
+        .map_err(|e| format!("Failed to check recovery database: {e}"))?;
+    if check != "ok" {
+        return Err("The recovery database failed its SQLite integrity check".to_string());
+    }
+    let db = WalletDatabase::from_connection(
+        conn,
+        network,
+        zcash_client_sqlite::util::SystemClock,
+        voting_crypto_deps::rand::rngs::OsRng,
+    );
+    list_accounts_from_db(&db, network, false)
+}
+
+fn list_accounts_from_db(
+    db: &WalletDatabase,
+    network: WalletNetwork,
+    include_addresses: bool,
+) -> Result<Vec<AccountInfo>, String> {
     let account_ids = db
         .get_account_ids()
         .map_err(|e| format!("Failed to list accounts: {e}"))?;
@@ -618,7 +648,11 @@ pub fn list_accounts(db_path: &str, network: WalletNetwork) -> Result<Vec<Accoun
 
         let (address, is_hardware) = match account.ufvk() {
             Some(ufvk) => (
-                current_receive_address(&db, network, id, ufvk)?,
+                if include_addresses {
+                    current_receive_address(db, network, id, ufvk)?
+                } else {
+                    String::new()
+                },
                 is_keystone_style_ufvk(ufvk),
             ),
             None => (String::new(), false),
@@ -635,6 +669,57 @@ pub fn list_accounts(db_path: &str, network: WalletNetwork) -> Result<Vec<Accoun
     }
 
     Ok(accounts)
+}
+
+/// Verify the full account key, including its ZIP32 index and BIP39 passphrase.
+/// Seed fingerprints alone are not sufficient to adopt a recovery candidate.
+pub fn verify_recovery_mnemonic(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    mnemonic: &str,
+    bip39_passphrase: &str,
+) -> Result<bool, String> {
+    let db = open_wallet_db_readonly_with_timeout(db_path, network, READ_DB_BUSY_TIMEOUT)?;
+    let account = db
+        .get_account(parse_account_uuid(account_uuid)?)
+        .map_err(|e| format!("Failed to inspect recovery account: {e}"))?
+        .ok_or("Recovery account was not found")?;
+    if account.ufvk().is_some_and(is_keystone_style_ufvk) {
+        return Ok(false);
+    }
+    let derivation = account
+        .source()
+        .key_derivation()
+        .ok_or("Recovery account has no ZIP32 derivation")?;
+    let stored = account
+        .ufvk()
+        .ok_or("Recovery account has no viewing key")?;
+    let seed = mnemonic_to_seed_with_passphrase(mnemonic, bip39_passphrase)?;
+    let derived = software_account_ufvk(network, &seed, u32::from(derivation.account_index()))?;
+    Ok(derived.encode(&network) == stored.encode(&network))
+}
+
+/// Match an independently obtained hardware-device UFVK without modifying the DB.
+pub fn verify_recovery_hardware_key(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    ufvk: &str,
+) -> Result<bool, String> {
+    let db = open_wallet_db_readonly_with_timeout(db_path, network, READ_DB_BUSY_TIMEOUT)?;
+    let account = db
+        .get_account(parse_account_uuid(account_uuid)?)
+        .map_err(|e| format!("Failed to inspect recovery account: {e}"))?
+        .ok_or("Recovery account was not found")?;
+    if !account.ufvk().is_some_and(is_keystone_style_ufvk) {
+        return Ok(false);
+    }
+    let supplied = UnifiedFullViewingKey::decode(&network, ufvk)
+        .map_err(|e| format!("Invalid hardware viewing key: {e}"))?;
+    Ok(account
+        .ufvk()
+        .is_some_and(|stored| stored.encode(&network) == supplied.encode(&network)))
 }
 
 pub fn get_account_export_metadata(
@@ -1244,6 +1329,132 @@ pub fn wallet_exists(db_path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recovery_inspection_never_creates_or_replaces_a_database() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("missing.db");
+        let path = path.to_str().unwrap();
+        assert!(inspect_wallet_for_recovery(path, WalletNetwork::Main).is_err());
+        assert!(!Path::new(path).exists());
+        std::fs::write(path, b"damaged wallet fixture").unwrap();
+        assert!(inspect_wallet_for_recovery(path, WalletNetwork::Main).is_err());
+        assert_eq!(std::fs::read(path).unwrap(), b"damaged wallet fixture");
+    }
+
+    #[test]
+    fn recovery_verifies_each_seed_index_and_passphrase_without_writes() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("wallet.db");
+        let path = path.to_str().unwrap();
+        let first_phrase = generate_mnemonic();
+        let second_phrase = generate_mnemonic();
+        let first_seed = mnemonic_to_seed(&first_phrase).unwrap();
+        let second_seed = mnemonic_to_seed_with_passphrase(&second_phrase, "passphrase").unwrap();
+        let (first, _) =
+            init_db_and_create_account(path, WalletNetwork::Main, &first_seed, None, "First")
+                .unwrap();
+        let (second, _) =
+            add_account_at_index(path, WalletNetwork::Main, "Second", &second_seed, None, 7)
+                .unwrap();
+        let before = std::fs::read(path).unwrap();
+        let accounts = inspect_wallet_for_recovery(path, WalletNetwork::Main).unwrap();
+        assert_eq!(accounts.len(), 2);
+        assert!(accounts.iter().all(|a| a.unified_address.is_empty()));
+        assert!(
+            verify_recovery_mnemonic(path, WalletNetwork::Main, &first, &first_phrase, "").unwrap()
+        );
+        assert!(verify_recovery_mnemonic(
+            path,
+            WalletNetwork::Main,
+            &second,
+            &second_phrase,
+            "passphrase"
+        )
+        .unwrap());
+        assert!(
+            !verify_recovery_mnemonic(path, WalletNetwork::Main, &second, &first_phrase, "")
+                .unwrap()
+        );
+        assert!(
+            !verify_recovery_mnemonic(path, WalletNetwork::Main, &second, &second_phrase, "")
+                .unwrap()
+        );
+        assert!(inspect_wallet_for_recovery(path, WalletNetwork::Test).is_err());
+        assert_eq!(std::fs::read(path).unwrap(), before);
+
+        delete_account(path, WalletNetwork::Main, &first).unwrap();
+        let accounts = inspect_wallet_for_recovery(path, WalletNetwork::Main).unwrap();
+        assert_eq!(accounts.len(), 1);
+        assert!(!accounts[0].is_seed_anchor);
+        assert!(verify_recovery_mnemonic(
+            path,
+            WalletNetwork::Main,
+            &second,
+            &second_phrase,
+            "passphrase"
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn recovery_supports_hardware_first_without_a_derived_seed_anchor() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("wallet.db");
+        let path = path.to_str().unwrap();
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let ufvk = hardware_style_ufvk(&seed, zip32::AccountId::ZERO);
+        let fingerprint = SeedFingerprint::from_seed(seed.expose_secret())
+            .unwrap()
+            .to_bytes();
+        let (uuid, _) = import_hardware_account(
+            path,
+            WalletNetwork::Main,
+            "Keystone",
+            &ufvk,
+            &fingerprint,
+            0,
+            None,
+        )
+        .unwrap();
+        let before = std::fs::read(path).unwrap();
+        let accounts = inspect_wallet_for_recovery(path, WalletNetwork::Main).unwrap();
+        assert_eq!(accounts.len(), 1);
+        assert!(accounts[0].is_hardware);
+        assert!(!accounts[0].is_seed_anchor);
+        assert!(verify_recovery_hardware_key(path, WalletNetwork::Main, &uuid, &ufvk).unwrap());
+        let other = hardware_style_ufvk(
+            &mnemonic_to_seed(&generate_mnemonic()).unwrap(),
+            zip32::AccountId::ZERO,
+        );
+        assert!(!verify_recovery_hardware_key(path, WalletNetwork::Main, &uuid, &other).unwrap());
+        assert!(!verify_recovery_mnemonic(path, WalletNetwork::Main, &uuid, &phrase, "").unwrap());
+        assert_eq!(std::fs::read(path).unwrap(), before);
+    }
+
+    fn hardware_style_ufvk(seed: &SecretVec<u8>, account_index: zip32::AccountId) -> String {
+        use zcash_address::unified::{Encoding, Fvk, Ufvk};
+        use zcash_protocol::consensus::NetworkType;
+
+        let full_ufvk = UnifiedSpendingKey::from_seed(
+            &WalletNetwork::Main,
+            seed.expose_secret(),
+            account_index,
+        )
+        .unwrap()
+        .to_unified_full_viewing_key();
+        let orchard_fvk = full_ufvk.orchard().unwrap().to_bytes();
+        let transparent_fvk = full_ufvk
+            .transparent()
+            .unwrap()
+            .serialize()
+            .try_into()
+            .unwrap();
+        Ufvk::try_from_items(vec![Fvk::Orchard(orchard_fvk), Fvk::P2pkh(transparent_fvk)])
+            .unwrap()
+            .encode(&NetworkType::Main)
+    }
 
     #[test]
     fn test_generate_mnemonic_is_24_words() {

--- a/scripts/test-wallet-recovery.sh
+++ b/scripts/test-wallet-recovery.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Exercise recovery through real Rust/SQLite and Flutter, with a disposable
+# app-support directory and an in-memory OS-storage backend. No wallet network
+# connections or installed app data are used.
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$project_root/rust"
+cargo build --lib
+recovery_target_dir="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')"
+case "$(uname -s)" in
+  Darwin) recovery_library="$recovery_target_dir/debug/librust_lib_zcash_wallet.dylib" ;;
+  Linux) recovery_library="$recovery_target_dir/debug/librust_lib_zcash_wallet.so" ;;
+  MINGW*|MSYS*|CYGWIN*) recovery_library="$recovery_target_dir/debug/rust_lib_zcash_wallet.dll" ;;
+  *) echo 'Unsupported host. Pass VIZOR_RECOVERY_NATIVE_LIBRARY directly to flutter test.' >&2; exit 1 ;;
+esac
+
+cd "$project_root"
+fvm flutter test --no-pub \
+  --dart-define="VIZOR_RECOVERY_NATIVE_LIBRARY=$recovery_library" \
+  test/core/storage/wallet_recovery_native_test.dart "$@"

--- a/scripts/test-wallet-setup.sh
+++ b/scripts/test-wallet-setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Real Rust/SQLite and encryption with disposable wallet data and fake OS storage.
+set -euo pipefail
+setup_project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+setup_mobile=false
+if [[ "${1:-}" == '--mobile' ]]; then
+  setup_mobile=true
+  shift
+fi
+cd "$setup_project_root/rust"
+cargo build --lib
+setup_target_dir="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')"
+case "$(uname -s)" in
+  Darwin) setup_library="$setup_target_dir/debug/librust_lib_zcash_wallet.dylib" ;;
+  Linux) setup_library="$setup_target_dir/debug/librust_lib_zcash_wallet.so" ;;
+  MINGW*|MSYS*|CYGWIN*) setup_library="$setup_target_dir/debug/rust_lib_zcash_wallet.dll" ;;
+  *) echo 'Unsupported native test host.' >&2; exit 1 ;;
+esac
+cd "$setup_project_root"
+setup_args=(--no-pub "--dart-define=VIZOR_RECOVERY_NATIVE_LIBRARY=$setup_library")
+if "$setup_mobile"; then
+  setup_args+=(--dart-define=VIZOR_FORM_FACTOR=mobile --tags mobile --run-skipped test/features/onboarding/mobile_wallet_setup_native_test.dart)
+else
+  setup_args+=(test/core/storage/wallet_setup_native_test.dart)
+fi
+fvm flutter test "${setup_args[@]}" "$@"

--- a/test/app_wallet_recovery_test.dart
+++ b/test/app_wallet_recovery_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_recovery.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/wallet_recovery_screen.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/wallet_provider.dart';
+
+final _routerProvider = Provider.autoDispose.family<GoRouter, String>((
+  ref,
+  location,
+) {
+  final bootstrap = ref.watch(appBootstrapProvider);
+  final router = GoRouter(
+    initialLocation: location,
+    redirect: (_, state) =>
+        appRedirect(ref: ref, bootstrap: bootstrap, state: state),
+    routes: [
+      ...appAuthRoutes(
+        ref,
+        bootstrap,
+        unlockScreen: const Text('Ordinary unlock'),
+      ),
+      GoRoute(path: '/home', builder: (_, _) => const Text('Wallet home')),
+    ],
+  );
+  ref.onDispose(router.dispose);
+  return router;
+});
+
+void main() {
+  for (final location in [
+    '/',
+    '/welcome',
+    '/home',
+    '/unlock',
+    '/wallet-recovery',
+  ]) {
+    testWidgets('recovery blocks ordinary wallet routes from $location', (
+      tester,
+    ) async {
+      final bootstrap = AppBootstrapState.recovery(
+        const WalletRecoveryState(
+          candidates: [],
+          network: 'main',
+          isPasswordConfigured: true,
+        ),
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
+          child: Consumer(
+            builder: (context, ref, _) => MaterialApp.router(
+              routerConfig: ref.watch(_routerProvider(location)),
+              builder: (_, child) =>
+                  AppTheme(data: AppThemeData.dark, child: child!),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(WalletRecoveryScreen), findsOneWidget);
+      expect(find.text('Create wallet'), findsNothing);
+      expect(find.text('Wallet home'), findsNothing);
+      expect(find.text('Ordinary unlock'), findsNothing);
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(WalletRecoveryScreen)),
+      );
+      expect(container.exists(walletProvider), isFalse);
+      expect(container.exists(appSecurityProvider), isFalse);
+      expect(tester.takeException(), isNull);
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+  }
+}

--- a/test/app_wallet_recovery_test.dart
+++ b/test/app_wallet_recovery_test.dart
@@ -1,12 +1,21 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:zcash_wallet/app.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_recovery.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/onboarding/wallet_recovery_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/welcome.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/wallet_provider.dart';
 
@@ -25,6 +34,7 @@ final _routerProvider = Provider.autoDispose.family<GoRouter, String>((
         bootstrap,
         unlockScreen: const Text('Ordinary unlock'),
       ),
+      ...appDesktopOnboardingRoutes(ref),
       GoRoute(path: '/home', builder: (_, _) => const Text('Wallet home')),
     ],
   );
@@ -33,6 +43,7 @@ final _routerProvider = Provider.autoDispose.family<GoRouter, String>((
 });
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   for (final location in [
     '/',
     '/welcome',
@@ -76,4 +87,150 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
     });
   }
+
+  group('interrupted setup startup boundary', () {
+    late Directory support;
+    const dbName = 'zcash_wallet_interrupted.db';
+    final store = AppSecureStore.instance;
+    const pathProvider = MethodChannel('plugins.flutter.io/path_provider');
+    final prepared = <String, String>{
+      kWalletRecoveryPendingKey: kWalletSetupPendingValue,
+      kWalletDbNameKey: dbName,
+      'zcash_password_verifier': 'persisted-verifier',
+      'zcash_password_verifier_salt': 'persisted-salt',
+    };
+
+    setUp(() async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      support = await Directory.systemTemp.createTemp('vizor-empty-setup-');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(pathProvider, (call) async => support.path);
+      SharedPreferences.setMockInitialValues({});
+      store.clearSessionPassword();
+    });
+    tearDown(() async {
+      store.clearSessionPassword();
+      FlutterSecureStorage.setMockInitialValues({});
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(pathProvider, null);
+      debugDefaultTargetPlatformOverride = null;
+      await support.delete(recursive: true);
+    });
+
+    for (final scenario
+        in <({String name, Map<String, String> values, bool resume})>[
+          (
+            name: 'allocated locator before DB creation',
+            values: prepared,
+            resume: true,
+          ),
+          (
+            name: 'marker before credential writes',
+            values: {kWalletRecoveryPendingKey: kWalletSetupPendingValue},
+            resume: true,
+          ),
+          (
+            name: 'partial credential write',
+            values: {...prepared}..remove('zcash_password_verifier'),
+            resume: true,
+          ),
+          (
+            name: 'unmarked missing DB',
+            values: {...prepared}..remove(kWalletRecoveryPendingKey),
+            resume: false,
+          ),
+          (
+            name: 'reconnection marker',
+            values: {...prepared, kWalletRecoveryPendingKey: dbName},
+            resume: false,
+          ),
+          (
+            name: 'invalid DB locator',
+            values: {...prepared, kWalletDbNameKey: '../wallet.db'},
+            resume: false,
+          ),
+          (
+            name: 'persisted active account',
+            values: {...prepared, 'zcash_active_account': 'existing-account'},
+            resume: false,
+          ),
+          (
+            name: 'persisted account list',
+            values: {
+              ...prepared,
+              'zcash_accounts': jsonEncode([
+                {'uuid': 'existing-account', 'name': 'Existing', 'order': 0},
+              ]),
+            },
+            resume: false,
+          ),
+          (
+            name: 'damaged account metadata',
+            values: {...prepared, 'zcash_accounts': '{damaged'},
+            resume: false,
+          ),
+        ]) {
+      test(scenario.name, () async {
+        final values = Map<String, String>.of(scenario.values);
+        FlutterSecureStorage.setMockInitialValues(values);
+        final bootstrap = await loadAppBootstrap();
+        expect(
+          bootstrap.initialLocation,
+          scenario.resume ? '/welcome' : '/wallet-recovery',
+        );
+        expect(bootstrap.isUnlocked, isFalse);
+        if (scenario.resume) expect(bootstrap.isPasswordConfigured, isFalse);
+        expect(values, scenario.values);
+        expect(await support.list().toList(), isEmpty);
+      });
+    }
+
+    for (final remnant in ['wal', 'symlink']) {
+      test('$remnant evidence prevents empty setup resumption', () async {
+        FlutterSecureStorage.setMockInitialValues(Map.of(prepared));
+        if (remnant == 'wal') {
+          await File(
+            '${support.path}/$dbName-wal',
+          ).writeAsString('preserved WAL');
+        } else {
+          await Link(
+            '${support.path}/$dbName',
+          ).create('${support.path}/missing.db');
+        }
+        final bootstrap = await loadAppBootstrap();
+        expect(bootstrap.initialLocation, '/wallet-recovery');
+        expect(bootstrap.walletRecovery!.candidates.single.canInspect, isFalse);
+        expect(await support.list(followLinks: false).toList(), hasLength(1));
+      });
+    }
+
+    testWidgets('an unused locator returns to the actual welcome screen', (
+      tester,
+    ) async {
+      try {
+        FlutterSecureStorage.setMockInitialValues(Map.of(prepared));
+        final bootstrap = (await tester.runAsync(loadAppBootstrap))!;
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
+            child: Consumer(
+              builder: (context, ref, _) => MaterialApp.router(
+                routerConfig: ref.watch(_routerProvider('/')),
+                builder: (_, child) =>
+                    AppTheme(data: AppThemeData.dark, child: child!),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(WelcomeScreen), findsOneWidget);
+        expect(find.byType(WalletRecoveryScreen), findsNothing);
+        expect(find.text('Create a wallet'), findsOneWidget);
+        expect(find.text('Import a wallet'), findsOneWidget);
+        await tester.pumpWidget(const SizedBox.shrink());
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+  });
 }

--- a/test/core/storage/wallet_recovery_native_test.dart
+++ b/test/core/storage/wallet_recovery_native_test.dart
@@ -25,7 +25,9 @@ import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_recovery.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_text_field.dart';
+import 'package:zcash_wallet/src/core/widgets/password_text_field.dart';
 import 'package:zcash_wallet/src/features/activity/gift_card_activity_index.dart';
 import 'package:zcash_wallet/src/features/home/screens/home_screen.dart';
 import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_home_screen.dart';
@@ -847,6 +849,30 @@ void main() {
               .isNotEmpty,
         );
         expect(find.text('Phrase needed'), findsNothing);
+        if (allMetadataMissing && !_mobile) {
+          final recoveryScroll = find.descendant(
+            of: find.byType(WalletRecoveryScreen),
+            matching: find.byType(Scrollable),
+          );
+          final firstPasswordField = find.byType(PasswordTextField).first;
+          expect(
+            tester.getTopLeft(firstPasswordField).dy,
+            greaterThanOrEqualTo(tester.getTopLeft(recoveryScroll.first).dy),
+            reason:
+                'The new-password step must start at the top of its scroll area.',
+          );
+        } else if (!allMetadataMissing && _mobile) {
+          final badge = find.descendant(
+            of: find.byType(WalletRecoveryScreen),
+            matching: find.byType(Image),
+          );
+          expect(
+            tester.getTopLeft(badge).dy,
+            greaterThanOrEqualTo(AppSpacing.sm),
+            reason:
+                'The ready step must not restore the discovery scroll offset.',
+          );
+        }
         debugPrint('recovery UI: account verified');
         await _capture(
           tester,

--- a/test/core/storage/wallet_recovery_native_test.dart
+++ b/test/core/storage/wallet_recovery_native_test.dart
@@ -809,7 +809,7 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        expect(find.text('Recover your wallet'), findsOneWidget);
+        expect(find.text('Wallet found'), findsOneWidget);
         expect(find.text('Create wallet'), findsNothing);
         final recoveryContainer = ProviderScope.containerOf(
           tester.element(find.byType(WalletRecoveryScreen)),
@@ -837,9 +837,16 @@ void main() {
         }
         await _pumpUntil(
           tester,
-          () => find.text('Recovery material verified').evaluate().isNotEmpty,
+          () => find
+              .text(
+                allMetadataMissing
+                    ? (_mobile ? 'Create passcode' : 'New password')
+                    : 'Verified',
+              )
+              .evaluate()
+              .isNotEmpty,
         );
-        expect(find.text('Recovery phrase needed'), findsNothing);
+        expect(find.text('Phrase needed'), findsNothing);
         debugPrint('recovery UI: account verified');
         await _capture(
           tester,
@@ -854,8 +861,8 @@ void main() {
             await _enterField(tester, 'New password', _newPassword);
             await _enterField(tester, 'Confirm password', _newPassword);
           }
-          await tester.ensureVisible(find.text('Reconnect wallet'));
-          await _tapNativeAction(tester, find.text('Reconnect wallet'));
+          await tester.ensureVisible(find.text('Reconnect wallet').last);
+          await _tapNativeAction(tester, find.text('Reconnect wallet').last);
         }
         final unlockScreen = find.byType(
           _mobile ? MobileUnlockScreen : UnlockScreen,

--- a/test/core/storage/wallet_recovery_native_test.dart
+++ b/test/core/storage/wallet_recovery_native_test.dart
@@ -10,26 +10,43 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
     show ExternalLibrary;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:zcash_wallet/app.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
 import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
 import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_recovery.dart';
-import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_text_field.dart';
+import 'package:zcash_wallet/src/features/activity/gift_card_activity_index.dart';
+import 'package:zcash_wallet/src/features/home/screens/home_screen.dart';
+import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_home_screen.dart';
+import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/passcode_widgets.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_unlock_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/unlock_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/wallet_recovery_screen.dart';
+import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_claim_coordinator_provider.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_home_entry_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_share_tracking_restorer_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust;
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 import '../../figma_compare/figma_compare_font_loader.dart';
+import '../../fakes/fake_sync_notifier.dart';
 
 const _nativeLibrary = String.fromEnvironment('VIZOR_RECOVERY_NATIVE_LIBRARY');
 const _captureDirectory = String.fromEnvironment('VIZOR_RECOVERY_CAPTURE_DIR');
@@ -396,6 +413,303 @@ void main() {
     },
   );
 
+  test('recovery tolerates damaged presentation metadata', () async {
+    final uuid = await createWallet();
+    final original = await getDb().readAsBytes();
+    backend.data.remove(kWalletDbNameKey);
+    backend.data['zcash_accounts'] = jsonEncode([
+      null,
+      {
+        'uuid': uuid,
+        'name': 42,
+        'profilePictureId': ['damaged'],
+      },
+    ]);
+    final session = await recoverySession();
+    expect(await session.unlockExistingSecrets(_password), isTrue);
+    await session.reconnect();
+    final restarted = await loadAppBootstrap();
+    expect(restarted.initialLocation, '/unlock');
+    expect(
+      restarted.initialAccountState.activeAccount!.name,
+      'Recovery fixture',
+    );
+    expect(await getDb().readAsBytes(), original);
+  });
+
+  test(
+    'damaged metadata alone never looks like a fresh installation',
+    () async {
+      backend.data['zcash_accounts'] = '{damaged';
+      final state = await loadAppBootstrap();
+      expect(state.initialLocation, '/wallet-recovery');
+      expect(state.walletRecovery!.candidates, isEmpty);
+      expect(backend.data, {'zcash_accounts': '{damaged'});
+      expect(await support.list().toList(), isEmpty);
+    },
+  );
+
+  test(
+    'damaged account metadata offers recovery even with a valid locator',
+    () async {
+      await createWallet();
+      final original = await getDb().readAsBytes();
+      backend.data['zcash_accounts'] = '{damaged';
+      final session = await recoverySession();
+      expect(await session.unlockExistingSecrets(_password), isTrue);
+      await session.reconnect();
+      expect((await loadAppBootstrap()).initialLocation, '/unlock');
+      expect(await getDb().readAsBytes(), original);
+    },
+  );
+
+  test(
+    'recovery preserves valid presentation fields beside damaged ones',
+    () async {
+      final uuid = await createWallet();
+      backend.data.remove(kWalletDbNameKey);
+      backend.data['zcash_accounts'] = jsonEncode([
+        {
+          'uuid': uuid,
+          'name': 'My recovered wallet',
+          'profilePictureId': 42,
+          'isHardware': true,
+          'walletLinkSourceAccountUuid': 'source-account',
+        },
+      ]);
+      final session = await recoverySession();
+      await session.unlockExistingSecrets(_password);
+      await session.reconnect();
+      final account =
+          (await loadAppBootstrap()).initialAccountState.activeAccount!;
+      expect(account.name, 'My recovered wallet');
+      expect(account.isHardware, isFalse);
+      expect(account.walletLinkSourceAccountUuid, 'source-account');
+    },
+  );
+
+  test('a missing recovery marker prevents every following write', () async {
+    await createWallet();
+    backend.data.remove(kWalletDbNameKey);
+    final session = await recoverySession();
+    await session.unlockExistingSecrets(_password);
+    final before = Map<String, String>.of(backend.data);
+    backend.dropWriteKey = kWalletRecoveryPendingKey;
+    await expectLater(session.reconnect(), throwsStateError);
+    expect(backend.data, before);
+    expect((await loadAppBootstrap()).initialLocation, '/wallet-recovery');
+    await session.reconnect();
+    expect((await loadAppBootstrap()).initialLocation, '/unlock');
+  });
+
+  for (final credentialKey in [
+    'zcash_password_verifier_salt',
+    'zcash_password_verifier',
+  ]) {
+    test('unpersisted $credentialKey cannot finish recovery', () async {
+      final uuid = await createWallet(metadata: false);
+      final original = await getDb().readAsBytes();
+      var session = await recoverySession();
+      await session.verifySoftwareSecret(
+        uuid,
+        const SoftwareWalletSecret(mnemonic: _phrase),
+      );
+      backend.dropWriteKey = credentialKey;
+      await expectLater(
+        session.reconnect(newPassword: _newPassword),
+        throwsStateError,
+      );
+      expect(backend.data[kWalletRecoveryPendingKey], _dbName);
+      expect(backend.data['zcash_account_mnemonic_$uuid'], isNull);
+      session.dispose();
+      session = await recoverySession();
+      await session.verifySoftwareSecret(
+        uuid,
+        const SoftwareWalletSecret(mnemonic: _phrase),
+      );
+      await session.reconnect(newPassword: _newPassword);
+      expect((await loadAppBootstrap()).initialLocation, '/unlock');
+      expect(await store.verifyPassword(_newPassword), isTrue);
+      expect(await store.readAccountMnemonic(uuid), _phrase);
+      expect(await getDb().readAsBytes(), original);
+    });
+  }
+
+  for (final drop in [false, true]) {
+    test(
+      'recovery checks final marker deletion (silent drop: $drop)',
+      () async {
+        await createWallet();
+        backend.data.remove(kWalletDbNameKey);
+        final original = await getDb().readAsBytes();
+        var session = await recoverySession();
+        await session.unlockExistingSecrets(_password);
+        if (drop) {
+          backend.dropDeleteKey = kWalletRecoveryPendingKey;
+        } else {
+          backend.failDeleteKey = kWalletRecoveryPendingKey;
+        }
+        await expectLater(
+          session.reconnect(),
+          drop
+              ? throwsStateError
+              : throwsA(isA<SecureStorageUnavailableException>()),
+        );
+        session.dispose();
+        session = await recoverySession();
+        await session.unlockExistingSecrets(_password);
+        await session.reconnect();
+        expect((await loadAppBootstrap()).initialLocation, '/unlock');
+        expect(await getDb().readAsBytes(), original);
+      },
+    );
+  }
+
+  test(
+    'every persisted recovery write can resume in a fresh session',
+    () async {
+      final first = await createWallet(metadata: false);
+      final second = await rust.importSoftwareAccountAtIndex(
+        dbPath: getDb().path,
+        network: 'main',
+        name: 'Second',
+        mnemonic: _secondPhrase,
+        bip39Passphrase: 'recovery passphrase',
+        birthdayHeight: BigInt.from(2_000_000),
+        zip32AccountIndex: 7,
+        isFirstWalletAccount: false,
+      );
+      final original = await getDb().readAsBytes();
+      // Stop immediately after each durable write, without running rollback.
+      // Only persisted key/value state survives into the new recovery session.
+      for (final stopAfterKey in [
+        kWalletRecoveryPendingKey,
+        'zcash_password_verifier_salt',
+        'zcash_password_verifier',
+        'zcash_secure_store_salt',
+        'zcash_account_mnemonic_$first',
+        'zcash_account_mnemonic_${second.accountUuid}',
+        'zcash_wallet_network',
+        'zcash_accounts',
+        'zcash_active_account',
+        kWalletDbNameKey,
+      ]) {
+        backend.data.clear();
+        store.clearSessionPassword();
+        var session = await recoverySession();
+        Future<void> proveAccounts() async {
+          expect(
+            await session.verifySoftwareSecret(
+              first,
+              const SoftwareWalletSecret(mnemonic: _phrase),
+            ),
+            isTrue,
+          );
+          expect(
+            await session.verifySoftwareSecret(
+              second.accountUuid,
+              const SoftwareWalletSecret(
+                mnemonic: _secondPhrase,
+                bip39Passphrase: 'recovery passphrase',
+              ),
+            ),
+            isTrue,
+          );
+        }
+
+        await proveAccounts();
+        backend.failAfterWriteKey = stopAfterKey;
+        await expectLater(
+          session.reconnect(newPassword: _newPassword),
+          throwsA(isA<SecureStorageUnavailableException>()),
+          reason: stopAfterKey,
+        );
+        session.dispose();
+        expect(await getDb().readAsBytes(), original, reason: stopAfterKey);
+        session = await recoverySession();
+        final configured = await store.isPasswordConfigured();
+        if (configured) {
+          expect(await session.unlockExistingSecrets(_newPassword), isTrue);
+        }
+        await proveAccounts();
+        await session.reconnect(newPassword: configured ? null : _newPassword);
+        final restarted = await loadAppBootstrap();
+        expect(restarted.initialLocation, '/unlock', reason: stopAfterKey);
+        expect(
+          restarted.initialAccountState.accounts.map((a) => a.uuid),
+          unorderedEquals([first, second.accountUuid]),
+        );
+        expect(await store.verifyPassword(_newPassword), isTrue);
+        expect(await store.readAccountMnemonic(first), _phrase);
+        final secret = await store.readAccountSoftwareWalletSecret(
+          second.accountUuid,
+        );
+        expect(secret?.mnemonic, _secondPhrase);
+        expect(secret?.bip39Passphrase, 'recovery passphrase');
+        expect(await getDb().readAsBytes(), original, reason: stopAfterKey);
+        session.dispose();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
+    'a candidate replaced after verification cannot be reconnected',
+    () async {
+      await createWallet();
+      backend.data.remove(kWalletDbNameKey);
+      final session = await recoverySession();
+      await session.unlockExistingSecrets(_password);
+      await createWallet(
+        metadata: false,
+        dbName: 'zcash_wallet_replacement.db',
+        phrase: _secondPhrase,
+      );
+      final replacement = await File(
+        '${support.path}/zcash_wallet_replacement.db',
+      ).readAsBytes();
+      await getDb().writeAsBytes(replacement);
+      final before = Map<String, String>.of(backend.data);
+      await expectLater(session.reconnect(), throwsStateError);
+      expect(backend.data, before);
+      expect(await getDb().readAsBytes(), replacement);
+    },
+  );
+
+  test('mixed software and hardware recovery verifies all accounts', () async {
+    final software = await createWallet(phrase: _secondPhrase);
+    final hardware = await rust.importHardwareAccount(
+      dbPath: getDb().path,
+      network: 'main',
+      name: 'Hardware fixture',
+      ufvkString: _keystoneUfvk,
+      seedFingerprint: List<int>.filled(32, 1),
+      zip32Index: 0,
+      birthdayHeight: BigInt.from(2_000_000),
+    );
+    backend.data.remove(kWalletDbNameKey);
+    final original = await getDb().readAsBytes();
+    final session = await recoverySession();
+    expect(await session.unlockExistingSecrets(_password), isTrue);
+    expect(session.isVerified(software), isTrue);
+    await expectLater(session.reconnect(), throwsStateError);
+    expect(
+      await session.verifyHardwareKey(hardware.accountUuid, _keystoneUfvk),
+      isTrue,
+    );
+    await session.reconnect();
+    final accounts = (await loadAppBootstrap()).initialAccountState.accounts;
+    expect(accounts.singleWhere((a) => a.uuid == software).isHardware, isFalse);
+    expect(
+      accounts.singleWhere((a) => a.uuid == hardware.accountUuid).isHardware,
+      isTrue,
+    );
+    expect(await store.verifyPassword(_password), isTrue);
+    expect(await store.readAccountMnemonic(software), _secondPhrase);
+    expect(await store.readAccountMnemonic(hardware.accountUuid), isNull);
+    expect(await getDb().readAsBytes(), original);
+  });
+
   test(
     'a pending recovery is honored even if the old pointer still exists',
     () async {
@@ -478,7 +792,6 @@ void main() {
           backend.data.remove(kWalletDbNameKey);
         }
         final bootstrap = (await tester.runAsync(loadAppBootstrap))!;
-        AppBootstrapState? restarted;
         final boundary = GlobalKey();
         tester.view.physicalSize = _mobile
             ? const Size(390, 844)
@@ -487,27 +800,20 @@ void main() {
         addTearDown(tester.view.resetPhysicalSize);
         addTearDown(tester.view.resetDevicePixelRatio);
         await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              appBootstrapProvider.overrideWithValue(bootstrap),
-              appBootstrapRetryProvider.overrideWithValue(() async {
-                restarted = await loadAppBootstrap();
-              }),
-            ],
-            child: MaterialApp(
-              home: AppTheme(
-                data: AppThemeData.dark,
-                child: RepaintBoundary(
-                  key: boundary,
-                  child: const WalletRecoveryScreen(),
-                ),
-              ),
+          RepaintBoundary(
+            key: boundary,
+            child: BootstrappedZcashWalletApp(
+              initialBootstrap: bootstrap,
+              overrides: _offlineAppOverrides(),
             ),
           ),
         );
         await tester.pumpAndSettle();
         expect(find.text('Recover your wallet'), findsOneWidget);
         expect(find.text('Create wallet'), findsNothing);
+        final recoveryContainer = ProviderScope.containerOf(
+          tester.element(find.byType(WalletRecoveryScreen)),
+        );
         await _capture(
           tester,
           boundary,
@@ -551,12 +857,66 @@ void main() {
           await tester.ensureVisible(find.text('Reconnect wallet'));
           await _tapNativeAction(tester, find.text('Reconnect wallet'));
         }
-        await _pumpUntil(tester, () => restarted != null);
-        expect(restarted!.initialLocation, '/unlock');
-        expect(restarted!.initialAccountState.activeAccountUuid, uuid);
+        final unlockScreen = find.byType(
+          _mobile ? MobileUnlockScreen : UnlockScreen,
+        );
+        await _pumpUntil(tester, () => unlockScreen.evaluate().isNotEmpty);
+        await tester.pumpAndSettle();
+        final unlockedContainer = ProviderScope.containerOf(
+          tester.element(unlockScreen),
+        );
+        expect(identical(recoveryContainer, unlockedContainer), isFalse);
+        expect(
+          unlockedContainer.read(appBootstrapProvider).initialLocation,
+          '/unlock',
+        );
+        expect(
+          unlockedContainer
+              .read(appBootstrapProvider)
+              .initialAccountState
+              .activeAccountUuid,
+          uuid,
+        );
+        expect(store.hasSessionPassword, isFalse);
         expect(await tester.runAsync(getWalletDbPath), getDb().path);
+        await _capture(
+          tester,
+          boundary,
+          allMetadataMissing ? 'loss-unlock' : 'unlock',
+        );
+        final recoveredPassword = allMetadataMissing ? _newPassword : _password;
+        if (_mobile) {
+          await _enterPasscode(tester, recoveredPassword, allowReset: true);
+        } else {
+          await _enterField(tester, 'Password', recoveredPassword);
+          await _tapNativeAction(tester, find.text('Unlock Vizor'));
+        }
+        final homeScreen = find.byType(_mobile ? MobileHomeScreen : HomeScreen);
+        await _pumpUntil(tester, () => homeScreen.evaluate().isNotEmpty);
+        await tester.pumpAndSettle();
+        final homeContainer = ProviderScope.containerOf(
+          tester.element(homeScreen),
+        );
+        expect(homeContainer.read(appSecurityProvider).requiresUnlock, isFalse);
+        final accounts = homeContainer.read(accountProvider).requireValue;
+        expect(accounts.activeAccountUuid, uuid);
+        expect(accounts.activeAddress, isNotEmpty);
+        await _capture(
+          tester,
+          boundary,
+          allMetadataMissing ? 'loss-home' : 'home',
+        );
+        // Finish the app's unrelated background discovery before destroying
+        // the provider scope, including when screenshots are disabled.
+        await tester.runAsync(
+          () => homeContainer.read(votingShareTrackingRestorerProvider).pause(),
+        );
         expect(tester.takeException(), isNull);
         await tester.pumpWidget(const SizedBox.shrink());
+        store.clearSessionPassword();
+        final restarted = (await tester.runAsync(loadAppBootstrap))!;
+        expect(restarted.initialLocation, '/unlock');
+        expect(restarted.initialAccountState.activeAccountUuid, uuid);
         debugDefaultTargetPlatformOverride = null;
       },
       timeout: const Timeout(Duration(seconds: 45)),
@@ -584,17 +944,82 @@ Future<void> _enterField(
     find.descendant(of: field, matching: find.byType(EditableText)),
     value,
   );
+  await tester.pump();
 }
 
-Future<void> _enterPasscode(WidgetTester tester, String passcode) async {
+Future<void> _enterPasscode(
+  WidgetTester tester,
+  String passcode, {
+  bool allowReset = false,
+}) async {
   final keypad = tester.widget<PasscodeNumpad>(find.byType(PasscodeNumpad));
-  expect(keypad.onHelp, isNull);
+  if (!allowReset) expect(keypad.onHelp, isNull);
   for (final digit in passcode.split('')) {
     final key = find.bySemanticsLabel('Digit $digit');
     await tester.ensureVisible(key);
     await _tapNativeAction(tester, key);
     await tester.pump();
   }
+}
+
+// Keep discovery, key verification, credential storage, bootstrap, account
+// hydration, security and routing real. Disable only unrelated network work.
+List<Override> _offlineAppOverrides() => [
+  syncProvider.overrideWith(_OfflineRecoverySync.new),
+  ironwoodMigrationCoordinatorProvider.overrideWith(
+    _OfflineRecoveryMigration.new,
+  ),
+  networkPrivacyProvider.overrideWith(_OfflineRecoveryPrivacy.new),
+  swapFeatureEnabledProvider.overrideWithValue(false),
+  zecHomeMarketDataProvider.overrideWithValue(null),
+  zecLiveUsdUnitPriceProvider.overrideWithValue(null),
+  votingHomeEntryVisibleProvider.overrideWithValue(false),
+  votingHomeRefreshActionProvider.overrideWithValue(() async {}),
+  votingPendingShareRoundLoaderProvider.overrideWithValue(
+    ({required dbPath, required accountUuids}) async => [],
+  ),
+  paymentLinkClaimRecoveryRunnerProvider.overrideWithValue(() async => []),
+  giftCardActivityIndexProvider.overrideWith(
+    (ref, accountUuid) async => GiftCardActivityIndex.empty,
+  ),
+];
+
+class _OfflineRecoverySync extends FakeSyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState(
+    accountUuid: (await ref.watch(accountProvider.future)).activeAccountUuid,
+    hasAccountScopedData: true,
+    isSyncComplete: true,
+    percentage: 1,
+    scannedHeight: 2000000,
+    chainTipHeight: 2000000,
+  );
+
+  @override
+  Future<void> refreshAfterUnlock() async {}
+
+  @override
+  Future<void> startSyncAnyway() async {}
+}
+
+class _OfflineRecoveryPrivacy extends NetworkPrivacyNotifier {
+  @override
+  NetworkPrivacyState build() => const NetworkPrivacyState.off();
+}
+
+class _OfflineRecoveryMigration extends IronwoodMigrationCoordinator {
+  @override
+  IronwoodMigrationCoordinatorState build() =>
+      const IronwoodMigrationCoordinatorState();
+
+  @override
+  Future<void> refreshNow({bool forceAdvance = false}) async {}
+
+  @override
+  Future<void> refreshForPolling() async {}
+
+  @override
+  Future<void> resumeBackgroundPreparations() async {}
 }
 
 Future<void> _pumpUntil(WidgetTester tester, bool Function() done) async {
@@ -636,6 +1061,9 @@ class _FaultStorage extends MapBase<String, String> {
   bool failReads = false;
   String? failWriteKey;
   String? dropWriteKey;
+  String? failAfterWriteKey;
+  String? failDeleteKey;
+  String? dropDeleteKey;
 
   @override
   Iterable<String> get keys => data.keys;
@@ -657,10 +1085,24 @@ class _FaultStorage extends MapBase<String, String> {
       return;
     }
     data[key] = value;
+    if (key == failAfterWriteKey) {
+      failAfterWriteKey = null;
+      throw PlatformException(code: 'fixture_interrupted_after_write');
+    }
   }
 
   @override
-  String? remove(Object? key) => data.remove(key);
+  String? remove(Object? key) {
+    if (key == failDeleteKey) {
+      failDeleteKey = null;
+      throw PlatformException(code: 'fixture_delete_interrupted');
+    }
+    if (key == dropDeleteKey) {
+      dropDeleteKey = null;
+      return data[key];
+    }
+    return data.remove(key);
+  }
 
   @override
   void clear() => data.clear();

--- a/test/core/storage/wallet_recovery_native_test.dart
+++ b/test/core/storage/wallet_recovery_native_test.dart
@@ -1,0 +1,667 @@
+// Run with scripts/test-wallet-recovery.sh. Uses the real Rust bridge, wallet
+// SQLite schema, seed derivation and secret encryption. Only the OS key store
+// and app-support path are replaced; no user wallet or network is accessed.
+import 'dart:io';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    show ExternalLibrary;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
+import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_recovery.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_text_field.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/passcode_widgets.dart';
+import 'package:zcash_wallet/src/features/onboarding/wallet_recovery_screen.dart';
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust;
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+
+import '../../figma_compare/figma_compare_font_loader.dart';
+
+const _nativeLibrary = String.fromEnvironment('VIZOR_RECOVERY_NATIVE_LIBRARY');
+const _captureDirectory = String.fromEnvironment('VIZOR_RECOVERY_CAPTURE_DIR');
+const _mobile = kAppFormFactor == AppFormFactor.mobile;
+const _password = _mobile ? '123456' : 'Recovery1!';
+const _newPassword = _mobile ? '654321' : 'Recovered2!';
+const _phrase =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const _secondPhrase =
+    'legal winner thank year wave sausage worth useful legal winner thank yellow';
+// Orchard + transparent UFVK derived from the public _phrase fixture at index 0.
+const _keystoneUfvk =
+    'uview1s8x5c6zq8pllw2v8ywmcp0fm46d5dk0er8gwwraz2l2s6g0cvq0jlyar820w9z6sh5l285d2ctzcukr2j2fn6cl7nyapa235fxkcmf7xkg4e3pc0phu7e95mukwx3j8t96p7yzuuxhdl9u28letaxay3gyscd9s4tr59dxg4uulsdxjxmy64ls4sy36n8p03j7f0d9w4ycjullvp5lqgslc4agjlgxzk53wnwkcm4andl5xqgs2afa7ewkkfl9fcyw7s5kknzlmn55m6sz93yvqpx78shy0uausk3avw';
+const _dbName = 'zcash_wallet_recovery_fixture.db';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  if (_nativeLibrary.isEmpty) {
+    test(
+      'native wallet recovery integration',
+      () {},
+      skip:
+          'Run scripts/test-wallet-recovery.sh to build and load the real Rust library.',
+    );
+    return;
+  }
+
+  late Directory support;
+  late _FaultStorage backend;
+  final store = AppSecureStore.instance;
+  File getDb() => File('${support.path}/$_dbName');
+
+  Future<String> createWallet({
+    bool metadata = true,
+    String dbName = _dbName,
+    String phrase = _phrase,
+  }) async {
+    final result = await rust.importWallet(
+      mnemonic: phrase,
+      bip39Passphrase: '',
+      birthdayHeight: BigInt.from(2_000_000),
+      network: 'main',
+      dbPath: '${support.path}/$dbName',
+      accountName: 'Recovery fixture',
+    );
+    if (metadata) {
+      await store.configurePassword(_password);
+      await store.writeAccountMnemonic(result.accountUuid, phrase);
+      await store.writeString(
+        'zcash_accounts',
+        jsonEncode([
+          {'uuid': result.accountUuid, 'name': 'Recovery fixture', 'order': 0},
+        ]),
+      );
+      await store.writeString('zcash_active_account', result.accountUuid);
+      await store.writeString('zcash_wallet_network', 'main');
+      await store.writePlain(kWalletDbNameKey, dbName);
+      store.clearSessionPassword();
+      expect((await loadAppBootstrap()).initialLocation, '/unlock');
+    }
+    return result.accountUuid;
+  }
+
+  Future<WalletRecoverySession> recoverySession() async {
+    final state = await loadAppBootstrap();
+    expect(state.initialLocation, '/wallet-recovery');
+    expect(state.walletRecovery, isNotNull);
+    return WalletRecoverySession(
+      candidate: state.walletRecovery!.candidates.firstWhere(
+        (c) => c.fileName == _dbName,
+      ),
+    );
+  }
+
+  setUpAll(() async {
+    await RustLib.init(externalLibrary: ExternalLibrary.open(_nativeLibrary));
+    await loadFigmaCompareFonts();
+  });
+  tearDownAll(RustLib.dispose);
+  setUp(() async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    support = await Directory.systemTemp.createTemp('vizor-recovery-test-');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async {
+            if (call.method == 'getApplicationSupportDirectory') {
+              return support.path;
+            }
+            return null;
+          },
+        );
+    backend = _FaultStorage();
+    FlutterSecureStorage.setMockInitialValues(backend);
+    SharedPreferences.setMockInitialValues({});
+    store.clearSessionPassword();
+  });
+  tearDown(() async {
+    store.clearSessionPassword();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    FlutterSecureStorage.setMockInitialValues({});
+    debugDefaultTargetPlatformOverride = null;
+    await support.delete(recursive: true);
+  });
+
+  test(
+    'fresh startup does not allocate a DB name or create a database',
+    () async {
+      final state = await loadAppBootstrap();
+      expect(state.initialLocation, '/welcome');
+      expect(await store.readPlain(kWalletDbNameKey), isNull);
+      expect(await support.list().toList(), isEmpty);
+      await expectLater(getWalletDbPath(), throwsStateError);
+    },
+  );
+
+  test(
+    'normal startup and account-list-only loss retain the existing DB',
+    () async {
+      final uuid = await createWallet();
+      backend.data.remove('zcash_accounts');
+      final state = await loadAppBootstrap();
+      expect(state.initialLocation, '/unlock');
+      expect(state.initialAccountState.activeAccountUuid, uuid);
+      expect(await getWalletDbPath(), getDb().path);
+    },
+  );
+
+  test(
+    'missing pointer reconnects with saved secrets and survives restart',
+    () async {
+      final uuid = await createWallet();
+      final original = await getDb().readAsBytes();
+      backend.data.remove(kWalletDbNameKey);
+      final session = await recoverySession();
+      expect(await store.readPlain(kWalletDbNameKey), isNull);
+      expect(await session.unlockExistingSecrets(_password), isTrue);
+      expect(session.isVerified(uuid), isTrue);
+      await session.reconnect();
+      expect(store.hasSessionPassword, isFalse);
+      final restarted = await loadAppBootstrap();
+      expect(restarted.initialLocation, '/unlock');
+      expect(restarted.initialAccountState.activeAccountUuid, uuid);
+      expect(await getWalletDbPath(), getDb().path);
+      expect(await getDb().readAsBytes(), original);
+    },
+  );
+
+  test(
+    'total metadata loss requires the matching recovery phrase before reconnecting',
+    () async {
+      final uuid = await createWallet();
+      final original = await getDb().readAsBytes();
+      backend.data.clear();
+      final session = await recoverySession();
+      expect(session.canReconnect, isFalse);
+      await expectLater(
+        session.reconnect(newPassword: _newPassword),
+        throwsStateError,
+      );
+      expect(backend.data, isEmpty);
+      expect(
+        await session.verifySoftwareSecret(
+          uuid,
+          const SoftwareWalletSecret(mnemonic: _secondPhrase),
+        ),
+        isFalse,
+      );
+      expect(
+        await session.verifySoftwareSecret(
+          uuid,
+          const SoftwareWalletSecret(mnemonic: _phrase),
+        ),
+        isTrue,
+      );
+      await session.reconnect(newPassword: _newPassword);
+      final restarted = await loadAppBootstrap();
+      expect(restarted.initialLocation, '/unlock');
+      expect(restarted.initialAccountState.activeAccountUuid, uuid);
+      expect(await store.verifyPassword(_newPassword), isTrue);
+      expect(await store.readAccountMnemonic(uuid), _phrase);
+      expect(await getDb().readAsBytes(), original);
+    },
+  );
+
+  test(
+    'a stale pointer is replaced only after account-key verification',
+    () async {
+      await createWallet();
+      backend.data[kWalletDbNameKey] = 'zcash_wallet_nonexistent.db';
+      final session = await recoverySession();
+      expect(
+        await store.readPlain(kWalletDbNameKey),
+        'zcash_wallet_nonexistent.db',
+      );
+      expect(await session.unlockExistingSecrets(_password), isTrue);
+      await session.reconnect();
+      expect(await getWalletDbPath(), getDb().path);
+      expect(
+        File('${support.path}/zcash_wallet_nonexistent.db').existsSync(),
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'multiple candidates are preserved and a different wallet cannot be adopted',
+    () async {
+      await createWallet();
+      await createWallet(
+        metadata: false,
+        dbName: 'zcash_wallet_other.db',
+        phrase: _secondPhrase,
+      );
+      final other = File('${support.path}/zcash_wallet_other.db');
+      final originalOther = await other.readAsBytes();
+      backend.data.remove(kWalletDbNameKey);
+      final state = await loadAppBootstrap();
+      expect(state.walletRecovery!.candidates, hasLength(2));
+      expect(await store.readPlain(kWalletDbNameKey), isNull);
+      final wrong = WalletRecoverySession(
+        candidate: state.walletRecovery!.candidates.firstWhere(
+          (c) => c.fileName == 'zcash_wallet_other.db',
+        ),
+      );
+      expect(await wrong.unlockExistingSecrets(_password), isTrue);
+      expect(wrong.canReconnect, isFalse);
+      await expectLater(wrong.reconnect(), throwsStateError);
+      expect(await other.readAsBytes(), originalOther);
+      expect(getDb().existsSync(), isTrue);
+    },
+  );
+
+  test(
+    'a healthy current pointer is not switched to an orphan wallet',
+    () async {
+      final uuid = await createWallet();
+      await createWallet(
+        metadata: false,
+        dbName: 'zcash_wallet_old.db',
+        phrase: _secondPhrase,
+      );
+      final state = await loadAppBootstrap();
+      expect(state.walletRecovery, isNull);
+      expect(state.initialAccountState.activeAccountUuid, uuid);
+      expect(await getWalletDbPath(), getDb().path);
+      expect(File('${support.path}/zcash_wallet_old.db').existsSync(), isTrue);
+    },
+  );
+
+  test('a mismatched network and corrupt DB remain recovery errors', () async {
+    await createWallet();
+    backend.data.remove(kWalletDbNameKey);
+    backend.data['zcash_wallet_network'] = 'test';
+    var state = await loadAppBootstrap();
+    expect(state.initialLocation, '/wallet-recovery');
+    expect(state.walletRecovery!.candidates.single.error, isNotNull);
+    backend.data['zcash_wallet_network'] = 'main';
+    await getDb().writeAsString('corrupt fixture');
+    state = await loadAppBootstrap();
+    expect(state.initialLocation, '/wallet-recovery');
+    expect(state.walletRecovery!.candidates.single.error, isNotNull);
+    expect(await getDb().readAsString(), 'corrupt fixture');
+    expect(await store.readPlain(kWalletDbNameKey), isNull);
+  });
+
+  test(
+    'unavailable storage remains blocked rather than appearing empty',
+    () async {
+      await createWallet();
+      final before = Map<String, String>.of(backend.data);
+      backend.failReads = true;
+      final state = await loadAppBootstrap();
+      expect(state.initialLocation, '/storage-unavailable');
+      expect(
+        state.failureKind,
+        AppBootstrapFailureKind.secureStorageUnavailable,
+      );
+      expect(backend.data, before);
+      expect(getDb().existsSync(), isTrue);
+    },
+  );
+
+  test(
+    'interrupted locator writes return to recovery and can be retried',
+    () async {
+      final uuid = await createWallet();
+      final original = await getDb().readAsBytes();
+      backend.data.remove(kWalletDbNameKey);
+      var session = await recoverySession();
+      await session.unlockExistingSecrets(_password);
+      backend.failWriteKey = 'zcash_active_account';
+      await expectLater(
+        session.reconnect(),
+        throwsA(isA<SecureStorageUnavailableException>()),
+      );
+      expect(backend.data[kWalletRecoveryPendingKey], _dbName);
+      session.dispose();
+      session = await recoverySession();
+      expect(await session.unlockExistingSecrets(_password), isTrue);
+      await session.reconnect();
+      expect(backend.data[kWalletRecoveryPendingKey], isNull);
+      expect(
+        (await loadAppBootstrap()).initialAccountState.activeAccountUuid,
+        uuid,
+      );
+      expect(await getDb().readAsBytes(), original);
+    },
+  );
+
+  test(
+    'a write acknowledged without persistence cannot complete recovery',
+    () async {
+      await createWallet();
+      backend.data.remove(kWalletDbNameKey);
+      final session = await recoverySession();
+      await session.unlockExistingSecrets(_password);
+      backend.dropWriteKey = kWalletDbNameKey;
+      await expectLater(session.reconnect(), throwsStateError);
+      expect((await loadAppBootstrap()).initialLocation, '/wallet-recovery');
+      expect(backend.data[kWalletRecoveryPendingKey], _dbName);
+      await session.reconnect();
+      expect((await loadAppBootstrap()).initialLocation, '/unlock');
+    },
+  );
+
+  test(
+    'partial multi-seed recovery identifies the missing account and preserves the DB',
+    () async {
+      final first = await createWallet();
+      final second = await rust.addAccount(
+        dbPath: getDb().path,
+        network: 'main',
+        name: 'Second',
+        mnemonic: _secondPhrase,
+        bip39Passphrase: '',
+        birthdayHeight: BigInt.from(2_000_000),
+      );
+      backend.data.remove(kWalletDbNameKey);
+      final original = await getDb().readAsBytes();
+      final session = await recoverySession();
+      await session.unlockExistingSecrets(_password);
+      expect(session.isVerified(first), isTrue);
+      expect(session.isVerified(second.accountUuid), isFalse);
+      expect(session.canReconnect, isFalse);
+      await expectLater(session.reconnect(), throwsStateError);
+      expect(await getDb().readAsBytes(), original);
+      expect(
+        await session.verifySoftwareSecret(
+          second.accountUuid,
+          const SoftwareWalletSecret(mnemonic: _secondPhrase),
+        ),
+        isTrue,
+      );
+      await session.reconnect();
+      expect(
+        (await loadAppBootstrap()).initialAccountState.accounts,
+        hasLength(2),
+      );
+    },
+  );
+
+  test(
+    'a pending recovery is honored even if the old pointer still exists',
+    () async {
+      await createWallet();
+      backend.data[kWalletRecoveryPendingKey] = _dbName;
+      expect((await loadAppBootstrap()).initialLocation, '/wallet-recovery');
+    },
+  );
+
+  test(
+    'WAL remnants and symlinks are evidence, not a fresh installation',
+    () async {
+      final wal = File('${getDb().path}-wal');
+      await wal.writeAsString('orphan WAL fixture');
+      var state = await loadAppBootstrap();
+      expect(state.initialLocation, '/wallet-recovery');
+      expect(state.walletRecovery!.candidates.single.canInspect, isFalse);
+      expect(await wal.readAsString(), 'orphan WAL fixture');
+      await wal.delete();
+      await Link(getDb().path).create('${support.path}/missing-target.db');
+      state = await loadAppBootstrap();
+      expect(state.initialLocation, '/wallet-recovery');
+      expect(state.walletRecovery!.candidates.single.canInspect, isFalse);
+    },
+  );
+
+  test(
+    'completed reset does not recreate or resurrect the deleted wallet',
+    () async {
+      await createWallet();
+      for (final entity in await support.list().toList()) {
+        await entity.delete();
+      }
+      backend.data.clear();
+      final state = await loadAppBootstrap();
+      expect(state.initialLocation, '/welcome');
+      expect(backend.data[kWalletDbNameKey], isNull);
+      expect(await support.list().toList(), isEmpty);
+    },
+  );
+
+  test(
+    'hardware-first recovery needs the independent device key and retains hardware identity',
+    () async {
+      final hardware = await rust.importHardwareAccount(
+        dbPath: getDb().path,
+        network: 'main',
+        name: 'Hardware fixture',
+        ufvkString: _keystoneUfvk,
+        seedFingerprint: List<int>.filled(32, 1),
+        zip32Index: 0,
+        birthdayHeight: BigInt.from(2_000_000),
+      );
+      final original = await getDb().readAsBytes();
+      final session = await recoverySession();
+      expect(session.canReconnect, isFalse);
+      expect(session.candidate.accounts.single.isSeedAnchor, isFalse);
+      expect(
+        await session.verifyHardwareKey(hardware.accountUuid, _keystoneUfvk),
+        isTrue,
+      );
+      await session.reconnect(newPassword: _newPassword);
+      final restarted = await loadAppBootstrap();
+      expect(restarted.initialLocation, '/unlock');
+      expect(restarted.initialAccountState.accounts.single.isHardware, isTrue);
+      expect(await getDb().readAsBytes(), original);
+    },
+  );
+
+  for (final allMetadataMissing in [false, true]) {
+    testWidgets(
+      allMetadataMissing
+          ? 'recovery UI restores signing material after total metadata loss'
+          : 'recovery UI verifies saved keys and restarts on the same wallet',
+      (tester) async {
+        final uuid = await tester.runAsync(() => createWallet());
+        if (allMetadataMissing) {
+          backend.data.clear();
+        } else {
+          backend.data.remove(kWalletDbNameKey);
+        }
+        final bootstrap = (await tester.runAsync(loadAppBootstrap))!;
+        AppBootstrapState? restarted;
+        final boundary = GlobalKey();
+        tester.view.physicalSize = _mobile
+            ? const Size(390, 844)
+            : const Size(1080, 720);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              appBootstrapProvider.overrideWithValue(bootstrap),
+              appBootstrapRetryProvider.overrideWithValue(() async {
+                restarted = await loadAppBootstrap();
+              }),
+            ],
+            child: MaterialApp(
+              home: AppTheme(
+                data: AppThemeData.dark,
+                child: RepaintBoundary(
+                  key: boundary,
+                  child: const WalletRecoveryScreen(),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Recover your wallet'), findsOneWidget);
+        expect(find.text('Create wallet'), findsNothing);
+        await _capture(
+          tester,
+          boundary,
+          allMetadataMissing ? 'loss-discovery' : 'discovery',
+        );
+        debugPrint('recovery UI: selecting candidate');
+        await tester.tap(find.text('Recover this wallet'));
+        await tester.pump(const Duration(milliseconds: 100));
+        debugPrint('recovery UI: entering credential');
+        if (allMetadataMissing) {
+          await tester.tap(find.text('Enter recovery phrase'));
+          await tester.pump();
+          await _enterField(tester, 'Recovery phrase', _phrase);
+          await tester.ensureVisible(find.text('Verify recovery phrase'));
+          await _tapNativeAction(tester, find.text('Verify recovery phrase'));
+        } else if (_mobile) {
+          await _enterPasscode(tester, _password);
+        } else {
+          await _enterField(tester, 'Password', _password);
+          await _tapNativeAction(tester, find.text('Continue'));
+        }
+        await _pumpUntil(
+          tester,
+          () => find.text('Recovery material verified').evaluate().isNotEmpty,
+        );
+        expect(find.text('Recovery phrase needed'), findsNothing);
+        debugPrint('recovery UI: account verified');
+        await _capture(
+          tester,
+          boundary,
+          allMetadataMissing ? 'loss-verified' : 'verified',
+        );
+        if (allMetadataMissing && _mobile) {
+          await _enterPasscode(tester, _newPassword);
+          await _enterPasscode(tester, _newPassword);
+        } else {
+          if (allMetadataMissing) {
+            await _enterField(tester, 'New password', _newPassword);
+            await _enterField(tester, 'Confirm password', _newPassword);
+          }
+          await tester.ensureVisible(find.text('Reconnect wallet'));
+          await _tapNativeAction(tester, find.text('Reconnect wallet'));
+        }
+        await _pumpUntil(tester, () => restarted != null);
+        expect(restarted!.initialLocation, '/unlock');
+        expect(restarted!.initialAccountState.activeAccountUuid, uuid);
+        expect(await tester.runAsync(getWalletDbPath), getDb().path);
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox.shrink());
+        debugDefaultTargetPlatformOverride = null;
+      },
+      timeout: const Timeout(Duration(seconds: 45)),
+    );
+  }
+}
+
+// Native actions must create their persistent storage-lock futures in the
+// real async zone, so a subsequent widget test can consume those futures.
+Future<void> _tapNativeAction(WidgetTester tester, Finder finder) async {
+  await tester.runAsync(() => tester.tap(finder));
+  await tester.pump();
+}
+
+Future<void> _enterField(
+  WidgetTester tester,
+  String label,
+  String value,
+) async {
+  final field = find.byWidgetPredicate(
+    (widget) => widget is AppTextField && widget.label == label,
+  );
+  await tester.ensureVisible(field);
+  await tester.enterText(
+    find.descendant(of: field, matching: find.byType(EditableText)),
+    value,
+  );
+}
+
+Future<void> _enterPasscode(WidgetTester tester, String passcode) async {
+  final keypad = tester.widget<PasscodeNumpad>(find.byType(PasscodeNumpad));
+  expect(keypad.onHelp, isNull);
+  for (final digit in passcode.split('')) {
+    final key = find.bySemanticsLabel('Digit $digit');
+    await tester.ensureVisible(key);
+    await _tapNativeAction(tester, key);
+    await tester.pump();
+  }
+}
+
+Future<void> _pumpUntil(WidgetTester tester, bool Function() done) async {
+  for (var i = 0; i < 100 && !done(); i++) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 50)),
+    );
+    await tester.pump();
+  }
+  expect(
+    done(),
+    isTrue,
+    reason:
+        'The native recovery operation did not reach its expected UI state.',
+  );
+}
+
+Future<void> _capture(
+  WidgetTester tester,
+  GlobalKey boundary,
+  String name,
+) async {
+  if (_captureDirectory.isEmpty) return;
+  final render =
+      boundary.currentContext!.findRenderObject()! as RenderRepaintBoundary;
+  await tester.runAsync(() async {
+    final image = await render.toImage(pixelRatio: .75);
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+    await Directory(_captureDirectory).create(recursive: true);
+    await File(
+      '$_captureDirectory/${_mobile ? 'mobile' : 'desktop'}-$name.png',
+    ).writeAsBytes(data!.buffer.asUint8List());
+    image.dispose();
+  });
+}
+
+class _FaultStorage extends MapBase<String, String> {
+  final data = <String, String>{};
+  bool failReads = false;
+  String? failWriteKey;
+  String? dropWriteKey;
+
+  @override
+  Iterable<String> get keys => data.keys;
+
+  @override
+  String? operator [](Object? key) {
+    if (failReads) throw PlatformException(code: 'fixture_storage_unavailable');
+    return data[key];
+  }
+
+  @override
+  void operator []=(String key, String value) {
+    if (key == failWriteKey) {
+      failWriteKey = null;
+      throw PlatformException(code: 'fixture_write_interrupted');
+    }
+    if (key == dropWriteKey) {
+      dropWriteKey = null;
+      return;
+    }
+    data[key] = value;
+  }
+
+  @override
+  String? remove(Object? key) => data.remove(key);
+
+  @override
+  void clear() => data.clear();
+}

--- a/test/core/storage/wallet_setup_native_test.dart
+++ b/test/core/storage/wallet_setup_native_test.dart
@@ -1,0 +1,3 @@
+import '../../support/wallet_setup_native_scenarios.dart';
+
+void main() => runWalletSetupNativeTests(mobile: false);

--- a/test/features/onboarding/mobile_customise_account_screen_test.dart
+++ b/test/features/onboarding/mobile_customise_account_screen_test.dart
@@ -689,7 +689,7 @@ class _RecordingSecurityNotifier extends AppSecurityNotifier {
   }
 
   @override
-  void commitPasswordSetup() {
+  Future<void> commitPasswordSetup() async {
     committed = true;
   }
 

--- a/test/features/onboarding/mobile_passcode_screen_test.dart
+++ b/test/features/onboarding/mobile_passcode_screen_test.dart
@@ -279,7 +279,7 @@ class _RecordingAppSecurityNotifier extends AppSecurityNotifier {
   Future<void> preparePasswordSetup(String password) async {}
 
   @override
-  void commitPasswordSetup() {
+  Future<void> commitPasswordSetup() async {
     state = const AppSecurityState(
       isPasswordConfigured: true,
       isUnlocked: true,

--- a/test/features/onboarding/mobile_wallet_setup_native_test.dart
+++ b/test/features/onboarding/mobile_wallet_setup_native_test.dart
@@ -1,0 +1,7 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import '../../support/wallet_setup_native_scenarios.dart';
+
+void main() => runWalletSetupNativeTests(mobile: true);

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -18,6 +18,7 @@ import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/config/zcash_explorer.dart';
 import 'package:zcash_wallet/src/core/formatting/address_display.dart';
 import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
@@ -45,7 +46,9 @@ void main() {
 
   setUp(() async {
     rustApi.reset();
-    FlutterSecureStorage.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({
+      kWalletDbNameKey: 'zcash_wallet_send_status_test.db',
+    });
     final tempDir = await Directory.systemTemp.createTemp('send_status_test');
     addTearDown(() async {
       try {

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -18,6 +18,7 @@ import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_lin
 import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_claim_lifecycle_registry_provider.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
@@ -25,6 +26,7 @@ import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_share_tracking_registry_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_submission_guard_provider.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
 
 final _rustApi = _AccountMutationRustApiFake();
 
@@ -191,6 +193,23 @@ void main() {
         },
       );
     }
+  });
+
+  test('first wallet account discovery does not allocate a database', () async {
+    FlutterSecureStorage.setMockInitialValues({});
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(accountProvider.future);
+    await container
+        .read(accountProvider.notifier)
+        .discoverAdditionalSoftwareAccounts(mnemonic: 'discovery fixture');
+    expect(_rustApi.lastDiscoveryPath, '');
+    expect(_rustApi.firstWalletDiscovery, isTrue);
+    expect(await AppSecureStore.instance.readPlain(kWalletDbNameKey), isNull);
   });
 
   test('wallet db cleanup paths include main db and voting sidecar files', () {
@@ -625,7 +644,9 @@ void main() {
   );
 
   test('successful account removal requests share restoration', () async {
-    FlutterSecureStorage.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({
+      kWalletDbNameKey: 'zcash_wallet_test.db',
+    });
     final supportDirectory = Directory.systemTemp.createTempSync(
       'vizor-account-removal',
     );
@@ -1221,6 +1242,28 @@ class _SwitchTestSecurityNotifier extends AppSecurityNotifier {
 }
 
 class _AccountMutationRustApiFake implements RustLibApi {
+  String? lastDiscoveryPath;
+  bool? firstWalletDiscovery;
+
+  @override
+  Future<rust_wallet.SoftwareWalletImportDiscoveryResult>
+  crateApiWalletDiscoverSoftwareWalletImportAccounts({
+    required String mnemonic,
+    required String bip39Passphrase,
+    BigInt? birthdayHeight,
+    required String network,
+    required String dbPath,
+    required String lightwalletdUrl,
+    required bool isFirstWalletAccount,
+  }) async {
+    lastDiscoveryPath = dbPath;
+    firstWalletDiscovery = isFirstWalletAccount;
+    return const rust_wallet.SoftwareWalletImportDiscoveryResult(
+      primaryAccountAlreadyExists: false,
+      accounts: [],
+    );
+  }
+
   final deletedAccountUuids = <String>[];
   final requestedAccounts = <String>[];
   var lookupStarted = Completer<void>();
@@ -1273,7 +1316,9 @@ class _AccountMutationRustApiFake implements RustLibApi {
 Future<void> _expectAccountDeletionDrainsLiveShareTracking({
   bool redeemedCard = false,
 }) async {
-  FlutterSecureStorage.setMockInitialValues({});
+  FlutterSecureStorage.setMockInitialValues({
+    kWalletDbNameKey: 'zcash_wallet_test.db',
+  });
   final supportDirectory = Directory.systemTemp.createTempSync(
     'vizor-account-share-drain',
   );

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -100,7 +100,9 @@ void main() {
     const pathProvider = MethodChannel('plugins.flutter.io/path_provider');
 
     setUp(() async {
-      FlutterSecureStorage.setMockInitialValues({});
+      FlutterSecureStorage.setMockInitialValues({
+        kWalletDbNameKey: 'zcash_wallet_test.db',
+      });
       supportDirectory = await Directory.systemTemp.createTemp(
         'vizor-switch-lock-',
       );
@@ -696,7 +698,9 @@ void main() {
   });
 
   test('note cleanup still runs when Home cache persistence fails', () async {
-    FlutterSecureStorage.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({
+      kWalletDbNameKey: 'zcash_wallet_test.db',
+    });
     final supportDirectory = Directory.systemTemp.createTempSync(
       'vizor-account-removal',
     );

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -18,7 +18,6 @@ import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_lin
 import 'package:zcash_wallet/src/features/payment_links/providers/payment_link_claim_lifecycle_registry_provider.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_received_store.dart';
 import 'package:zcash_wallet/src/features/payment_links/services/payment_link_recovery_store.dart';
-import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';

--- a/test/services/voting/voting_file_cache_test.dart
+++ b/test/services/voting/voting_file_cache_test.dart
@@ -26,7 +26,7 @@ void main() {
     () async {
       FlutterSecureStorage.setMockInitialValues({});
       final storage = AppSecureStore.instance;
-      final oldName = await storage.ensureWalletDbName();
+      final oldName = await storage.createWalletDbName();
       final oldCache = Directory('${root.path}/$oldName.voting-cache');
       final sibling = Directory(
         '${root.path}/zcash_wallet_${'a' * 24}.db.voting-cache',
@@ -51,7 +51,7 @@ void main() {
       expect(await oldCache.exists(), true);
       // Matches resetWallet: secrets are wiped even if cache cleanup failed.
       await storage.deleteAll();
-      expect(await storage.ensureWalletDbName(), isNot(oldName));
+      expect(await storage.readPlain(kWalletDbNameKey), isNull);
       await clearVotingCachesForReset(
         resolveSupportDirectory: () async => root,
       );

--- a/test/support/wallet_setup_native_scenarios.dart
+++ b/test/support/wallet_setup_native_scenarios.dart
@@ -545,7 +545,7 @@ void runWalletSetupNativeTests({required bool mobile}) {
           router.routeInformationProvider.value.uri.path,
           '/wallet-recovery',
         );
-        expect(find.text('Recover your wallet'), findsOneWidget);
+        expect(find.text('Wallet found'), findsOneWidget);
         expect(tester.takeException(), isNull);
         expect(
           await tester.runAsync(() => store.verifyPasswordOnly(password)),

--- a/test/support/wallet_setup_native_scenarios.dart
+++ b/test/support/wallet_setup_native_scenarios.dart
@@ -1,0 +1,465 @@
+// Real Rust, SQLite and encryption; only OS storage, sync and support paths
+// are isolated. Run through scripts/test-wallet-setup.sh.
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    show ExternalLibrary;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_recovery.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/create/customise_account_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_customise_account_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
+import 'package:zcash_wallet/src/features/onboarding/wallet_recovery_screen.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust;
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+
+import '../figma_compare/figma_compare_font_loader.dart';
+
+const _library = String.fromEnvironment('VIZOR_RECOVERY_NATIVE_LIBRARY');
+const _phrase =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const _ufvk =
+    'uview1s8x5c6zq8pllw2v8ywmcp0fm46d5dk0er8gwwraz2l2s6g0cvq0jlyar820w9z6sh5l285d2ctzcukr2j2fn6cl7nyapa235fxkcmf7xkg4e3pc0phu7e95mukwx3j8t96p7yzuuxhdl9u28letaxay3gyscd9s4tr59dxg4uulsdxjxmy64ls4sy36n8p03j7f0d9w4ycjullvp5lqgslc4agjlgxzk53wnwkcm4andl5xqgs2afa7ewkkfl9fcyw7s5kknzlmn55m6sz93yvqpx78shy0uausk3avw';
+const _verifier = 'zcash_password_verifier';
+const _verifierSalt = 'zcash_password_verifier_salt';
+
+void runWalletSetupNativeTests({required bool mobile}) {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  if (_library.isEmpty) {
+    test(
+      'native wallet setup failures',
+      () {},
+      skip: 'Run scripts/test-wallet-setup.sh.',
+    );
+    return;
+  }
+  final password = mobile ? '123456' : 'Setup123!';
+  final store = AppSecureStore.instance;
+  late Directory support;
+  late _FaultStorage storage;
+
+  setUpAll(() async {
+    await RustLib.init(externalLibrary: ExternalLibrary.open(_library));
+    await loadFigmaCompareFonts();
+  });
+  tearDownAll(RustLib.dispose);
+  setUp(() async {
+    support = await Directory.systemTemp.createTemp('vizor-setup-test-');
+    storage = _FaultStorage();
+    FlutterSecureStorage.setMockInitialValues(storage);
+    SharedPreferences.setMockInitialValues({});
+    store.clearSessionPassword();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => call.method == 'getApplicationSupportDirectory'
+              ? support.path
+              : null,
+        );
+  });
+  tearDown(() async {
+    FlutterSecureStorage.setMockInitialValues({});
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    await support.delete(recursive: true);
+  });
+
+  Future<ProviderContainer> container() async {
+    final result = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        syncProvider.overrideWith(_NoSync.new),
+      ],
+    );
+    addTearDown(result.dispose);
+    await result.read(accountProvider.future);
+    return result;
+  }
+
+  Future<void> importAccount(ProviderContainer ref, bool hardware) {
+    final account = ref.read(accountProvider.notifier);
+    return hardware
+        ? account.importKeystoneAccount(
+            name: 'Setup fixture',
+            ufvk: _ufvk,
+            seedFingerprint: List.filled(32, 0),
+            zip32Index: 0,
+            birthdayHeight: 2000000,
+          )
+        : account.importAccount(
+            mnemonic: _phrase,
+            birthdayHeight: 2000000,
+            name: 'Setup fixture',
+          );
+  }
+
+  for (final failure in [
+    'zcash_accounts',
+    'zcash_active_account',
+    'zcash_account_mnemonic_',
+    'software-active',
+    'software-drop-secret',
+  ]) {
+    test(
+      'partial $failure failure preserves credentials and recovers the same DB',
+      () async {
+        final ref = await container();
+        final security = ref.read(appSecurityProvider.notifier);
+        final hardware =
+            failure == 'zcash_accounts' || failure == 'zcash_active_account';
+        await security.preparePasswordSetup(password);
+        final verifier = storage[_verifier];
+        final salt = storage[_verifierSalt];
+        expect(storage[kWalletRecoveryPendingKey], isNotNull);
+        if (failure == 'software-drop-secret') {
+          storage.dropWritePrefix = 'zcash_account_mnemonic_';
+        } else {
+          storage.failWritePrefix = failure == 'software-active'
+              ? 'zcash_active_account'
+              : failure;
+        }
+        await expectLater(
+          importAccount(ref, hardware),
+          throwsA(isA<SecureStorageUnavailableException>()),
+        );
+        final path = await getWalletDbPath();
+        final bytes = await File(path).readAsBytes();
+        final accounts = await rust.inspectWalletForRecovery(
+          dbPath: path,
+          network: 'main',
+        );
+        expect(accounts, hasLength(1));
+        await security.rollbackPasswordSetup();
+        expect(security.requiresWalletSetupRecovery, isTrue);
+        expect(storage[_verifier], verifier);
+        expect(storage[_verifierSalt], salt);
+        expect(await File(path).readAsBytes(), bytes);
+        await expectLater(
+          security.preparePasswordSetup(password),
+          throwsStateError,
+        );
+        // Even a stale account-provider snapshot cannot replace this wallet.
+        await expectLater(importAccount(ref, hardware), throwsStateError);
+        expect(await getWalletDbPath(), path);
+        expect(await File(path).readAsBytes(), bytes);
+        final restart = await loadAppBootstrap();
+        expect(restart.initialLocation, '/wallet-recovery');
+        final recovery = WalletRecoverySession(
+          candidate: restart.walletRecovery!.candidates.single,
+        );
+        expect(await recovery.unlockExistingSecrets(password), isTrue);
+        final uuid = accounts.single.uuid;
+        if (hardware) {
+          expect(await recovery.verifyHardwareKey(uuid, _ufvk), isTrue);
+        } else {
+          expect(recovery.isVerified(uuid), failure == 'software-active');
+          expect(
+            await recovery.verifySoftwareSecret(
+              uuid,
+              const SoftwareWalletSecret(mnemonic: _phrase),
+            ),
+            isTrue,
+          );
+        }
+        await recovery.reconnect();
+        expect((await loadAppBootstrap()).initialLocation, '/unlock');
+        expect(await store.verifyPassword(password), isTrue);
+        if (!hardware) expect(await store.readAccountMnemonic(uuid), _phrase);
+        expect(await getWalletDbPath(), path);
+        expect(await File(path).readAsBytes(), bytes);
+      },
+    );
+  }
+
+  test(
+    'failed preflight restarts safely before a native account exists',
+    () async {
+      final ref = await container();
+      final security = ref.read(appSecurityProvider.notifier);
+      await security.preparePasswordSetup(password);
+      await expectLater(
+        ref
+            .read(accountProvider.notifier)
+            .importAccount(mnemonic: 'invalid phrase', birthdayHeight: 2000000),
+        throwsA(anything),
+      );
+      expect(await readWalletDbName(), isNotNull);
+      await security.rollbackPasswordSetup();
+      expect(security.requiresWalletSetupRecovery, isFalse);
+      expect(await store.isPasswordConfigured(), isFalse);
+      expect(storage[kWalletRecoveryPendingKey], kWalletSetupPendingValue);
+      expect(await readWalletDbName(), isNull);
+      expect((await loadAppBootstrap()).initialLocation, '/welcome');
+      await security.preparePasswordSetup(password);
+      await importAccount(ref, false);
+      await security.commitPasswordSetup();
+      expect(await readWalletDbName(), isNotNull);
+      expect(storage[kWalletRecoveryPendingKey], isNull);
+      expect(await store.verifyPasswordOnly(password), isTrue);
+    },
+  );
+
+  test(
+    'pre-account setup interruption can resume with a password entry',
+    () async {
+      final original = await container();
+      await original
+          .read(appSecurityProvider.notifier)
+          .preparePasswordSetup(password);
+      store.clearSessionPassword();
+      final restart = await loadAppBootstrap();
+      expect(restart.initialLocation, '/welcome');
+      final resumed = ProviderContainer(
+        overrides: [appBootstrapProvider.overrideWithValue(restart)],
+      );
+      addTearDown(resumed.dispose);
+      await resumed.read(accountProvider.future);
+      final security = resumed.read(appSecurityProvider.notifier);
+      await security.preparePasswordSetup(password);
+      await importAccount(resumed, true);
+      await security.commitPasswordSetup();
+      expect(storage[kWalletRecoveryPendingKey], isNull);
+      expect(await store.verifyPasswordOnly(password), isTrue);
+    },
+  );
+
+  test(
+    'empty initialized setup DB stays reusable after invalid hardware input',
+    () async {
+      final ref = await container();
+      final security = ref.read(appSecurityProvider.notifier);
+      await security.preparePasswordSetup(password);
+      await expectLater(
+        ref
+            .read(accountProvider.notifier)
+            .importKeystoneAccount(
+              name: 'Invalid fixture',
+              ufvk: 'invalid ufvk',
+              seedFingerprint: List.filled(32, 0),
+              zip32Index: 0,
+              birthdayHeight: 2000000,
+            ),
+        throwsA(anything),
+      );
+      final path = await getWalletDbPath();
+      expect(await File(path).exists(), isTrue);
+      await security.rollbackPasswordSetup();
+      expect((await loadAppBootstrap()).initialLocation, '/welcome');
+      expect(await File(path).exists(), isTrue);
+      await security.preparePasswordSetup(password);
+      await importAccount(ref, true);
+      await security.commitPasswordSetup();
+      expect(await getWalletDbPath(), path);
+    },
+  );
+
+  test('empty setup DB without its stored locator requires recovery', () async {
+    final ref = await container();
+    final security = ref.read(appSecurityProvider.notifier);
+    await security.preparePasswordSetup(password);
+    await expectLater(
+      ref
+          .read(accountProvider.notifier)
+          .importKeystoneAccount(
+            name: 'Invalid fixture',
+            ufvk: 'invalid ufvk',
+            seedFingerprint: List.filled(32, 0),
+            zip32Index: 0,
+            birthdayHeight: 2000000,
+          ),
+      throwsA(anything),
+    );
+    final path = await getWalletDbPath();
+    final originalBytes = await File(path).readAsBytes();
+    storage.data.remove(kWalletDbNameKey);
+    store.clearSessionPassword();
+    expect((await loadAppBootstrap()).initialLocation, '/wallet-recovery');
+    expect(await File(path).readAsBytes(), originalBytes);
+    expect(storage[kWalletDbNameKey], isNull);
+    expect(await store.verifyPasswordOnly(password), isTrue);
+  });
+
+  test(
+    'unreadable DB and keyring errors cannot remove prepared credentials',
+    () async {
+      final ref = await container();
+      final security = ref.read(appSecurityProvider.notifier);
+      await security.preparePasswordSetup(password);
+      await importAccount(ref, true);
+      final verifier = storage[_verifier];
+      // Missing pointer plus an existing wallet is not an empty installation.
+      storage.data.remove(kWalletDbNameKey);
+      storage.failReads = true;
+      await security.rollbackPasswordSetup();
+      storage.failReads = false;
+      expect(security.requiresWalletSetupRecovery, isTrue);
+      expect(storage[_verifier], verifier);
+      expect(storage[kWalletRecoveryPendingKey], isNotNull);
+      expect((await loadAppBootstrap()).initialLocation, '/wallet-recovery');
+    },
+  );
+
+  for (final hardware in [true, false]) {
+    testWidgets(
+      '${hardware ? 'Keystone' : 'software'} setup failure opens the recovery screen',
+      (tester) async {
+        await tester.binding.setSurfaceSize(
+          mobile ? const Size(393, 852) : const Size(1280, 900),
+        );
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        storage.failWritePrefix = hardware
+            ? 'zcash_active_account'
+            : 'zcash_account_mnemonic_';
+        AppBootstrapState? restarted;
+        late GoRouter router;
+        final args = CustomiseAccountArgs(
+          pendingPassword: password,
+          setupArgs: hardware
+              ? SetPasswordScreenArgs.importKeystone(
+                  name: 'Keystone fixture',
+                  ufvk: _ufvk,
+                  seedFingerprint: List.filled(32, 0),
+                  zip32Index: 0,
+                  birthdayHeight: 2000000,
+                )
+              : const SetPasswordScreenArgs.importWallet(
+                  mnemonic: _phrase,
+                  birthdayHeight: 2000000,
+                ),
+        );
+        final ref = ProviderContainer(
+          overrides: [
+            appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+            syncProvider.overrideWith(_NoSync.new),
+            appBootstrapRetryProvider.overrideWithValue(() async {
+              restarted = await loadAppBootstrap();
+              router.go(restarted!.initialLocation);
+            }),
+          ],
+        );
+        addTearDown(ref.dispose);
+        await ref.read(accountProvider.future);
+        router = GoRouter(
+          initialLocation: '/setup',
+          routes: [
+            GoRoute(
+              path: '/setup',
+              builder: (_, _) => mobile
+                  ? MobileCustomiseAccountScreen(args: args)
+                  : CustomiseAccountScreen(args: args),
+            ),
+            GoRoute(
+              path: '/wallet-recovery',
+              builder: (_, _) => ProviderScope(
+                overrides: [appBootstrapProvider.overrideWithValue(restarted!)],
+                child: const WalletRecoveryScreen(),
+              ),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: ref,
+            child: MaterialApp.router(
+              routerConfig: router,
+              builder: (_, child) => AppTheme(
+                data: AppThemeData.dark,
+                child: Material(child: child!),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        tester.testTextInput.hide();
+        final button = find.byKey(
+          ValueKey(
+            mobile
+                ? 'mobile_customise_account_continue'
+                : 'customise_account_finish_button',
+          ),
+        );
+        await tester.ensureVisible(button);
+        // Keep global native/storage futures in the real async zone.
+        await tester.runAsync(() => tester.tap(button));
+        for (var i = 0; i < 200 && restarted == null; i++) {
+          await tester.runAsync(
+            () => Future<void>.delayed(const Duration(milliseconds: 50)),
+          );
+          await tester.pump();
+        }
+        await tester.pumpAndSettle();
+        expect(restarted?.initialLocation, '/wallet-recovery');
+        expect(
+          router.routeInformationProvider.value.uri.path,
+          '/wallet-recovery',
+        );
+        expect(find.text('Recover your wallet'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+        expect(
+          await tester.runAsync(() => store.verifyPasswordOnly(password)),
+          isTrue,
+        );
+        await tester.pumpWidget(const SizedBox.shrink());
+      },
+      timeout: const Timeout(Duration(seconds: 40)),
+    );
+  }
+}
+
+class _NoSync extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState();
+  @override
+  bool needsPauseForWalletMutation() => false;
+}
+
+class _FaultStorage extends MapBase<String, String> {
+  final data = <String, String>{};
+  String? failWritePrefix;
+  String? dropWritePrefix;
+  bool failReads = false;
+  @override
+  Iterable<String> get keys => data.keys;
+  @override
+  String? operator [](Object? key) {
+    if (failReads) throw PlatformException(code: 'fixture_storage_unavailable');
+    return data[key];
+  }
+
+  @override
+  void operator []=(String key, String value) {
+    if (failWritePrefix != null && key.startsWith(failWritePrefix!)) {
+      failWritePrefix = null;
+      throw PlatformException(code: 'fixture_storage_write_failure');
+    }
+    if (dropWritePrefix != null && key.startsWith(dropWritePrefix!)) {
+      dropWritePrefix = null;
+      return;
+    }
+    data[key] = value;
+  }
+
+  @override
+  String? remove(Object? key) => data.remove(key);
+  @override
+  void clear() => data.clear();
+}

--- a/test/support/wallet_setup_native_scenarios.dart
+++ b/test/support/wallet_setup_native_scenarios.dart
@@ -1,5 +1,6 @@
 // Real Rust, SQLite and encryption; only OS storage, sync and support paths
 // are isolated. Run through scripts/test-wallet-setup.sh.
+import 'dart:async';
 import 'dart:collection';
 import 'dart:io';
 
@@ -24,6 +25,7 @@ import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args
 import 'package:zcash_wallet/src/features/onboarding/wallet_recovery_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust;
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
@@ -228,7 +230,10 @@ void runWalletSetupNativeTests({required bool mobile}) {
       final restart = await loadAppBootstrap();
       expect(restart.initialLocation, '/welcome');
       final resumed = ProviderContainer(
-        overrides: [appBootstrapProvider.overrideWithValue(restart)],
+        overrides: [
+          appBootstrapProvider.overrideWithValue(restart),
+          syncProvider.overrideWith(_NoSync.new),
+        ],
       );
       addTearDown(resumed.dispose);
       await resumed.read(accountProvider.future);
@@ -240,6 +245,134 @@ void runWalletSetupNativeTests({required bool mobile}) {
       expect(await store.verifyPasswordOnly(password), isTrue);
     },
   );
+
+  test(
+    'allocated DB locator without a file resumes setup in a fresh session',
+    () async {
+      final birthday = Completer<BigInt>();
+      final birthdayRequested = Completer<void>();
+      final ref = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+          syncProvider.overrideWith(_NoSync.new),
+          rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue((
+            _,
+            _,
+          ) {
+            birthdayRequested.complete();
+            return birthday.future;
+          }),
+        ],
+      );
+      addTearDown(ref.dispose);
+      await ref.read(accountProvider.future);
+      final security = ref.read(appSecurityProvider.notifier);
+      await security.preparePasswordSetup(password);
+      final interrupted = ref
+          .read(accountProvider.notifier)
+          .createAccountFromMnemonic(mnemonic: _phrase);
+      await birthdayRequested.future.timeout(const Duration(seconds: 5));
+      expect(await readWalletDbName(), isNotNull);
+      final path = await getWalletDbPath();
+      expect(await File(path).exists(), isFalse);
+      ref.dispose();
+      store.clearSessionPassword();
+      final interruptedExpectation = expectLater(
+        interrupted,
+        throwsA(anything),
+      );
+      birthday.completeError(StateError('setup interrupted'));
+      await interruptedExpectation;
+
+      final restart = await loadAppBootstrap();
+      expect(restart.initialLocation, '/welcome');
+      final resumed = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(restart),
+          syncProvider.overrideWith(_NoSync.new),
+          rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
+            (_, _) async => BigInt.from(2000000),
+          ),
+        ],
+      );
+      addTearDown(resumed.dispose);
+      await resumed.read(accountProvider.future);
+      final resumedSecurity = resumed.read(appSecurityProvider.notifier);
+      await resumedSecurity.preparePasswordSetup(password);
+      await resumed
+          .read(accountProvider.notifier)
+          .createAccountFromMnemonic(
+            mnemonic: _phrase,
+            name: 'Resumed fixture',
+          );
+      await resumedSecurity.commitPasswordSetup();
+      expect(await getWalletDbPath(), path);
+      expect(await File(path).exists(), isTrue);
+      expect(storage[kWalletRecoveryPendingKey], isNull);
+      expect(await store.verifyPasswordOnly(password), isTrue);
+      expect(resumed.read(accountProvider).value!.accounts, hasLength(1));
+    },
+  );
+
+  test(
+    'password configuration interruption preserves the marker and resumes',
+    () async {
+      final ref = await container();
+      final security = ref.read(appSecurityProvider.notifier);
+      storage.failWriteKey = _verifier;
+      await expectLater(
+        security.preparePasswordSetup(password),
+        throwsA(isA<SecureStorageUnavailableException>()),
+      );
+      expect(storage[kWalletRecoveryPendingKey], kWalletSetupPendingValue);
+      expect(storage[_verifierSalt], isNotNull);
+      expect(storage[_verifier], isNull);
+      store.clearSessionPassword();
+
+      final restart = await loadAppBootstrap();
+      expect(restart.initialLocation, '/welcome');
+      final resumed = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(restart),
+          syncProvider.overrideWith(_NoSync.new),
+        ],
+      );
+      addTearDown(resumed.dispose);
+      await resumed.read(accountProvider.future);
+      final resumedSecurity = resumed.read(appSecurityProvider.notifier);
+      await resumedSecurity.preparePasswordSetup(password);
+      await importAccount(resumed, true);
+      await resumedSecurity.commitPasswordSetup();
+      expect(storage[kWalletRecoveryPendingKey], isNull);
+      expect(await store.verifyPasswordOnly(password), isTrue);
+    },
+  );
+
+  test('a silently dropped setup marker blocks password preparation', () async {
+    final ref = await container();
+    final security = ref.read(appSecurityProvider.notifier);
+    storage.dropWritePrefix = kWalletRecoveryPendingKey;
+    await expectLater(
+      security.preparePasswordSetup(password),
+      throwsStateError,
+    );
+    expect(storage[kWalletRecoveryPendingKey], isNull);
+    expect(storage[_verifier], isNull);
+    expect(storage[_verifierSalt], isNull);
+  });
+
+  test('a rejected setup marker blocks password preparation', () async {
+    final ref = await container();
+    final security = ref.read(appSecurityProvider.notifier);
+    storage.failWriteKey = kWalletRecoveryPendingKey;
+    await expectLater(
+      security.preparePasswordSetup(password),
+      throwsA(isA<SecureStorageUnavailableException>()),
+    );
+    expect(storage[kWalletRecoveryPendingKey], isNull);
+    expect(storage[_verifier], isNull);
+    expect(storage[_verifierSalt], isNull);
+  });
 
   test(
     'empty initialized setup DB stays reusable after invalid hardware input',
@@ -435,6 +568,7 @@ class _NoSync extends SyncNotifier {
 class _FaultStorage extends MapBase<String, String> {
   final data = <String, String>{};
   String? failWritePrefix;
+  String? failWriteKey;
   String? dropWritePrefix;
   bool failReads = false;
   @override
@@ -447,6 +581,10 @@ class _FaultStorage extends MapBase<String, String> {
 
   @override
   void operator []=(String key, String value) {
+    if (failWriteKey == key) {
+      failWriteKey = null;
+      throw PlatformException(code: 'fixture_storage_write_failure');
+    }
     if (failWritePrefix != null && key.startsWith(failWritePrefix!)) {
       failWritePrefix = null;
       throw PlatformException(code: 'fixture_storage_write_failure');


### PR DESCRIPTION
When secure-storage account metadata is lost, Vizor now finds the existing wallet database and offers recovery instead of treating the installation as empty. Reconnection verifies the required software or hardware keys for every account before restoring the wallet connection and saved signing material.

Startup discovery is read-only. Unreadable databases, WAL remnants, invalid paths, and damaged metadata remain in recovery; they do not permit creating a replacement wallet. Recovery also checks persisted writes so an interrupted or silently dropped save can be retried.

First-time setup can resume when it stopped after allocating a database name but before creating an account. A verified onboarding marker is saved before password credentials, allowing a restart after a partial credential write to return to setup safely.

Validation:
- 195 Flutter tests passed: 103 related tests, plus 16 setup and 30 native recovery tests in each desktop/mobile lane. One mobile-tagged test was excluded from the desktop lane.
- Native recovery tests use real Rust, SQLite, and encryption; OS storage is a fault-injected fixture. The focused Rust recovery tests also passed (15).
- Static analysis, formatting, and diff checks passed. Widget tests cover recovery, unlock, home, and resumed onboarding.
- Linux x86_64, Windows 11 ARM64, and Apple Silicon macOS Release apps were built from PR head `0df1f7755`; each build verified all 2,113 tracked source files after packaging.
- Linux passed with the real GNOME Secret Service backend from the pinned `flutter_secure_storage_linux 3.0.0`. Windows passed with the real CurrentUser DPAPI file backend. macOS passed with the real Data Protection Keychain using testnet-specific services and isolated app support data.
- On every OS, removing account metadata recovered the same wallet with the existing password. Removing the app's complete secure-storage record recovered the same wallet with its recovery phrase and a new password, followed by a cold restart, unlock, and home.
- Actual process termination passed at two first-setup boundaries on every OS: immediately after the onboarding marker, and after credentials plus an allocated database name but before a database file existed. Both restarts returned to onboarding. Resumed setup reused the allocated database name, replaced the incomplete credentials, cleared the marker, and passed another cold restart and unlock.
- Linux and Windows ran with outbound networking isolated. macOS performed public testnet read-only sync, so database content advanced; the stopped deletion boundaries preserved the database bytes, and recovery retained the database filename and account UUID.

The real-OS runs used one synthetic software account per platform. Chain sync completion, transaction broadcast, Keystone, and multiple-account recovery were not exercised in those runs; hardware and multiple-account recovery remain covered by the automated native tests.

The macOS harness used the available `com.keplr.vizor` provisioning profile because the machine had no profile for a unique test bundle identifier. Its Release Flutter/Rust code came from the exact PR head, its secure-storage services were testnet-only, and its Application Support path was isolated. The harness was unsandboxed to apply that isolated home directory. Product mainnet Keychain items and Application Support data were not accessed or changed.

This PR remains a draft for review.

Related: #631. Linux keyring error handling is tracked separately in #642.
