### PR TITLE
Receive cross-chain payment links across native platforms

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
                     android:scheme="https"
                     android:host="${vizorDeeplinkHost}" />
             </intent-filter>
-            <!-- ZIP-321 payment links: zcash:<address>?amount=... open Vizor.
+            <!-- Payment request schemes open the review card in Vizor.
                  Handled in MainActivity (com.zcash.wallet/payment_uri channel),
                  not Flutter's built-in deep linking. -->
             <intent-filter>
@@ -61,6 +61,10 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="zcash"/>
+                <data android:scheme="bitcoin"/>
+                <data android:scheme="litecoin"/>
+                <data android:scheme="ethereum"/>
+                <data android:scheme="solana"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
@@ -313,19 +313,22 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     /**
-     * Whether [data] is a link this app takes in: a ZIP-321 `zcash:` payment
+     * Whether [data] is a link this app takes in: a supported payment request
      * link, or a verified HTTPS link on the deeplink host with no userinfo and
      * no explicit port. One predicate for both kinds, so the two intent-filters
      * in the manifest and this capture never disagree about what is accepted.
      */
     private fun acceptsIncomingUri(data: Uri): Boolean {
         val scheme = data.scheme ?: return false
-        if ("zcash".equals(scheme, ignoreCase = true)) return true
+        if (isPaymentRequestScheme(scheme)) return true
         return "https".equals(scheme, ignoreCase = true) &&
             DEEPLINK_HOST.equals(data.host, ignoreCase = true) &&
             data.userInfo == null &&
             data.port == -1
     }
+
+    private fun isPaymentRequestScheme(scheme: String): Boolean =
+        PAYMENT_REQUEST_SCHEMES.any { it.equals(scheme, ignoreCase = true) }
 
     private fun captureIncomingUri(intent: Intent?, isLaunchIntent: Boolean = false) {
         if (intent == null || intent.action != Intent.ACTION_VIEW) return
@@ -371,7 +374,9 @@ class MainActivity : FlutterFragmentActivity() {
     /**
      * Whether this link may be written to disk. A ZIP-321 `zcash:` request
      * carries no bearer secret; an https deeplink can carry a Gift Card claim
-     * mnemonic in its fragment and never leaves memory.
+     * mnemonic in its fragment and never leaves memory. Other schemes remain
+     * memory-only until Dart classifies them: a Solana transaction request,
+     * for example, can contain a server URL with bearer material.
      */
     private fun isSecretFreeIncomingUri(uri: String): Boolean {
         val scheme = runCatching { Uri.parse(uri).scheme }.getOrNull() ?: return false
@@ -393,6 +398,8 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     companion object {
+        private val PAYMENT_REQUEST_SCHEMES =
+            setOf("zcash", "bitcoin", "litecoin", "ethereum", "solana")
         private const val CAMERA_PERMISSION_CHANNEL = "com.zcash.wallet/camera_permission"
         private const val HAPTICS_CHANNEL = "com.zcash.wallet/haptics"
         private const val PRIVACY_SHIELD_CHANNEL = "com.zcash.wallet/privacy_shield"

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -805,14 +805,17 @@ import UIKit
   }
 }
 
-/// Buffers trusted Vizor HTTPS links until the Dart isolate has installed its
-/// handler. Never logs the URL because a route may contain bearer material.
+/// Buffers payment requests and trusted Vizor HTTPS links until the Dart isolate
+/// has installed its handler. Never logs URLs that may contain bearer material.
 final class IncomingUriChannelBridge {
   static let shared = IncomingUriChannelBridge()
   static let deeplinkHost =
     (Bundle.main.object(forInfoDictionaryKey: "VizorDeeplinkHost") as? String)?
     .lowercased() ?? "link.vizor.cash"
   private static let paymentLinkPath = "/payment-links/open"
+  private static let paymentRequestSchemes: Set<String> = [
+    "zcash", "bitcoin", "litecoin", "ethereum", "solana"
+  ]
   /// Sanity ceiling, set far above every link this app actually accepts.
   ///
   /// Dart owns the real size limits -- `VizorPaymentLink.maxEncodedLength` and
@@ -862,10 +865,10 @@ final class IncomingUriChannelBridge {
   }
 
   func handles(_ url: URL) -> Bool {
-    // A ZIP-321 payment link is an opaque `zcash:` URL: no host to check, and
-    // the Dart side owns its parsing. Everything else must be one of the
-    // verified HTTPS routes on the deeplink host.
-    if url.scheme?.lowercased() == "zcash" {
+    // Payment request schemes have no host to check; Dart owns their parsing.
+    // Everything else must be a verified HTTPS route on the deeplink host.
+    if let scheme = url.scheme?.lowercased(),
+      Self.paymentRequestSchemes.contains(scheme) {
       return true
     }
     guard

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,6 +51,10 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>zcash</string>
+				<string>bitcoin</string>
+				<string>litecoin</string>
+				<string>ethereum</string>
+				<string>solana</string>
 			</array>
 		</dict>
 	</array>

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -58,8 +58,18 @@ static void register_icon_theme_paths() {
   }
 }
 
-static gboolean is_zcash_uri(const gchar* value) {
-  return value != nullptr && g_ascii_strncasecmp(value, "zcash:", 6) == 0;
+static gboolean is_payment_uri(const gchar* value) {
+  if (value == nullptr) {
+    return FALSE;
+  }
+  static const gchar* prefixes[] = {
+      "zcash:", "bitcoin:", "litecoin:", "ethereum:", "solana:"};
+  for (const gchar* prefix : prefixes) {
+    if (g_ascii_strncasecmp(value, prefix, strlen(prefix)) == 0) {
+      return TRUE;
+    }
+  }
+  return FALSE;
 }
 
 // Bound on links buffered before Dart installs its handler, matching the
@@ -71,7 +81,7 @@ static const guint kMaxPendingPaymentUris = 16;
 // that is already waiting, which would make the "keep only the latest link"
 // notice churn on a duplicate of the link it is showing.
 static void add_pending_payment_uri(MyApplication* self, const gchar* value) {
-  if (!is_zcash_uri(value)) {
+  if (!is_payment_uri(value)) {
     return;
   }
   for (guint i = 0; i < self->pending_payment_uris->len; ++i) {
@@ -220,7 +230,7 @@ static void my_application_activate(GApplication* application) {
 }
 
 // Implements GApplication::open. Reached only on the primary instance, when a
-// later process forwards zcash: links over D-Bus.
+// later process forwards payment requests over D-Bus.
 static void my_application_open(GApplication* application, GFile** files,
                                 gint n_files, const gchar* /*hint*/) {
   MyApplication* self = MY_APPLICATION(application);
@@ -265,7 +275,7 @@ static gboolean my_application_local_command_line(GApplication* application,
     g_autoptr(GPtrArray) files = g_ptr_array_new_with_free_func(g_object_unref);
     for (gchar** argument = self->dart_entrypoint_arguments;
          argument != nullptr && *argument != nullptr; ++argument) {
-      if (is_zcash_uri(*argument)) {
+      if (is_payment_uri(*argument)) {
         g_ptr_array_add(files, g_file_new_for_uri(*argument));
       }
     }

--- a/linux/runner/tests/test_single_instance.py
+++ b/linux/runner/tests/test_single_instance.py
@@ -129,17 +129,20 @@ class Runner:
 
 
 def runner_tests():
-    primary = Runner('primary', args=('zcash:test-fixture', 'argument with spaces'),
+    bitcoin_request = 'bitcoin:bc1qfixture?amount=0.01&label=Coffee%20shop'
+    evm_request = 'ethereum:0xToken@8453/transfer?address=0xPayee&uint256=25000000'
+    primary = Runner('primary', args=('zcash:test-fixture', bitcoin_request,
+                                      'argument with spaces'),
                      extra={'VIZOR_TEST_FRAME_DELAY_MS': '1800'})
     wait_for(lambda: events('plugins', primary.process.pid), 'plugin registration')
-    secondary = Runner('during-startup', args=('zcash:queued-fixture',))
+    secondary = Runner('during-startup', args=(evm_request,))
     secondary.wait()
     assert len(events('engine')) == 1
     assert not events('first-frame')
     assert primary.state()['visible'] is False
     primary.ready()
     assert events('engine', primary.process.pid)[0][2:] == [
-        'zcash:test-fixture', 'argument with spaces']
+        'zcash:test-fixture', bitcoin_request, 'argument with spaces']
     passed('startup reactivation creates one engine and waits for first frame')
     passed('cold-start Dart arguments remain intact')
 
@@ -147,17 +150,24 @@ def runner_tests():
     wait_for(lambda: events('payment-ready', primary.process.pid),
              'Dart payment URI readiness')
     assert [row[2] for row in events('payment-uri', primary.process.pid)] == [
-        'zcash:test-fixture', 'zcash:queued-fixture']
+        'zcash:test-fixture', bitcoin_request, evm_request]
     passed('cold and forwarded links survive the wait for Dart readiness')
 
-    secondary = Runner('warm-payment-link', args=('zcash:warm-fixture',))
-    secondary.wait()
-    wait_for(lambda: any(row[2] == 'zcash:warm-fixture'
-                         for row in events('payment-uri', primary.process.pid)),
-             'warm link forwarding')
+    warm_requests = (
+        'zcash:warm-fixture',
+        'litecoin:ltc1qfixture?amount=1.5',
+        'solana:Payee?amount=25&spl-token=Mint&reference=Order',
+        'BITCOIN:bc1quppercase?amount=2',
+    )
+    for index, uri in enumerate(warm_requests):
+        secondary = Runner(f'warm-payment-link-{index}', args=(uri,))
+        secondary.wait()
+        wait_for(lambda: any(row[2] == uri
+                             for row in events('payment-uri', primary.process.pid)),
+                 'warm link forwarding')
     assert len(events('engine')) == 1
-    assert len(events('payment-uri', primary.process.pid)) == 3
-    passed('warm payment link reaches the primary without another engine')
+    assert len(events('payment-uri', primary.process.pid)) == 7
+    passed('all payment schemes reach the primary without another engine')
 
     # A different executable path models another extracted AppImage directory.
     shutil.copy2(OUTPUT / 'runner', OUTPUT / 'runner-copy')

--- a/linux/vizor.desktop.in
+++ b/linux/vizor.desktop.in
@@ -6,5 +6,5 @@ Exec=@BINARY_NAME@ %u
 Icon=@APPLICATION_ID@
 Terminal=false
 Categories=Office;Finance;
-MimeType=x-scheme-handler/zcash;
+MimeType=x-scheme-handler/zcash;x-scheme-handler/bitcoin;x-scheme-handler/litecoin;x-scheme-handler/ethereum;x-scheme-handler/solana;
 StartupWMClass=@APPLICATION_ID@

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -20,6 +20,10 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>zcash</string>
+				<string>bitcoin</string>
+				<string>litecoin</string>
+				<string>ethereum</string>
+				<string>solana</string>
 			</array>
 		</dict>
 	</array>

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -949,6 +949,9 @@ final class DeviceOwnerAuthChannel {
 }
 
 final class PaymentUriChannel {
+  private static let paymentRequestSchemes: Set<String> = [
+    "zcash", "bitcoin", "litecoin", "ethereum", "solana"
+  ]
   private static var channel: FlutterMethodChannel?
   private static var pendingURLs: [String] = []
   private static var dartReady = false
@@ -980,7 +983,9 @@ final class PaymentUriChannel {
 
   static func handle(urls: [URL]) {
     let urlStrings = urls.compactMap { url -> String? in
-      guard url.scheme?.lowercased() == "zcash" else {
+      guard let scheme = url.scheme?.lowercased(),
+        paymentRequestSchemes.contains(scheme)
+      else {
         return nil
       }
       return url.absoluteString

--- a/scripts/test-windows-payment-protocol.sh
+++ b/scripts/test-windows-payment-protocol.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Portable native contract test. All Windows APIs are in-memory test doubles;
+# this script does not register a URI handler or open a wallet.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+runner_dir="$repo_root/windows/runner"
+test_output="$(mktemp -d "${TMPDIR:-/tmp}/vizor-payment-protocol.XXXXXX")"
+
+"${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror \
+  -I"$runner_dir/tests/stubs" \
+  "$runner_dir/payment_uri_protocol.cpp" \
+  "$runner_dir/tests/payment_uri_protocol_test.cpp" \
+  -o "$test_output/payment-uri-protocol-test"
+"$test_output/payment-uri-protocol-test"

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -19,12 +19,12 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   std::vector<std::string> command_line_arguments =
       GetCommandLineArguments();
   std::vector<std::string> initial_payment_uris =
-      GetZcashUriArguments(command_line_arguments);
+      GetPaymentUriArguments(command_line_arguments);
 
   SingleInstanceGuard single_instance;
   const SingleInstanceAcquireResult instance_result = single_instance.Acquire();
   if (instance_result == SingleInstanceAcquireResult::kSecondary) {
-    // A zcash: link launched this secondary process. Hand the URIs to the
+    // A payment request launched this secondary process. Hand the URIs to the
     // primary window, which presents itself from its WM_COPYDATA handler; only
     // fall back to a bare activation when nothing could be delivered.
     if (ForwardPaymentUrisToRunningInstance(
@@ -71,9 +71,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // plugins.
   const HRESULT ro_init = ::RoInitialize(RO_INIT_SINGLETHREADED);
   const bool ro_initialized = SUCCEEDED(ro_init);
-  // Conditional: don't steal the zcash: handler from another wallet/channel on
-  // every launch. Install/update hooks (RunVelopackHooks) still claim it.
-  RegisterZcashProtocolHandlerIfUnclaimed();
+  // Conditional: don't steal payment URI handlers from another wallet/channel on
+  // every launch. Install/update hooks retain Zcash's existing claim behavior.
+  RegisterPaymentProtocolHandlersIfUnclaimed();
 
   flutter::DartProject project(L"data");
 

--- a/windows/runner/payment_uri_handoff.cpp
+++ b/windows/runner/payment_uri_handoff.cpp
@@ -43,7 +43,7 @@ bool IsVizorPrimaryWindow(HWND hwnd, UINT activation_message) {
 // is screened with the same rule the primary applies so a URI accepted here is
 // the same set accepted there.
 bool SendPaymentUri(HWND hwnd, const std::string& uri) {
-  if (!IsZcashUri(uri) || !IsDecodablePaymentUriPayload(uri)) {
+  if (!IsPaymentUri(uri) || !IsDecodablePaymentUriPayload(uri)) {
     return false;
   }
 
@@ -124,7 +124,7 @@ bool ForwardPaymentUrisToRunningInstance(const std::vector<std::string>& uris,
   }
 
   // The primary claims the single-instance lock before it creates its window,
-  // so a zcash: launch that arrives during startup finds no target on the
+  // so a payment URI launch that arrives during startup finds no target on the
   // first pass. Retry on the same schedule ActivateExistingInstance uses;
   // otherwise the secondary falls back to a bare activation, the window comes
   // to the front on someone else's screen, and the payment URI is lost.
@@ -166,7 +166,7 @@ bool TryReadPaymentUriCopyData(LPARAM lparam, std::string* uri) {
   const auto* copy_data = reinterpret_cast<const COPYDATASTRUCT*>(lparam);
   if (copy_data == nullptr || copy_data->dwData != kPaymentUriCopyDataId ||
       copy_data->lpData == nullptr || copy_data->cbData == 0 ||
-      copy_data->cbData > kMaxZcashUriBytes + 1) {
+      copy_data->cbData > kMaxPaymentUriBytes + 1) {
     return false;
   }
 
@@ -176,7 +176,7 @@ bool TryReadPaymentUriCopyData(LPARAM lparam, std::string* uri) {
   }
 
   std::string value(raw, copy_data->cbData - 1);
-  if (!IsZcashUri(value) || !IsDecodablePaymentUriPayload(value)) {
+  if (!IsPaymentUri(value) || !IsDecodablePaymentUriPayload(value)) {
     return false;
   }
 

--- a/windows/runner/payment_uri_handoff.h
+++ b/windows/runner/payment_uri_handoff.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-// Forwards zcash: payment URIs to an already-running Vizor instance. The target
+// Forwards payment request URIs to an already-running Vizor instance. The target
 // window is the one that acknowledges |activation_message| (the registered
 // single-instance message from SingleInstanceGuard), so the instance boundary
 // used here is the same one the instance lock enforces. Retries while the

--- a/windows/runner/payment_uri_protocol.cpp
+++ b/windows/runner/payment_uri_protocol.cpp
@@ -63,26 +63,40 @@ void SetStringValue(HKEY key, const wchar_t* name, const std::wstring& value) {
       static_cast<DWORD>((value.size() + 1) * sizeof(wchar_t)));
 }
 
-// Whether the effective payment URI shell open command could be read, and if so
-// whether one exists at all. Any failure we cannot attribute to "there is no
-// registration" is kUnreadable: a REG_EXPAND_SZ whose expansion needs a
+// Whether the effective payment URI handler uses a command or a COM delegate.
+// Any failure other than a missing registration is kUnreadable: a
+// REG_EXPAND_SZ whose expansion needs a
 // second pass, a value of an unexpected type, a key an ACL keeps us out of.
-// Callers must read kUnreadable as "somebody owns the scheme" -- reporting it
-// as absent is how a failed read ends up overwriting another wallet's handler.
+// Callers must preserve both delegated and unreadable registrations: neither
+// proves that this executable owns the scheme or that the scheme is unclaimed.
 enum class DefaultCommandState {
   kAbsent,
   kPresent,
+  kDelegated,
   kUnreadable,
 };
 
 // Reads the effective payment URI shell open command into |command|, which is left
-// empty unless kPresent is returned. Only ERROR_FILE_NOT_FOUND -- no key, or
-// no default value under it -- counts as kAbsent.
+// empty unless kPresent is returned. A DelegateExecute owner takes precedence
+// over the default command, which may be missing, empty, or left by an installer.
+// Only ERROR_FILE_NOT_FOUND for both values counts as kAbsent.
 DefaultCommandState ReadDefaultCommand(const wchar_t* scheme,
                                        std::wstring* command) {
   const std::wstring effective_command_path =
       std::wstring(scheme) + L"\\shell\\open\\command";
   command->clear();
+
+  DWORD delegate_size = 0;
+  const LSTATUS delegate_status =
+      ::RegGetValueW(HKEY_CLASSES_ROOT, effective_command_path.c_str(),
+                     L"DelegateExecute", RRF_RT_REG_SZ, nullptr, nullptr,
+                     &delegate_size);
+  if (delegate_status == ERROR_SUCCESS) {
+    return DefaultCommandState::kDelegated;
+  }
+  if (delegate_status != ERROR_FILE_NOT_FOUND) {
+    return DefaultCommandState::kUnreadable;
+  }
 
   DWORD size = 0;
   LSTATUS status =
@@ -327,7 +341,7 @@ void UnregisterPaymentProtocolHandler(const wchar_t* scheme) {
     return;
   }
   // Delete only a registration we could actually read and whose executable
-  // is this module. An unreadable command is not evidence the scheme is ours,
+  // is this module. A delegated or unreadable handler is not evidence it is ours,
   // and neither is a command that merely contains our path, so leave both
   // alone rather than tearing down a handler that may belong to someone else.
   std::wstring command;
@@ -359,7 +373,8 @@ void RegisterPaymentProtocolHandlerIfUnclaimed(const wchar_t* scheme) {
   // assume it is owned and write nothing. Treating a permissions error or an
   // ERROR_MORE_DATA expansion as "unclaimed" is what would let a plain launch
   // overwrite the handler another wallet is holding.
-  if (state == DefaultCommandState::kUnreadable) {
+  if (state == DefaultCommandState::kDelegated ||
+      state == DefaultCommandState::kUnreadable) {
     return;
   }
   if (state == DefaultCommandState::kPresent && !command.empty()) {

--- a/windows/runner/payment_uri_protocol.cpp
+++ b/windows/runner/payment_uri_protocol.cpp
@@ -11,11 +11,12 @@
 
 namespace {
 
-constexpr wchar_t kProtocolKeyPath[] = L"Software\\Classes\\zcash";
-constexpr wchar_t kProtocolCommandKeyPath[] =
-    L"Software\\Classes\\zcash\\shell\\open\\command";
-constexpr wchar_t kEffectiveProtocolCommandKeyPath[] =
-    L"zcash\\shell\\open\\command";
+constexpr const wchar_t* kPaymentRequestSchemes[] = {
+    L"zcash", L"bitcoin", L"litecoin", L"ethereum", L"solana"};
+
+std::wstring ProtocolKeyPath(const wchar_t* scheme) {
+  return std::wstring(L"Software\\Classes\\") + scheme;
+}
 
 struct RegistryKey {
   HKEY value = nullptr;
@@ -62,7 +63,7 @@ void SetStringValue(HKEY key, const wchar_t* name, const std::wstring& value) {
       static_cast<DWORD>((value.size() + 1) * sizeof(wchar_t)));
 }
 
-// Whether the effective zcash: shell open command could be read, and if so
+// Whether the effective payment URI shell open command could be read, and if so
 // whether one exists at all. Any failure we cannot attribute to "there is no
 // registration" is kUnreadable: a REG_EXPAND_SZ whose expansion needs a
 // second pass, a value of an unexpected type, a key an ACL keeps us out of.
@@ -74,15 +75,18 @@ enum class DefaultCommandState {
   kUnreadable,
 };
 
-// Reads the effective zcash: shell open command into |command|, which is left
+// Reads the effective payment URI shell open command into |command|, which is left
 // empty unless kPresent is returned. Only ERROR_FILE_NOT_FOUND -- no key, or
 // no default value under it -- counts as kAbsent.
-DefaultCommandState ReadDefaultCommand(std::wstring* command) {
+DefaultCommandState ReadDefaultCommand(const wchar_t* scheme,
+                                       std::wstring* command) {
+  const std::wstring effective_command_path =
+      std::wstring(scheme) + L"\\shell\\open\\command";
   command->clear();
 
   DWORD size = 0;
   LSTATUS status =
-      ::RegGetValueW(HKEY_CLASSES_ROOT, kEffectiveProtocolCommandKeyPath,
+      ::RegGetValueW(HKEY_CLASSES_ROOT, effective_command_path.c_str(),
                      nullptr, RRF_RT_REG_SZ, nullptr, nullptr, &size);
   if (status == ERROR_FILE_NOT_FOUND) {
     return DefaultCommandState::kAbsent;
@@ -104,7 +108,7 @@ DefaultCommandState ReadDefaultCommand(std::wstring* command) {
         static_cast<DWORD>(value.size() * sizeof(wchar_t));
     DWORD read_bytes = capacity_bytes;
     status =
-        ::RegGetValueW(HKEY_CLASSES_ROOT, kEffectiveProtocolCommandKeyPath,
+        ::RegGetValueW(HKEY_CLASSES_ROOT, effective_command_path.c_str(),
                        nullptr, RRF_RT_REG_SZ, nullptr, value.data(),
                        &read_bytes);
     if (status == ERROR_SUCCESS) {
@@ -177,7 +181,7 @@ bool IsAbsoluteWindowsPath(const std::wstring& value) {
 // (ERROR_NOT_READY), an ACL-restricted directory (ERROR_ACCESS_DENIED) and an
 // unreachable UNC share (ERROR_BAD_NETPATH) all leave a handler that is merely
 // unreachable right now, which is still the user's chosen handler; stealing the
-// zcash: scheme from it is not something the user can undo by plugging the
+// scheme from it is not something the user can undo by plugging the
 // drive back in.
 bool PathExistsOrIsUnreachable(const std::wstring& path) {
   if (::GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES) {
@@ -287,29 +291,29 @@ void NotifyAssociationChanged() {
   ::SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
 }
 
-}  // namespace
-
-void RegisterZcashProtocolHandler() {
+void RegisterPaymentProtocolHandler(const wchar_t* scheme) {
   const std::wstring module_path = ModuleFileName();
   if (module_path.empty()) {
     return;
   }
 
   RegistryKey protocol_key;
-  if (!CreateCurrentUserKey(kProtocolKeyPath, &protocol_key)) {
+  if (!CreateCurrentUserKey(ProtocolKeyPath(scheme).c_str(), &protocol_key)) {
     return;
   }
-  SetStringValue(protocol_key.value, nullptr, L"URL:Zcash Payment URI");
+  SetStringValue(protocol_key.value, nullptr, L"URL:Vizor Payment URI");
   SetStringValue(protocol_key.value, L"URL Protocol", L"");
 
   RegistryKey icon_key;
-  if (CreateCurrentUserKey(L"Software\\Classes\\zcash\\DefaultIcon",
+  if (CreateCurrentUserKey((ProtocolKeyPath(scheme) + L"\\DefaultIcon").c_str(),
                            &icon_key)) {
     SetStringValue(icon_key.value, nullptr, L"\"" + module_path + L"\",0");
   }
 
   RegistryKey command_key;
-  if (!CreateCurrentUserKey(kProtocolCommandKeyPath, &command_key)) {
+  if (!CreateCurrentUserKey(
+          (ProtocolKeyPath(scheme) + L"\\shell\\open\\command").c_str(),
+          &command_key)) {
     return;
   }
   SetStringValue(command_key.value, nullptr,
@@ -317,7 +321,7 @@ void RegisterZcashProtocolHandler() {
   NotifyAssociationChanged();
 }
 
-void UnregisterZcashProtocolHandler() {
+void UnregisterPaymentProtocolHandler(const wchar_t* scheme) {
   const std::wstring module_path = ToLower(ModuleFileName());
   if (module_path.empty()) {
     return;
@@ -327,30 +331,30 @@ void UnregisterZcashProtocolHandler() {
   // and neither is a command that merely contains our path, so leave both
   // alone rather than tearing down a handler that may belong to someone else.
   std::wstring command;
-  if (ReadDefaultCommand(&command) != DefaultCommandState::kPresent) {
+  if (ReadDefaultCommand(scheme, &command) != DefaultCommandState::kPresent) {
     return;
   }
   if (!CommandLaunchesModule(command, module_path)) {
     return;
   }
 
-  ::RegDeleteTreeW(HKEY_CURRENT_USER, kProtocolKeyPath);
+  ::RegDeleteTreeW(HKEY_CURRENT_USER, ProtocolKeyPath(scheme).c_str());
   NotifyAssociationChanged();
 }
 
-void RegisterZcashProtocolHandlerIfUnclaimed() {
+void RegisterPaymentProtocolHandlerIfUnclaimed(const wchar_t* scheme) {
   const std::wstring module_path = ToLower(ModuleFileName());
   if (module_path.empty()) {
     return;
   }
   // Only claim the scheme at startup when nobody holds it, or when the handler
   // that holds it points at an executable that no longer exists. Registering on
-  // every launch unconditionally would silently steal the zcash: handler back
-  // from another wallet (or another Vizor channel) the user selected. Install
-  // and update hooks still register unconditionally -- that is the intended
-  // moment to claim the handler.
+  // every launch unconditionally would silently steal a payment URI handler
+  // back from another wallet (or Vizor channel) the user selected. The existing
+  // Zcash install hook registers unconditionally; new schemes respect an
+  // existing owner even at install.
   std::wstring command;
-  const DefaultCommandState state = ReadDefaultCommand(&command);
+  const DefaultCommandState state = ReadDefaultCommand(scheme, &command);
   // A read we could not complete says nothing about who owns the scheme, so
   // assume it is owned and write nothing. Treating a permissions error or an
   // ERROR_MORE_DATA expansion as "unclaimed" is what would let a plain launch
@@ -373,5 +377,30 @@ void RegisterZcashProtocolHandlerIfUnclaimed() {
       return;
     }
   }
-  RegisterZcashProtocolHandler();
+  RegisterPaymentProtocolHandler(scheme);
+}
+
+}  // namespace
+
+void RegisterPaymentProtocolHandlers() {
+  // Preserve Zcash's existing install/update association. Supporting additional
+  // payment networks does not opt the user out of their other wallet choices.
+  RegisterPaymentProtocolHandler(L"zcash");
+  for (const wchar_t* scheme : kPaymentRequestSchemes) {
+    if (std::wstring(scheme) != L"zcash") {
+      RegisterPaymentProtocolHandlerIfUnclaimed(scheme);
+    }
+  }
+}
+
+void RegisterPaymentProtocolHandlersIfUnclaimed() {
+  for (const wchar_t* scheme : kPaymentRequestSchemes) {
+    RegisterPaymentProtocolHandlerIfUnclaimed(scheme);
+  }
+}
+
+void UnregisterPaymentProtocolHandlers() {
+  for (const wchar_t* scheme : kPaymentRequestSchemes) {
+    UnregisterPaymentProtocolHandler(scheme);
+  }
 }

--- a/windows/runner/payment_uri_protocol.h
+++ b/windows/runner/payment_uri_protocol.h
@@ -1,12 +1,14 @@
 #ifndef RUNNER_PAYMENT_URI_PROTOCOL_H_
 #define RUNNER_PAYMENT_URI_PROTOCOL_H_
 
-void RegisterZcashProtocolHandler();
-// Like RegisterZcashProtocolHandler, but only registers when no handler owns
-// the zcash: scheme yet, or when this exact install already owns it. Use this
-// on normal startup so a launch does not steal the handler the user picked;
-// the install/update hooks use the unconditional variant to claim it.
-void RegisterZcashProtocolHandlerIfUnclaimed();
-void UnregisterZcashProtocolHandler();
+// Install/update: keep Zcash's existing registration behavior. Additional
+// payment schemes are registered only when another live handler does not own
+// them, preserving the user's other wallet choices.
+void RegisterPaymentProtocolHandlers();
+// Normal startup: leave every live or unreadable registration alone, including
+// this install's own registration, and repair only missing or dangling owners.
+void RegisterPaymentProtocolHandlersIfUnclaimed();
+// Remove only schemes whose effective command launches this exact install.
+void UnregisterPaymentProtocolHandlers();
 
 #endif  // RUNNER_PAYMENT_URI_PROTOCOL_H_

--- a/windows/runner/tests/payment_uri_protocol_test.cpp
+++ b/windows/runner/tests/payment_uri_protocol_test.cpp
@@ -1,0 +1,169 @@
+// Exercises the production registration code against an in-memory registry.
+// The stub Windows APIs never read or write the host registry or filesystem.
+#include <windows.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+
+#include "../payment_uri_protocol.h"
+
+struct TestRegistryKey {
+  std::wstring path;
+};
+
+TestRegistryKey user_root, classes_root;
+HKEY HKEY_CURRENT_USER = &user_root;
+HKEY HKEY_CLASSES_ROOT = &classes_root;
+std::wstring module_path = L"C:\\Vizor\\vizor.exe";
+std::map<std::wstring, std::wstring> registry;
+std::set<std::wstring> unreadable;
+std::set<std::wstring> files;
+std::set<std::wstring> deleted;
+int writes = 0;
+
+DWORD GetModuleFileNameW(void*, wchar_t* output, DWORD capacity) {
+  const size_t length = std::min(module_path.size(), size_t(capacity - 1));
+  module_path.copy(output, length);
+  output[length] = L'\0';
+  return static_cast<DWORD>(length);
+}
+
+LSTATUS RegCloseKey(HKEY key) {
+  delete key;
+  return ERROR_SUCCESS;
+}
+
+LSTATUS RegCreateKeyExW(HKEY root, const wchar_t* path, DWORD, wchar_t*, DWORD,
+                        DWORD, void*, HKEY* key, DWORD*) {
+  assert(root == HKEY_CURRENT_USER);
+  *key = new TestRegistryKey{path};
+  return ERROR_SUCCESS;
+}
+
+LSTATUS RegSetValueExW(HKEY key, const wchar_t* name, DWORD, DWORD,
+                       const BYTE* value, DWORD size) {
+  ++writes;
+  if (name == nullptr) {
+    registry[key->path] = std::wstring(
+        reinterpret_cast<const wchar_t*>(value), size / sizeof(wchar_t) - 1);
+  }
+  return ERROR_SUCCESS;
+}
+
+LSTATUS RegGetValueW(HKEY root, const wchar_t* path, const wchar_t*, DWORD,
+                     DWORD*, void* output, DWORD* size) {
+  assert(root == HKEY_CLASSES_ROOT);
+  const std::wstring absolute = std::wstring(L"Software\\Classes\\") + path;
+  if (unreadable.count(absolute)) return ERROR_ACCESS_DENIED;
+  const auto found = registry.find(absolute);
+  if (found == registry.end()) return ERROR_FILE_NOT_FOUND;
+  const DWORD needed = static_cast<DWORD>(
+      (found->second.size() + 1) * sizeof(wchar_t));
+  if (output == nullptr) {
+    *size = needed;
+    return ERROR_SUCCESS;
+  }
+  if (*size < needed) {
+    *size = needed;
+    return ERROR_MORE_DATA;
+  }
+  std::memcpy(output, found->second.c_str(), needed);
+  *size = needed;
+  return ERROR_SUCCESS;
+}
+
+LSTATUS RegDeleteTreeW(HKEY root, const wchar_t* path) {
+  assert(root == HKEY_CURRENT_USER);
+  deleted.insert(path);
+  return ERROR_SUCCESS;
+}
+
+DWORD GetFileAttributesW(const wchar_t* path) {
+  return files.count(path) ? 0 : INVALID_FILE_ATTRIBUTES;
+}
+DWORD GetLastError() { return ERROR_FILE_NOT_FOUND; }
+void SHChangeNotify(long, unsigned int, const void*, const void*) {}
+
+std::wstring SchemePath(const wchar_t* scheme) {
+  return std::wstring(L"Software\\Classes\\") + scheme;
+}
+std::wstring CommandPath(const wchar_t* scheme) {
+  return SchemePath(scheme) + L"\\shell\\open\\command";
+}
+std::wstring OurCommand() { return L"\"" + module_path + L"\" \"%1\""; }
+
+void Reset() {
+  registry.clear();
+  unreadable.clear();
+  files.clear();
+  deleted.clear();
+  writes = 0;
+}
+
+int main() {
+  constexpr const wchar_t* schemes[] = {
+      L"zcash", L"bitcoin", L"litecoin", L"ethereum", L"solana"};
+  Reset();
+  RegisterPaymentProtocolHandlersIfUnclaimed();
+  for (const wchar_t* scheme : schemes) {
+    assert(registry.at(CommandPath(scheme)) == OurCommand());
+  }
+  const int initial_writes = writes;
+  RegisterPaymentProtocolHandlersIfUnclaimed();
+  assert(writes == initial_writes);
+  std::cout << "PASS: all schemes register, and normal startup does not rewrite them\n";
+
+  for (const wchar_t* scheme : schemes) {
+    Reset();
+    const auto command_path = CommandPath(scheme);
+    // The unquoted path deliberately contains spaces: it must remain owned.
+    const std::wstring competitor = L"C:\\Program Files\\Other Wallet\\wallet.exe";
+    const std::wstring command = competitor + L" \"%1\"";
+    registry[command_path] = command;
+    files.insert(competitor);
+    RegisterPaymentProtocolHandlersIfUnclaimed();
+    assert(registry.at(command_path) == command);
+    UnregisterPaymentProtocolHandlers();
+    assert(!deleted.count(SchemePath(scheme)));
+
+    Reset();
+    unreadable.insert(command_path);
+    RegisterPaymentProtocolHandlersIfUnclaimed();
+    assert(!registry.count(command_path));
+    UnregisterPaymentProtocolHandlers();
+    assert(!deleted.count(SchemePath(scheme)));
+
+    Reset();
+    registry[command_path] = L"\"C:\\RemovedWallet\\wallet.exe\" \"%1\"";
+    RegisterPaymentProtocolHandlersIfUnclaimed();
+    assert(registry.at(command_path) == OurCommand());
+  }
+  std::cout << "PASS: live and unreadable owners survive; dangling owners are repaired\n";
+
+  Reset();
+  const std::wstring competitor_command = L"\"C:\\OtherWallet\\wallet.exe\" \"%1\"";
+  files.insert(L"C:\\OtherWallet\\wallet.exe");
+  for (const wchar_t* scheme : schemes) {
+    registry[CommandPath(scheme)] = competitor_command;
+  }
+  RegisterPaymentProtocolHandlers();
+  assert(registry.at(CommandPath(L"zcash")) == OurCommand());
+  for (const wchar_t* scheme : {L"bitcoin", L"litecoin", L"ethereum", L"solana"}) {
+    assert(registry.at(CommandPath(scheme)) == competitor_command);
+  }
+  std::cout << "PASS: install keeps new schemes' other-wallet choices\n";
+
+  Reset();
+  RegisterPaymentProtocolHandlersIfUnclaimed();
+  registry[CommandPath(L"ethereum")] = competitor_command;
+  registry[CommandPath(L"solana")] = L"\"C:\\Wrapper\\wrapper.exe\" " + OurCommand();
+  UnregisterPaymentProtocolHandlers();
+  assert(deleted == std::set<std::wstring>({
+      SchemePath(L"zcash"), SchemePath(L"bitcoin"), SchemePath(L"litecoin")}));
+  std::cout << "PASS: uninstall removes only this install's effective handlers\n";
+}

--- a/windows/runner/tests/payment_uri_protocol_test.cpp
+++ b/windows/runner/tests/payment_uri_protocol_test.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 
@@ -25,6 +26,10 @@ std::set<std::wstring> unreadable;
 std::set<std::wstring> files;
 std::set<std::wstring> deleted;
 int writes = 0;
+
+std::wstring RegistryValueKey(const std::wstring& path, const wchar_t* name) {
+  return name == nullptr ? path : path + L"::" + name;
+}
 
 DWORD GetModuleFileNameW(void*, wchar_t* output, DWORD capacity) {
   const size_t length = std::min(module_path.size(), size_t(capacity - 1));
@@ -48,19 +53,20 @@ LSTATUS RegCreateKeyExW(HKEY root, const wchar_t* path, DWORD, wchar_t*, DWORD,
 LSTATUS RegSetValueExW(HKEY key, const wchar_t* name, DWORD, DWORD,
                        const BYTE* value, DWORD size) {
   ++writes;
-  if (name == nullptr) {
-    registry[key->path] = std::wstring(
-        reinterpret_cast<const wchar_t*>(value), size / sizeof(wchar_t) - 1);
-  }
+  registry[RegistryValueKey(key->path, name)] = std::wstring(
+      reinterpret_cast<const wchar_t*>(value), size / sizeof(wchar_t) - 1);
   return ERROR_SUCCESS;
 }
 
-LSTATUS RegGetValueW(HKEY root, const wchar_t* path, const wchar_t*, DWORD,
+LSTATUS RegGetValueW(HKEY root, const wchar_t* path, const wchar_t* name, DWORD,
                      DWORD*, void* output, DWORD* size) {
   assert(root == HKEY_CLASSES_ROOT);
   const std::wstring absolute = std::wstring(L"Software\\Classes\\") + path;
-  if (unreadable.count(absolute)) return ERROR_ACCESS_DENIED;
-  const auto found = registry.find(absolute);
+  const std::wstring value_key = RegistryValueKey(absolute, name);
+  if (unreadable.count(absolute) || unreadable.count(value_key)) {
+    return ERROR_ACCESS_DENIED;
+  }
+  const auto found = registry.find(value_key);
   if (found == registry.end()) return ERROR_FILE_NOT_FOUND;
   const DWORD needed = static_cast<DWORD>(
       (found->second.size() + 1) * sizeof(wchar_t));
@@ -166,4 +172,47 @@ int main() {
   assert(deleted == std::set<std::wstring>({
       SchemePath(L"zcash"), SchemePath(L"bitcoin"), SchemePath(L"litecoin")}));
   std::cout << "PASS: uninstall removes only this install's effective handlers\n";
+
+  const std::wstring delegate_clsid = L"{11111111-2222-3333-4444-555555555555}";
+  const std::optional<std::wstring> default_commands[] = {
+      OurCommand(), L"", std::nullopt};
+  for (const wchar_t* scheme : schemes) {
+    for (const auto& default_command : default_commands) {
+      Reset();
+      const auto command_path = CommandPath(scheme);
+      const auto delegate_key = RegistryValueKey(command_path, L"DelegateExecute");
+      registry[delegate_key] = delegate_clsid;
+      if (default_command) registry[command_path] = *default_command;
+
+      UnregisterPaymentProtocolHandlers();
+      assert(!deleted.count(SchemePath(scheme)));
+      RegisterPaymentProtocolHandlersIfUnclaimed();
+      assert(registry.count(command_path) == default_command.has_value());
+      if (default_command) assert(registry.at(command_path) == *default_command);
+      assert(registry.at(delegate_key) == delegate_clsid);
+      // Zcash retains its existing explicit install-claim policy. New schemes
+      // must preserve a delegate owner at installation as well as at startup.
+      if (std::wstring(scheme) != L"zcash") {
+        RegisterPaymentProtocolHandlers();
+        assert(registry.count(command_path) == default_command.has_value());
+        if (default_command) assert(registry.at(command_path) == *default_command);
+        assert(registry.at(delegate_key) == delegate_clsid);
+      }
+    }
+  }
+  std::cout << "PASS: delegate owners survive missing, empty, and Vizor default commands\n";
+
+  for (const wchar_t* scheme : schemes) {
+    for (const bool has_default : {false, true}) {
+      Reset();
+      const auto command_path = CommandPath(scheme);
+      unreadable.insert(RegistryValueKey(command_path, L"DelegateExecute"));
+      if (has_default) registry[command_path] = OurCommand();
+      RegisterPaymentProtocolHandlersIfUnclaimed();
+      assert(registry.count(command_path) == has_default);
+      UnregisterPaymentProtocolHandlers();
+      assert(!deleted.count(SchemePath(scheme)));
+    }
+  }
+  std::cout << "PASS: an unreadable delegate cannot be claimed or removed\n";
 }

--- a/windows/runner/tests/stubs/shellapi.h
+++ b/windows/runner/tests/stubs/shellapi.h
@@ -1,0 +1,3 @@
+#ifndef VIZOR_TEST_SHELLAPI_H_
+#define VIZOR_TEST_SHELLAPI_H_
+#endif

--- a/windows/runner/tests/stubs/shlobj.h
+++ b/windows/runner/tests/stubs/shlobj.h
@@ -1,0 +1,8 @@
+#ifndef VIZOR_TEST_SHLOBJ_H_
+#define VIZOR_TEST_SHLOBJ_H_
+
+constexpr long SHCNE_ASSOCCHANGED = 0x08000000;
+constexpr unsigned int SHCNF_IDLIST = 0;
+void SHChangeNotify(long, unsigned int, const void*, const void*);
+
+#endif

--- a/windows/runner/tests/stubs/windows.h
+++ b/windows/runner/tests/stubs/windows.h
@@ -1,0 +1,38 @@
+#ifndef VIZOR_TEST_WINDOWS_H_
+#define VIZOR_TEST_WINDOWS_H_
+
+#include <cstdint>
+
+using DWORD = uint32_t;
+using LSTATUS = int32_t;
+using BYTE = unsigned char;
+struct TestRegistryKey;
+using HKEY = TestRegistryKey*;
+
+extern HKEY HKEY_CURRENT_USER;
+extern HKEY HKEY_CLASSES_ROOT;
+
+constexpr DWORD MAX_PATH = 260;
+constexpr LSTATUS ERROR_SUCCESS = 0;
+constexpr LSTATUS ERROR_FILE_NOT_FOUND = 2;
+constexpr LSTATUS ERROR_PATH_NOT_FOUND = 3;
+constexpr LSTATUS ERROR_ACCESS_DENIED = 5;
+constexpr LSTATUS ERROR_INVALID_NAME = 123;
+constexpr LSTATUS ERROR_MORE_DATA = 234;
+constexpr DWORD INVALID_FILE_ATTRIBUTES = 0xffffffff;
+constexpr DWORD KEY_SET_VALUE = 2;
+constexpr DWORD REG_SZ = 1;
+constexpr DWORD RRF_RT_REG_SZ = 2;
+
+DWORD GetModuleFileNameW(void*, wchar_t*, DWORD);
+LSTATUS RegCloseKey(HKEY);
+LSTATUS RegCreateKeyExW(HKEY, const wchar_t*, DWORD, wchar_t*, DWORD, DWORD,
+                        void*, HKEY*, DWORD*);
+LSTATUS RegSetValueExW(HKEY, const wchar_t*, DWORD, DWORD, const BYTE*, DWORD);
+LSTATUS RegGetValueW(HKEY, const wchar_t*, const wchar_t*, DWORD, DWORD*, void*,
+                     DWORD*);
+LSTATUS RegDeleteTreeW(HKEY, const wchar_t*);
+DWORD GetFileAttributesW(const wchar_t*);
+DWORD GetLastError();
+
+#endif

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -8,30 +8,30 @@
 #include <cctype>
 #include <iostream>
 
-bool IsZcashUri(const std::string& value) {
-  constexpr char prefix[] = "zcash:";
-  constexpr size_t prefix_length = sizeof(prefix) - 1;
-  if (value.size() < prefix_length || value.size() > kMaxZcashUriBytes) {
+bool IsPaymentUri(const std::string& value) {
+  if (value.size() > kMaxPaymentUriBytes) {
     return false;
   }
-
-  for (size_t i = 0; i < prefix_length; ++i) {
-    const auto actual =
-        static_cast<unsigned char>(value[i]);
-    const auto expected =
-        static_cast<unsigned char>(prefix[i]);
-    if (std::tolower(actual) != std::tolower(expected)) {
-      return false;
+  constexpr const char* prefixes[] = {
+      "zcash:", "bitcoin:", "litecoin:", "ethereum:", "solana:"};
+  for (const char* prefix : prefixes) {
+    size_t i = 0;
+    while (prefix[i] != '\0' && i < value.size() &&
+           std::tolower(static_cast<unsigned char>(value[i])) == prefix[i]) {
+      ++i;
+    }
+    if (prefix[i] == '\0') {
+      return true;
     }
   }
-  return true;
+  return false;
 }
 
 // Returns true when |value| is something the Dart side can actually decode.
 // The channel carries the URI through StandardMessageCodec, which throws on
 // malformed UTF-8; a bad payload that arrives before Dart is ready aborts
 // takePendingUris and wedges the payment-URI channel for the rest of the
-// session. Control characters are rejected too: no ZIP-321 URI contains one,
+// session. Control characters are rejected too: payment request URIs contain none,
 // and they have no business reaching the send screen.
 bool IsDecodablePaymentUriPayload(const std::string& value) {
   if (value.empty()) {
@@ -84,7 +84,7 @@ std::vector<std::string> GetCommandLineArguments() {
   return command_line_arguments;
 }
 
-std::vector<std::string> GetZcashUriArguments(
+std::vector<std::string> GetPaymentUriArguments(
     const std::vector<std::string>& arguments) {
   std::vector<std::string> uris;
   for (const auto& argument : arguments) {
@@ -92,7 +92,7 @@ std::vector<std::string> GetZcashUriArguments(
     // so the two entry points accept the same set. An argv URI reaches Dart
     // through the identical channel, and an undecodable one wedges it just as
     // thoroughly as a forwarded one would.
-    if (IsZcashUri(argument) && IsDecodablePaymentUriPayload(argument)) {
+    if (IsPaymentUri(argument) && IsDecodablePaymentUriPayload(argument)) {
       uris.push_back(argument);
     }
   }

--- a/windows/runner/utils.h
+++ b/windows/runner/utils.h
@@ -14,7 +14,7 @@
 // up to this bound and let Dart explain; the bound exists only so a
 // pathological multi-megabyte payload still cannot travel. Matches
 // MAX_INCOMING_URI_BYTES on Android and maxIncomingUriBytes on iOS.
-constexpr size_t kMaxZcashUriBytes = 64 * 1024;
+constexpr size_t kMaxPaymentUriBytes = 64 * 1024;
 
 // Creates a console for the process, and redirects stdout and stderr to
 // it for both the runner and the Flutter library.
@@ -32,13 +32,13 @@ std::wstring Utf16FromUtf8(const std::string& utf8_string);
 // encoded in UTF-8. Returns an empty std::vector<std::string> on failure.
 std::vector<std::string> GetCommandLineArguments();
 
-// Extracts zcash: payment URIs from command-line arguments.
-std::vector<std::string> GetZcashUriArguments(
+// Extracts payment request URIs from command-line arguments.
+std::vector<std::string> GetPaymentUriArguments(
     const std::vector<std::string>& arguments);
 
-// Returns whether |value| is a zcash: URI small enough to forward through the
+// Returns whether |value| is a supported payment URI small enough to forward through the
 // native launch-URI bridge.
-bool IsZcashUri(const std::string& value);
+bool IsPaymentUri(const std::string& value);
 
 // Returns whether |value| is a payment-URI payload the Dart side can actually
 // decode. Both entry points -- a cold-start argv URI and one forwarded from a

--- a/windows/runner/velopack_uninstall.cpp
+++ b/windows/runner/velopack_uninstall.cpp
@@ -215,12 +215,12 @@ void DeleteUserData() {
 }
 
 void BeforeUninstallHook(void* user_data, const char* app_version) {
-  UnregisterZcashProtocolHandler();
+  UnregisterPaymentProtocolHandlers();
   DeleteUserData();
 }
 
 void RegisterProtocolHook(void* user_data, const char* app_version) {
-  RegisterZcashProtocolHandler();
+  RegisterPaymentProtocolHandlers();
 }
 
 }  // namespace


### PR DESCRIPTION
Opening a Bitcoin, Litecoin, Ethereum, or Solana payment link needs to deliver the complete URI to Vizor, including when the app is already running or Dart has not installed its channel handler yet. This PR extends the existing native Zcash link bridges to those four schemes across Android, iOS, macOS, Linux, and Windows.

This is **step 2 of 5** in integration PR #654, based on the merged parser/asset-resolution PR #655. It targets `rowan/cross-chain-payments-integration`. The shared Dart intake and request-card/Pay routing will be connected in step 4; this PR registers and forwards the native input.

## Implementation

- Android: registers the four schemes in the existing `ACTION_VIEW` intent filter and accepts them through MainActivity's existing capture/channel path. The scheme check is case-insensitive. Cross-chain requests remain in memory; only the existing Zcash classification permits persisted pending URIs. HTTPS gift-card link handling retains its existing policy.
- iOS: registers the schemes in `Info.plist` and accepts them in `IncomingUriChannelBridge`, preserving its existing queue and Dart-readiness handling. Verified Vizor HTTPS links retain their host/path checks.
- macOS: registers the schemes in `Info.plist` and extends `PaymentUriChannel` filtering, keeping delivery through the existing Apple-event/channel path.
- Linux: adds the desktop MIME associations and recognizes the schemes during launch arguments, pending-URI buffering, and GApplication/D-Bus forwarding to the primary instance.
- Windows: extends launch argument filtering and `WM_COPYDATA` forwarding to all five payment schemes, preserving the 64 KiB transport limit and existing UTF-8/control-character validation. Renames the Zcash-specific helpers consistently across their callers.
- Windows registration: normal startup preserves live, delegated, or unreadable handlers and repairs missing/dangling registrations. Install/update retains Zcash's existing behavior while respecting other wallets' handlers for the four new schemes. Uninstall removes only registrations whose effective command launches the current Vizor executable.

- Windows delegate ownership: checks `DelegateExecute` before interpreting the default command. Startup and uninstall preserve delegated handlers even when the default command is missing, empty, or points to Vizor. An unreadable delegate also prevents claiming or removing the registration. Install/update for the four new schemes uses the same ownership check; Zcash retains its existing explicit install-claim policy. See [Microsoft's documented delegate registration](https://devblogs.microsoft.com/oldnewthing/20100312-01/?p=14623).

## Review focus

1. Preserve each complete URI across cold launch, startup buffering, and forwarding to a running instance.
2. Keep manifest/desktop registration and native acceptance predicates consistent.
3. Preserve existing Zcash and HTTPS gift-card handling, including in-memory treatment of potentially sensitive cross-chain links.
4. Avoid taking over another wallet's Windows handlers or removing registrations owned by another installation.

## Validation

Windows ownership follow-up validated at `36d6130f77`. The other platform paths are unchanged from the validation at `96c0e1324c`.

- `scripts/test-windows-payment-protocol.sh` — six groups passed against the production registration code with in-memory Windows API doubles: registration/idempotence, live/unreadable/dangling owners, install behavior, uninstall ownership, delegated owners with missing/empty/Vizor default commands, and unreadable delegates. Both unintended registration and deletion were reproduced before the correction.
- `scripts/test-linux-single-instance.sh` in a Linux container — 17 checks passed using the production runner with real GTK, D-Bus, and process locks; Flutter content was substituted. Covered startup buffering, all payment schemes, warm forwarding, restoring the existing window, separate mainnet/testnet identities, and concurrent launches. The local x86_64 Linux image ran under Docker emulation on macOS; this was not a packaged-app test.
- `plutil -lint ios/Runner/Info.plist macos/Runner/Info.plist` — passed.
- `xcrun swiftc -frontend -parse ios/Runner/AppDelegate.swift macos/Runner/MainFlutterWindow.swift` — passed syntax parsing.
- Android manifest XML parsing and `bash -n` for both native test scripts — passed.
- Checked all Windows callers for the renamed URI helpers; `git diff --check` — passed.

The Windows test does not exercise a real registry or shell launch. No Android/iOS/macOS app build or device link-opening check was performed for this PR. End-to-end request presentation awaits the Dart/UI integration in the later domain PRs.
