### PR TITLE
Fix clipped mobile Card review fees and align row first lines

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -582,6 +582,23 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     mobile: true,
   ),
   FigmaCompareScenario(
+    id: 'mobile-payment-link-review-wrapped-fee',
+    description: 'Mobile Gift Card review with a wrapping fee label',
+    builder: buildMobilePaymentLinkReviewWrappedFeeUseCase,
+    scrollToEnd: true,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-payment-link-review-large-text',
+    description:
+        'Mobile Gift Card review with enlarged text, scrolled to action',
+    builder: buildMobilePaymentLinkReviewLargeTextUseCase,
+    scrollToEnd: true,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
     id: 'mobile-payment-link-ready-celebrating',
     description: 'Mobile Gift Card deposited celebration state',
     builder: buildMobilePaymentLinkReadyCelebratingUseCase,

--- a/lib/src/core/widgets/app_button.dart
+++ b/lib/src/core/widgets/app_button.dart
@@ -209,6 +209,7 @@ class AppButton extends StatefulWidget {
     this.variant = AppButtonVariant.primary,
     this.size = AppButtonSize.large,
     this.height,
+    this.growWithContent = false,
     this.contentPadding,
     this.leading,
     this.trailing,
@@ -241,6 +242,10 @@ class AppButton extends StatefulWidget {
   /// Optional visual height override for one-off composed components that
   /// use the button palette but have a different fixed height in Figma.
   final double? height;
+
+  /// Treat the configured height as a minimum, allowing wrapped content to
+  /// make the button taller. Pair with [constrainContent] for wrapping labels.
+  final bool growWithContent;
 
   /// Optional override for the button's internal padding. Default (`null`)
   /// keeps the design-system sizing for all regular buttons; narrow composed
@@ -409,13 +414,14 @@ class _AppButtonState extends State<AppButton> {
     // no-op pass-through, so callers that leave `minWidth` null keep the
     // pre-existing fully-intrinsic behavior.
     final pill = ConstrainedBox(
-      constraints: widget.minWidth != null
-          ? BoxConstraints(minWidth: widget.minWidth!)
-          : const BoxConstraints(),
+      constraints: BoxConstraints(
+        minWidth: widget.minWidth ?? 0,
+        minHeight: widget.growWithContent ? height : 0,
+      ),
       child: AnimatedContainer(
         duration: isGhost ? Duration.zero : const Duration(milliseconds: 120),
         curve: Curves.easeOut,
-        height: height,
+        height: widget.growWithContent ? null : height,
         decoration: ShapeDecoration(
           color: currentBg,
           shape: StadiumBorder(

--- a/lib/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart
+++ b/lib/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart
@@ -41,8 +41,6 @@ const _selectorTop = _cardTop + _cardHeight + AppSpacing.md;
 const _selectorHeight = 80.0;
 const _bottomInset = 12.0;
 const _buttonHeight = 50.0;
-const _reviewSummaryTop = 456.625;
-const _reviewSummaryHeight = 193.0;
 const _readyStatusTop = 474.0;
 // Tallest measured status block: two lines of body text plus the wait pill.
 const _readyStatusAllowance = 160.0;
@@ -804,96 +802,109 @@ class PaymentLinkReviewMobileView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _MobilePaymentLinkFrame(
-      title: title,
-      onBack: onBack,
-      // The summary hangs off a fixed offset while the CTA hangs off the
-      // bottom, so below this height the two overlap.
-      minStageHeight:
-          _reviewSummaryTop +
-          _reviewSummaryHeight +
-          AppSpacing.md +
-          _buttonHeight +
-          _bottomInset,
-      body: Stack(
-        fit: StackFit.expand,
-        children: [
-          Positioned(
-            top: _subtitleTop,
-            left: _sideInset,
-            right: _sideInset,
-            child: Text(
-              subtitle,
-              key: const ValueKey('payment_link_mobile_review_subtitle'),
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: context.colors.text.secondary,
+    return CustomScrollView(
+      key: const ValueKey('payment_link_mobile_review_scroll'),
+      slivers: [
+        SliverToBoxAdapter(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              MobileTopNav.back(title: title, onBack: onBack),
+              const SizedBox(height: AppSpacing.sm),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: _sideInset),
+                child: Text(
+                  subtitle,
+                  key: const ValueKey('payment_link_mobile_review_subtitle'),
+                  textAlign: TextAlign.center,
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: context.colors.text.secondary,
+                  ),
+                ),
               ),
+              const SizedBox(height: AppSpacing.xl + AppSpacing.sm),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: _sideInset),
+                child: _MobileCardSlot(card: card),
+              ),
+              const SizedBox(height: AppSpacing.base + AppSpacing.xs),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: _sideInset),
+                child: Container(
+                  key: const ValueKey('payment_link_mobile_review_summary'),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.sm,
+                    vertical: AppSpacing.base,
+                  ),
+                  decoration: BoxDecoration(
+                    color: context.colors.background.ground,
+                    borderRadius: BorderRadius.circular(AppRadii.large),
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _MobileReviewRow(
+                        label: 'Card amount',
+                        value: cardAmountText,
+                      ),
+                      _MobileReviewRow(
+                        label: kPaymentLinkCardFeeLabel,
+                        value: cardFeeText,
+                        onHelp: onFeeHelp,
+                      ),
+                      const SizedBox(height: AppSpacing.sm),
+                      SizedBox(
+                        key: const ValueKey(
+                          'payment_link_mobile_review_divider',
+                        ),
+                        width: double.infinity,
+                        height: 1,
+                        child: ColoredBox(color: context.colors.border.regular),
+                      ),
+                      const SizedBox(height: AppSpacing.sm),
+                      _MobileReviewRow(
+                        label: kPaymentLinkTotalDeductedLabel,
+                        value: totalAmountText,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        // Only the footer fills spare viewport space. The preceding sliver
+        // contributes its actual content height to the scroll extent.
+        SliverFillRemaining(
+          hasScrollBody: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(
+              _sideInset,
+              AppSpacing.md,
+              _sideInset,
+              _bottomInset,
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                AppButton(
+                  key: const ValueKey(
+                    'payment_link_mobile_review_continue_button',
+                  ),
+                  onPressed: onContinue,
+                  size: AppButtonSize.large,
+                  height: _buttonHeight,
+                  growWithContent: true,
+                  constrainContent: true,
+                  expand: true,
+                  child: Text(continueLabel, textAlign: TextAlign.center),
+                ),
+              ],
             ),
           ),
-          Positioned(
-            top: _cardTop,
-            left: _sideInset,
-            right: _sideInset,
-            child: _MobileCardSlot(card: card),
-          ),
-          Positioned(
-            top: _reviewSummaryTop,
-            left: _sideInset,
-            right: _sideInset,
-            child: Container(
-              key: const ValueKey('payment_link_mobile_review_summary'),
-              width: double.infinity,
-              height: _reviewSummaryHeight,
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSpacing.sm,
-                vertical: AppSpacing.base,
-              ),
-              decoration: BoxDecoration(
-                color: context.colors.background.ground,
-                borderRadius: BorderRadius.circular(AppRadii.large),
-              ),
-              child: Column(
-                children: [
-                  _MobileReviewRow(label: 'Card amount', value: cardAmountText),
-                  _MobileReviewRow(
-                    label: kPaymentLinkCardFeeLabel,
-                    value: cardFeeText,
-                    onHelp: onFeeHelp,
-                  ),
-                  const SizedBox(height: AppSpacing.sm),
-                  SizedBox(
-                    key: const ValueKey('payment_link_mobile_review_divider'),
-                    width: double.infinity,
-                    height: 1,
-                    child: ColoredBox(color: context.colors.border.regular),
-                  ),
-                  const SizedBox(height: AppSpacing.sm),
-                  _MobileReviewRow(
-                    label: kPaymentLinkTotalDeductedLabel,
-                    value: totalAmountText,
-                  ),
-                ],
-              ),
-            ),
-          ),
-          Positioned(
-            left: _sideInset,
-            right: _sideInset,
-            bottom: _bottomInset,
-            child: AppButton(
-              key: const ValueKey('payment_link_mobile_review_continue_button'),
-              onPressed: onContinue,
-              size: AppButtonSize.large,
-              height: _buttonHeight,
-              expand: true,
-              child: Text(continueLabel),
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }
@@ -1740,9 +1751,9 @@ class _MobileReviewRow extends StatelessWidget {
       ),
     );
 
-    return SizedBox(
-      height: 32,
-      child: Row(
+    return LayoutBuilder(
+      builder: (context, constraints) => Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Expanded(
             child: Padding(
@@ -1755,33 +1766,39 @@ class _MobileReviewRow extends StatelessWidget {
               ),
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.xs,
-              AppSpacing.xxs,
-              AppSpacing.xxs,
-              AppSpacing.xxs,
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  value,
-                  key: ValueKey('payment_link_mobile_review_value_$label'),
-                  textAlign: TextAlign.right,
-                  style: AppTypography.labelLarge.copyWith(
-                    color: context.colors.text.primary,
+          ConstrainedBox(
+            // Reserve space for the label even for long amounts or large text.
+            constraints: BoxConstraints(maxWidth: constraints.maxWidth / 2),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.xs,
+                AppSpacing.xxs,
+                AppSpacing.xxs,
+                AppSpacing.xxs,
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Text(
+                      value,
+                      key: ValueKey('payment_link_mobile_review_value_$label'),
+                      textAlign: TextAlign.right,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: context.colors.text.primary,
+                      ),
+                    ),
                   ),
-                ),
-                if (onHelp != null) ...[
-                  const SizedBox(width: AppSpacing.xxs),
-                  Listener(
-                    key: const ValueKey('payment_link_mobile_fee_help'),
-                    onPointerUp: (_) => onHelp!(),
-                    child: help,
-                  ),
+                  if (onHelp != null) ...[
+                    const SizedBox(width: AppSpacing.xxs),
+                    Listener(
+                      key: const ValueKey('payment_link_mobile_fee_help'),
+                      onPointerUp: (_) => onHelp!(),
+                      child: help,
+                    ),
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
         ],

--- a/lib/widgetbook/payment_link_mobile_use_cases.dart
+++ b/lib/widgetbook/payment_link_mobile_use_cases.dart
@@ -176,6 +176,34 @@ Widget buildMobilePaymentLinkReviewUseCase(BuildContext context) {
   );
 }
 
+/// Reproduces the fee label wrapping with the fee help icon visible.
+Widget buildMobilePaymentLinkReviewWrappedFeeUseCase(BuildContext context) {
+  return const _MobilePaymentLinkFrame(
+    child: PaymentLinkReviewMobileView(
+      card: PaymentLinkGiftCard(
+        artwork: PaymentLinkCardArtwork.gift,
+        cardWidth: _cardWidth,
+        cardHeight: _cardHeight,
+        amountText: '0.001',
+        showCaret: false,
+      ),
+      onBack: _noop,
+      cardAmountText: '0.001 ZEC',
+      cardFeeText: '0.0002 ZEC',
+      totalAmountText: '0.0012 ZEC',
+      onContinue: _noop,
+      onFeeHelp: _noop,
+    ),
+  );
+}
+
+Widget buildMobilePaymentLinkReviewLargeTextUseCase(BuildContext context) {
+  return MediaQuery(
+    data: MediaQuery.of(context).copyWith(textScaler: TextScaler.linear(2)),
+    child: buildMobilePaymentLinkReviewWrappedFeeUseCase(context),
+  );
+}
+
 Widget buildMobilePaymentLinkReadyCelebratingUseCase(BuildContext context) {
   return const _MobilePaymentLinkFrame(
     child: PaymentLinkReadyMobileView(

--- a/test/core/widgets/review_components_test.dart
+++ b/test/core/widgets/review_components_test.dart
@@ -248,6 +248,38 @@ void main() {
       );
     });
   });
+
+  testWidgets(
+    'content-sized button grows for wrapped labels and shrinks back',
+    (tester) async {
+      const key = ValueKey('growing-button');
+      for (final label in [
+        'Confirm',
+        'Confirm\nand create\nthe gift card',
+        'Confirm',
+      ]) {
+        await _pump(
+          tester,
+          AppButton(
+            key: key,
+            onPressed: () {},
+            height: 50,
+            growWithContent: true,
+            constrainContent: true,
+            expand: true,
+            child: Text(label, textAlign: TextAlign.center),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final labelRect = tester.getRect(find.text(label));
+        final buttonRect = tester.getRect(find.byKey(key));
+        expect(buttonRect.height, label.contains('\n') ? greaterThan(50) : 50);
+        expect(buttonRect.contains(labelRect.topLeft), isTrue);
+        expect(buttonRect.contains(labelRect.bottomRight), isTrue);
+        expect(tester.takeException(), isNull);
+      }
+    },
+  );
 }
 
 Future<void> _pump(WidgetTester tester, Widget child) async {

--- a/test/features/payment_links/payment_link_mobile_views_test.dart
+++ b/test/features/payment_links/payment_link_mobile_views_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:flutter/material.dart' show MaterialApp;
 import 'package:flutter/widgets.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/payment_links/widgets/mobile/payment_link_mobile_views.dart';
@@ -69,17 +70,14 @@ void main() {
     );
   });
 
-  testWidgets('review summary matches the mobile Figma surface geometry', (
-    tester,
-  ) async {
+  testWidgets('review summary preserves its surface styling', (tester) async {
     await _pumpReview(tester);
 
     final summary = find.byKey(
       const ValueKey('payment_link_mobile_review_summary'),
     );
-    expect(tester.getSize(summary), const Size(361, 193));
+    expect(tester.getSize(summary).width, 361);
     expect(tester.getTopLeft(summary).dx, 16);
-    expect(tester.getTopLeft(summary).dy, closeTo(456.625, 0.01));
 
     final container = tester.widget<Container>(summary);
     expect(
@@ -92,6 +90,83 @@ void main() {
     final decoration = container.decoration! as BoxDecoration;
     expect(decoration.color, AppThemeData.light.colors.background.ground);
     expect(decoration.borderRadius, BorderRadius.circular(AppRadii.large));
+  });
+
+  for (final size in [const Size(393, 773), const Size(320, 568)]) {
+    for (final scale in [1.0, 2.0]) {
+      testWidgets('review contains wrapped content at $size, scale $scale', (
+        tester,
+      ) async {
+        var continued = 0;
+        await _pumpReview(
+          tester,
+          size: size,
+          textScale: scale,
+          onFeeHelp: _noop,
+          onContinue: () => continued++,
+          cardAmountText: '0.001 ZEC',
+          cardFeeText: '0.0002 ZEC',
+          totalAmountText: '0.0012 ZEC',
+        );
+        _expectSummaryTextFits(tester);
+        final normalHeight = tester.getSize(_summary).height;
+
+        // More digits must grow content, without hiding either column.
+        await _pumpReview(
+          tester,
+          size: size,
+          textScale: scale,
+          onFeeHelp: _noop,
+          onContinue: () => continued++,
+          cardAmountText: '12345678.12345678 ZEC',
+          cardFeeText: '0.00020001 ZEC',
+          totalAmountText: '12345678.12365679 ZEC',
+        );
+        _expectSummaryTextFits(tester);
+        expect(tester.getSize(_summary).height, greaterThan(normalHeight));
+
+        final button = find.byKey(
+          const ValueKey('payment_link_mobile_review_continue_button'),
+        );
+        await tester.scrollUntilVisible(button, 150);
+        await tester.pumpAndSettle();
+        expect(
+          tester.getRect(button).top - tester.getRect(_summary).bottom,
+          greaterThanOrEqualTo(AppSpacing.md),
+        );
+        await tester.ensureVisible(button);
+        await tester.pumpAndSettle();
+        final buttonLabel = tester.renderObject<RenderParagraph>(
+          find.descendant(of: button, matching: find.byType(RichText)),
+        );
+        _expectParagraphFits(buttonLabel);
+        expect(
+          tester.getSize(button).height,
+          greaterThanOrEqualTo(buttonLabel.size.height),
+        );
+        await tester.tap(button);
+        await tester.pump();
+        expect(continued, 1);
+        expect(tester.takeException(), isNull);
+      });
+    }
+  }
+
+  testWidgets('review keeps its action at the bottom when content fits', (
+    tester,
+  ) async {
+    await _pumpReview(tester, onFeeHelp: _noop);
+    final button = find.byKey(
+      const ValueKey('payment_link_mobile_review_continue_button'),
+    );
+    expect(tester.getRect(button).bottom, 773 - 12);
+    final scrollable = tester.state<ScrollableState>(
+      find.descendant(
+        of: find.byKey(const ValueKey('payment_link_mobile_review_scroll')),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    expect(scrollable.position.maxScrollExtent, 0);
   });
 
   testWidgets('amount selector strip uses the lowered mobile anchor', (
@@ -226,32 +301,104 @@ void main() {
   });
 }
 
-Future<void> _pumpReview(WidgetTester tester, {VoidCallback? onFeeHelp}) async {
-  await tester.binding.setSurfaceSize(const Size(393, 773));
+Future<void> _pumpReview(
+  WidgetTester tester, {
+  VoidCallback? onFeeHelp,
+  VoidCallback? onContinue,
+  Size size = const Size(393, 773),
+  double textScale = 1,
+  String cardAmountText = '4.45 ZEC',
+  String cardFeeText = '0.04 ZEC',
+  String totalAmountText = '4.49 ZEC',
+}) async {
+  await tester.binding.setSurfaceSize(size);
   addTearDown(() => tester.binding.setSurfaceSize(null));
 
   await tester.pumpWidget(
     MaterialApp(
-      builder: (_, navigator) =>
-          AppTheme(data: AppThemeData.light, child: navigator!),
+      builder: (context, navigator) => AppTheme(
+        data: AppThemeData.light,
+        child: MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(textScaler: TextScaler.linear(textScale)),
+          child: navigator!,
+        ),
+      ),
       home: Directionality(
         textDirection: TextDirection.ltr,
         child: SizedBox(
-          width: 393,
-          height: 773,
+          width: size.width,
+          height: size.height,
           child: PaymentLinkReviewMobileView(
             card: const SizedBox(width: 361, height: 225.625),
             onBack: _noop,
-            cardAmountText: '4.45 ZEC',
-            cardFeeText: '0.04 ZEC',
-            totalAmountText: '4.49 ZEC',
-            onContinue: _noop,
+            cardAmountText: cardAmountText,
+            cardFeeText: cardFeeText,
+            totalAmountText: totalAmountText,
+            onContinue: onContinue ?? _noop,
             onFeeHelp: onFeeHelp,
           ),
         ),
       ),
     ),
   );
+}
+
+final _summary = find.byKey(
+  const ValueKey('payment_link_mobile_review_summary'),
+);
+
+void _expectSummaryTextFits(WidgetTester tester) {
+  final summaryRect = tester.getRect(_summary);
+  final divider = tester.getRect(
+    find.byKey(const ValueKey('payment_link_mobile_review_divider')),
+  );
+  final texts = find.descendant(of: _summary, matching: find.byType(RichText));
+  expect(texts, findsNWidgets(6));
+  for (final label in [
+    'Card amount',
+    'Card fee (deposit + redeem)',
+    'Total amount deducted',
+  ]) {
+    final labelRect = tester.getRect(find.text(label));
+    final valueRect = tester.getRect(
+      find.byKey(ValueKey('payment_link_mobile_review_value_$label')),
+    );
+    expect(
+      valueRect.top,
+      closeTo(labelRect.top, 0.01),
+      reason: '$label and its value must start on the same line',
+    );
+    expect(valueRect.left, greaterThanOrEqualTo(labelRect.right));
+  }
+  for (final element in texts.evaluate()) {
+    final paragraph = element.renderObject! as RenderParagraph;
+    _expectParagraphFits(paragraph);
+    final rect = paragraph.localToGlobal(Offset.zero) & paragraph.size;
+    expect(summaryRect.contains(rect.topLeft), isTrue);
+    expect(summaryRect.contains(rect.bottomRight), isTrue);
+    final total = paragraph.text.toPlainText().contains(
+      'Total amount deducted',
+    );
+    if (total) {
+      expect(rect.top, greaterThan(divider.bottom));
+    } else if (paragraph.text.toPlainText().contains('Card fee')) {
+      expect(rect.bottom, lessThan(divider.top));
+    }
+  }
+  expect(tester.takeException(), isNull);
+}
+
+void _expectParagraphFits(RenderParagraph paragraph) {
+  final painter = TextPainter(
+    text: paragraph.text,
+    textDirection: paragraph.textDirection,
+    textScaler: paragraph.textScaler,
+  )..layout(maxWidth: paragraph.size.width);
+  // Presence and absence of RenderFlex errors do not catch clipped glyphs.
+  expect(paragraph.size.height, greaterThanOrEqualTo(painter.height - 0.01));
+  painter.dispose();
 }
 
 void _noop() {}


### PR DESCRIPTION
Mobile Card review clipped the second line of “Card fee (deposit + redeem)” when the amount and help icon reduced the label width. Review rows and the summary now size to their contents, with each amount aligned to the label’s first line.

The review uses a scrolling content layout that keeps the action at the bottom when space permits and below the summary when content grows. An opt-in button sizing mode lets the action grow with wrapped text. Other button callers retain their existing sizing.

### Validation
- 74 focused mobile tests and 20 shared component tests passed.
- `fvm flutter analyze --no-pub`: no issues.
- Full mobile lane: 1,349 passed, 20 failed. All 20 failures were reproduced on the original base (`b133711d5`); no new failures.
- Regression checks fail on the original clipped layout (24px available versus 34px required) and on the previous centered alignment (8.5px offset), and pass after the fix.
- Compared widget screenshots before/after at 393×773, plus a 320×568 dark screen and 2× text. Verified single-line labels, wrapped labels, first-line alignment, and scrolling to the action. Native device testing was not performed.
