### PR TITLE
Add desktop and mobile cross-chain payment request cards

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 
 import '../widgetbook/activity_use_cases.dart';
 import '../widgetbook/keystone_use_cases.dart';
+import '../widgetbook/cross_chain_payment_request_use_cases.dart';
 import '../widgetbook/payment_link_claim_outcome_use_cases.dart';
 import '../widgetbook/home_use_cases.dart';
 import '../widgetbook/donation_use_cases.dart';
@@ -1478,6 +1479,50 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     id: 'payment-request-full',
     description: 'Desktop payment request card with label, message and note',
     builder: buildPaymentRequestFullUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'cross-chain-payment-base-usdc',
+    description:
+        'Base USDC request with an estimated ZEC spend and slippage setting',
+    builder: buildBaseUsdcPaymentRequestUseCase,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'cross-chain-payment-slippage',
+    description:
+        'Payment request slippage settings using the existing Pay editor',
+    builder: buildPaymentRequestSlippageUseCase,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'cross-chain-payment-requester',
+    description: 'Payment request with requester-provided label and message',
+    builder: buildPaymentRequestRequesterDetailsUseCase,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'cross-chain-payment-requester-long',
+    description: 'Payment request with a long requester-provided message',
+    builder: buildPaymentRequestLongRequesterDetailsUseCase,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'cross-chain-payment-bitcoin',
+    description: 'Bitcoin payment request with eight-decimal precision',
+    builder: buildBitcoinPaymentRequestUseCase,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'cross-chain-payment-litecoin',
+    description: 'Litecoin payment request with its native asset icon',
+    builder: buildLitecoinPaymentRequestUseCase,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
+    id: 'cross-chain-payment-solana-usdc',
+    description: 'Solana USDC request with network badge and mint disclosure',
+    builder: buildSolanaUsdcPaymentRequestUseCase,
+    mobile: true,
   ),
   FigmaCompareScenario(
     id: 'payment-request-minimal',

--- a/lib/src/core/layout/mobile/app_mobile_sheet.dart
+++ b/lib/src/core/layout/mobile/app_mobile_sheet.dart
@@ -2,11 +2,13 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform;
-import 'package:flutter/material.dart' show Material, showModalBottomSheet;
+import 'package:flutter/material.dart'
+    show BottomSheet, Material, showModalBottomSheet;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../theme/app_theme.dart';
+import '../../widgets/app_button.dart';
 import '../../widgets/app_icon.dart';
 
 /// Shows a mobile modal as a floating card — the Figma modal base
@@ -98,6 +100,7 @@ class MobileModalCard extends StatelessWidget {
     required this.child,
     this.transparentBackground = false,
     this.margin,
+    this.onBack,
     super.key,
   });
 
@@ -110,6 +113,9 @@ class MobileModalCard extends StatelessWidget {
   /// Centered dialogs own their outer insets and pass [EdgeInsets.zero].
   /// Bottom sheets retain the default side and safe-area-aware bottom gaps.
   final EdgeInsets? margin;
+
+  /// A floating return action above the card for a nested sheet.
+  final VoidCallback? onBack;
 
   @override
   Widget build(BuildContext context) {
@@ -166,7 +172,117 @@ class MobileModalCard extends StatelessWidget {
             right: sideMargin,
             bottom: bottomGap,
           ),
-      child: card,
+      child: onBack == null
+          ? card
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Align(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: AppButton(
+                    key: const ValueKey('mobile_modal_back_button'),
+                    variant: AppButtonVariant.secondary,
+                    minWidth: 44,
+                    height: 44,
+                    contentPadding: EdgeInsets.zero,
+                    enabledBackgroundColor: colors.background.base,
+                    onPressed: onBack,
+                    child: Semantics(
+                      label: 'Back',
+                      child: AppIcon(
+                        AppIcons.arrowBack,
+                        size: 20,
+                        color: colors.icon.accent,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Flexible(child: card),
+              ],
+            ),
+    );
+  }
+}
+
+/// Adds Flutter's drag motion and dismissal to a sheet rendered without a route.
+/// Key this by request identity so a closing sheet cannot close its replacement.
+class AppDraggableMobileSheet extends StatefulWidget {
+  const AppDraggableMobileSheet({
+    required this.onDismiss,
+    required this.child,
+    this.dismissRequested = false,
+    this.onClosing,
+    super.key,
+  });
+
+  final VoidCallback onDismiss;
+  final Widget child;
+  final bool dismissRequested;
+  final VoidCallback? onClosing;
+
+  @override
+  State<AppDraggableMobileSheet> createState() =>
+      _AppDraggableMobileSheetState();
+}
+
+class _AppDraggableMobileSheetState extends State<AppDraggableMobileSheet>
+    with SingleTickerProviderStateMixin {
+  late final _controller = BottomSheet.createAnimationController(this)
+    ..value = 1;
+  late final _position = Tween<Offset>(
+    begin: const Offset(0, 1),
+    end: Offset.zero,
+  ).animate(_controller);
+  bool _closing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.dismissRequested) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && widget.dismissRequested) _dismiss();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AppDraggableMobileSheet oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.dismissRequested && !oldWidget.dismissRequested) _dismiss();
+  }
+
+  void _dismiss() {
+    if (_closing) return;
+    setState(() => _closing = true);
+    widget.onClosing?.call();
+    _controller.reverse().then((_) {
+      if (mounted) widget.onDismiss();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SlideTransition(
+      position: _position,
+      child: IgnorePointer(
+        ignoring: _closing,
+        child: BottomSheet(
+          animationController: _controller,
+          onClosing: _dismiss,
+          showDragHandle: false,
+          backgroundColor: const Color(0x00000000),
+          elevation: 0,
+          builder: (_) => widget.child,
+        ),
+      ),
     );
   }
 }

--- a/lib/src/core/widgets/app_modal_overlay_scope.dart
+++ b/lib/src/core/widgets/app_modal_overlay_scope.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+
+/// Gives a modal mounted above the router its own [Overlay] ancestor for
+/// tooltips and text selection. Keep the routed background outside this scope
+/// so opening the modal does not remount the underlying screen.
+class AppModalOverlayScope extends StatefulWidget {
+  const AppModalOverlayScope({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  State<AppModalOverlayScope> createState() => _AppModalOverlayScopeState();
+}
+
+class _AppModalOverlayScopeState extends State<AppModalOverlayScope> {
+  // initialEntries is read once; always render the current child.
+  late final OverlayEntry _entry = OverlayEntry(builder: (_) => widget.child);
+
+  @override
+  void didUpdateWidget(covariant AppModalOverlayScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.child, widget.child)) _entry.markNeedsBuild();
+  }
+
+  @override
+  Widget build(BuildContext context) => Overlay(initialEntries: [_entry]);
+}

--- a/lib/src/core/widgets/review_list_row.dart
+++ b/lib/src/core/widgets/review_list_row.dart
@@ -17,7 +17,8 @@ const kTxFeeHelpTooltip =
 /// supplied, never a sender the wallet verified — so the one surface that
 /// shows it says so. The send review never renders it at all.
 const kPaymentRequestRequesterTooltip =
-    "Name supplied by the payment link. Vizor can't verify who sent it.";
+    'The requester provided this name. '
+    "It may differ from the recipient's name.";
 
 /// One 32px "List Item" row inside a `ReviewWrapCard`: left label, right
 /// value cluster with optional 16px leading/trailing icons.

--- a/lib/src/features/pay/widgets/cross_chain_payment_request_card.dart
+++ b/lib/src/features/pay/widgets/cross_chain_payment_request_card.dart
@@ -1,0 +1,721 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../core/formatting/address_display.dart';
+import '../../../core/payments/cross_chain_payment_request.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/full_address_viewer.dart';
+import '../../../core/widgets/review_wrap_card.dart';
+import '../../send/widgets/payment_request_card.dart'
+    show PaymentRequestRequesterDetailsCard;
+import '../../swap/domain/swap_asset.dart';
+import '../../swap/models/swap_slippage_formatting.dart';
+import '../../swap/widgets/swap_asset_icon.dart';
+import '../models/payment_request_resolution.dart';
+
+/// Request review content shared by the desktop modal and mobile sheet.
+/// The host owns the surrounding surface and executes no payment from here.
+class CrossChainPaymentRequestCard extends StatefulWidget {
+  const CrossChainPaymentRequestCard({
+    required this.request,
+    required this.resolution,
+    required this.onContinue,
+    required this.onCancel,
+    required this.onNetworkSelected,
+    required this.onRetry,
+    this.onEdit,
+    this.isLoading = false,
+    this.loadingMessage = 'Checking payment options…',
+    this.isPreparingReview = false,
+    this.selectedChain,
+    this.availabilityMessage,
+    this.estimatedZecAmount,
+    this.slippageBps,
+    this.onOpenSlippage,
+    this.isMobile = false,
+    super.key,
+  });
+
+  final CrossChainPaymentRequest request;
+  final PaymentRequestResolution resolution;
+  final VoidCallback onContinue;
+  final VoidCallback onCancel;
+  final ValueChanged<String> onNetworkSelected;
+  final VoidCallback onRetry;
+  final VoidCallback? onEdit;
+  final bool isLoading;
+  final String loadingMessage;
+  final bool isPreparingReview;
+  final String? selectedChain;
+  final String? availabilityMessage;
+  final double? estimatedZecAmount;
+  final int? slippageBps;
+  final VoidCallback? onOpenSlippage;
+  final bool isMobile;
+
+  @override
+  State<CrossChainPaymentRequestCard> createState() =>
+      _CrossChainPaymentRequestCardState();
+}
+
+class _CrossChainPaymentRequestCardState
+    extends State<CrossChainPaymentRequestCard> {
+  final _scrollController = ScrollController();
+  bool _addressExpanded = false;
+  bool _requesterExpanded = false;
+  bool _networkPickerExpanded = false;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(CrossChainPaymentRequestCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.request.id != widget.request.id) {
+      _addressExpanded = false;
+      _requesterExpanded = false;
+      _networkPickerExpanded = false;
+    }
+  }
+
+  String get _networkLabel {
+    final request = widget.request;
+    if (request.isEvm) {
+      if (request.chainId case final chainId?) {
+        return evmPaymentNetworks[chainId]?.label ??
+            'Unsupported network (chain ID $chainId)';
+      }
+      for (final network in evmPaymentNetworks.values) {
+        if (network.chain == widget.selectedChain) return network.label;
+      }
+      return 'Select network';
+    }
+    return switch (request.chain) {
+      'btc' => 'Bitcoin',
+      'ltc' => 'Litecoin',
+      'sol' => 'Solana',
+      _ => 'Network unavailable',
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final request = widget.request;
+    final resolution = widget.resolution;
+    final amount = resolution.amountText;
+    final hasAmount =
+        resolution.asset != null && amount != null && amount.isNotEmpty;
+    final statusMessage =
+        request.unsupportedReason ??
+        widget.availabilityMessage ??
+        resolution.message;
+    final canContinue =
+        resolution.isReady &&
+        !resolution.needsNetwork &&
+        !widget.isLoading &&
+        !widget.isPreparingReview &&
+        widget.availabilityMessage == null &&
+        request.unsupportedReason == null;
+    final canRetry =
+        !widget.isLoading &&
+        !widget.isPreparingReview &&
+        widget.availabilityMessage != null &&
+        request.unsupportedReason == null;
+    final sectionGap = widget.isMobile ? AppSpacing.sm : AppSpacing.md;
+    final requester = request.label?.replaceAll(RegExp(r'\s+'), ' ').trim();
+    final note = request.message?.trim();
+    final hasRequester = requester != null && requester.isNotEmpty;
+    final hasNote = note != null && note.isNotEmpty;
+
+    final details = SingleChildScrollView(
+      key: const ValueKey('cross_chain_payment_request_scroll'),
+      controller: _scrollController,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (hasRequester || hasNote) ...[
+            PaymentRequestRequesterDetailsCard(
+              requester: hasRequester ? requester : null,
+              note: hasNote ? note : null,
+              expanded: _requesterExpanded,
+              onToggle: hasNote
+                  ? () =>
+                        setState(() => _requesterExpanded = !_requesterExpanded)
+                  : null,
+            ),
+            SizedBox(height: sectionGap),
+          ],
+          _transactionContent(context, hasAmount: hasAmount),
+          if (widget.slippageBps != null &&
+              resolution.isReady &&
+              request.unsupportedReason == null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            _slippageControl(context),
+          ],
+        ],
+      ),
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _header(context),
+          SizedBox(height: sectionGap),
+          if (constraints.hasBoundedHeight)
+            Flexible(
+              child: RawScrollbar(
+                controller: _scrollController,
+                thumbVisibility: true,
+                thumbColor: context.colors.surface.scrollbarThumb,
+                child: details,
+              ),
+            )
+          else
+            details,
+          if (widget.isLoading ||
+              widget.isPreparingReview ||
+              statusMessage != null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            Semantics(
+              liveRegion: true,
+              child: Text(
+                widget.isPreparingReview
+                    ? 'Preparing payment review…'
+                    : widget.isLoading
+                    ? widget.loadingMessage
+                    : statusMessage!,
+                key: const ValueKey('cross_chain_payment_request_status'),
+                maxLines: 5,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.bodyMedium.copyWith(
+                  color: context.colors.text.secondary,
+                ),
+              ),
+            ),
+          ],
+          SizedBox(height: sectionGap),
+          AppButton(
+            key: const ValueKey('cross_chain_payment_request_continue'),
+            onPressed: canRetry
+                ? widget.onRetry
+                : canContinue
+                ? widget.onContinue
+                : null,
+            expand: true,
+            constrainContent: true,
+            child: Text(
+              widget.isPreparingReview
+                  ? 'Preparing…'
+                  : widget.isLoading
+                  ? 'Checking…'
+                  : canRetry
+                  ? 'Try again'
+                  : resolution.isReady && !hasAmount
+                  ? 'Enter amount'
+                  : 'Review payment',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (widget.onEdit != null && hasAmount && resolution.isReady) ...[
+            const SizedBox(height: AppSpacing.xs),
+            AppButton(
+              key: const ValueKey('cross_chain_payment_request_edit'),
+              onPressed: widget.isLoading || widget.isPreparingReview
+                  ? null
+                  : widget.onEdit,
+              variant: AppButtonVariant.ghost,
+              expand: true,
+              child: const Text('Edit'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _header(BuildContext context) => Row(
+    children: [
+      Expanded(
+        child: Semantics(
+          header: true,
+          child: Text(
+            'Payment request',
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.headlineMedium.copyWith(
+              color: context.colors.text.accent,
+            ),
+          ),
+        ),
+      ),
+      const SizedBox(width: AppSpacing.xs),
+      Semantics(
+        label: 'Close payment request',
+        child: AppButton(
+          key: const ValueKey('cross_chain_payment_request_cancel'),
+          onPressed: widget.onCancel,
+          variant: AppButtonVariant.ghost,
+          height: widget.isMobile ? 44 : 32,
+          minWidth: widget.isMobile ? 44 : 32,
+          contentPadding: EdgeInsets.zero,
+          child: AppIcon(
+            AppIcons.cross,
+            size: AppIconSize.medium,
+            color: context.colors.icon.regular,
+          ),
+        ),
+      ),
+    ],
+  );
+
+  Widget _slippageControl(BuildContext context) => Row(
+    children: [
+      Expanded(
+        child: Text(
+          'Slippage',
+          style: AppTypography.bodyMedium.copyWith(
+            color: context.colors.text.secondary,
+          ),
+        ),
+      ),
+      Semantics(
+        label: 'Change slippage',
+        child: AppButton(
+          key: const ValueKey('cross_chain_payment_request_slippage'),
+          onPressed: widget.isLoading || widget.isPreparingReview
+              ? null
+              : widget.onOpenSlippage,
+          variant: AppButtonVariant.ghost,
+          size: AppButtonSize.small,
+          height: widget.isMobile ? 44 : 32,
+          contentPadding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(formatSwapSlippage(widget.slippageBps!)),
+              const SizedBox(width: AppSpacing.xxs),
+              AppIcon(AppIcons.cog, size: 16, color: context.colors.icon.muted),
+            ],
+          ),
+        ),
+      ),
+    ],
+  );
+
+  Widget _transactionContent(BuildContext context, {required bool hasAmount}) {
+    final request = widget.request;
+    final estimatedZec = widget.estimatedZecAmount;
+    final showEstimate =
+        hasAmount &&
+        widget.resolution.isReady &&
+        !widget.isLoading &&
+        widget.availabilityMessage == null &&
+        request.unsupportedReason == null &&
+        estimatedZec != null &&
+        estimatedZec.isFinite &&
+        estimatedZec > 0;
+    final radius = BorderRadius.circular(AppRadii.large);
+    return Container(
+      key: const ValueKey('cross_chain_payment_request_transaction'),
+      foregroundDecoration: BoxDecoration(
+        borderRadius: radius,
+        border: Border.all(color: context.colors.border.regular),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _Detail(
+                  label: 'Recipient gets',
+                  child: _assetAmount(context, hasAmount: hasAmount),
+                ),
+                if (request.needsNetwork && request.unsupportedReason == null)
+                  _networkPicker(context),
+                if (showEstimate) ...[
+                  const SizedBox(height: AppSpacing.sm),
+                  const ReviewWrapDivider(),
+                  const SizedBox(height: AppSpacing.sm),
+                  Wrap(
+                    key: const ValueKey('payment_request_zec_estimate'),
+                    alignment: WrapAlignment.spaceBetween,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    spacing: AppSpacing.xs,
+                    runSpacing: AppSpacing.xxs,
+                    children: [
+                      Text(
+                        'Estimated spend',
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: context.colors.text.secondary,
+                        ),
+                      ),
+                      Text(
+                        estimatedZec < 0.0001
+                            ? '< 0.0001 ZEC'
+                            : '≈ ${SwapAsset.zec.formatAmount(estimatedZec)} ZEC',
+                        style: AppTypography.bodyMediumStrong.copyWith(
+                          color: context.colors.text.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (request.address.isNotEmpty)
+            ReviewWrapCard(
+              mainAxisSize: MainAxisSize.min,
+              padding: const EdgeInsets.all(AppSpacing.sm),
+              children: [_recipient(context)],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _assetAmount(BuildContext context, {required bool hasAmount}) {
+    final request = widget.request;
+    final resolution = widget.resolution;
+    final asset = resolution.asset;
+    final hasNetworkPicker =
+        request.needsNetwork && request.unsupportedReason == null;
+    final value = hasAmount
+        ? resolution.amountText!
+        : resolution.needsNetwork
+        ? 'Network not specified'
+        : request.amount == null
+        ? 'Amount not specified'
+        : widget.isLoading
+        ? 'Loading amount…'
+        : 'Amount unavailable';
+    final amountStyle =
+        (hasAmount
+                ? AppTypography.headlineLarge
+                : AppTypography.bodyMediumStrong)
+            .copyWith(color: context.colors.text.accent);
+    final amount = Text(
+      value,
+      key: const ValueKey('cross_chain_payment_request_amount'),
+      softWrap: true,
+      style: amountStyle,
+    );
+    final identity = Wrap(
+      spacing: AppSpacing.xs,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        if (asset != null)
+          Text(
+            asset.symbol,
+            style: AppTypography.bodyMediumStrong.copyWith(
+              color: context.colors.text.primary,
+            ),
+          ),
+        if (asset != null && !hasNetworkPicker)
+          Text(
+            '·',
+            style: AppTypography.bodyMedium.copyWith(
+              color: context.colors.text.muted,
+            ),
+          ),
+        if (!hasNetworkPicker)
+          Text(
+            _networkLabel,
+            key: const ValueKey('cross_chain_payment_request_network'),
+            style: AppTypography.bodyMedium.copyWith(
+              color: context.colors.text.secondary,
+            ),
+          ),
+      ],
+    );
+    final summary = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        amount,
+        if (asset != null || !hasNetworkPicker) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          identity,
+        ],
+      ],
+    );
+    const iconSize = 48.0;
+    final icon = asset == null
+        ? null
+        : ExcludeSemantics(
+            child: SwapAssetIcon(
+              key: const ValueKey('payment_request_asset_icon'),
+              asset: asset,
+              size: iconSize,
+              badgeScale: 20 / iconSize,
+              overhangScale: 4 / iconSize,
+              showChainBadge: asset.symbol.toLowerCase() != asset.chainTicker,
+            ),
+          );
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.xs),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          if (icon == null) return summary;
+          final measure = TextPainter(
+            text: TextSpan(text: value, style: amountStyle),
+            textDirection: Directionality.of(context),
+            textScaler: MediaQuery.textScalerOf(context),
+          )..layout();
+          final stackAmount =
+              hasAmount &&
+              measure.width + iconSize + AppSpacing.sm > constraints.maxWidth;
+          measure.dispose();
+          // Give long exact amounts the full card width instead of shrinking
+          // their digits or leaving the final digit beside the icon alone.
+          if (stackAmount) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    icon,
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(child: identity),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                amount,
+              ],
+            );
+          }
+          return Row(
+            children: [
+              icon,
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(child: summary),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _networkPicker(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      const SizedBox(height: AppSpacing.sm),
+      DecoratedBox(
+        position: DecorationPosition.foreground,
+        decoration: ShapeDecoration(
+          shape: StadiumBorder(
+            side: widget.selectedChain == null || widget.isPreparingReview
+                ? BorderSide.none
+                : BorderSide(color: context.colors.border.strong),
+          ),
+        ),
+        child: _disclosureButton(
+          key: const ValueKey('payment_request_select_network'),
+          label: _networkLabel,
+          expanded: _networkPickerExpanded,
+          variant: AppButtonVariant.secondary,
+          onPressed: widget.isPreparingReview
+              ? null
+              : () => setState(
+                  () => _networkPickerExpanded = !_networkPickerExpanded,
+                ),
+        ),
+      ),
+      if (widget.selectedChain != null) ...[
+        const SizedBox(height: AppSpacing.xxs),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          child: Text(
+            'Selected by you',
+            style: AppTypography.bodySmall.copyWith(
+              color: context.colors.text.secondary,
+            ),
+          ),
+        ),
+      ],
+      if (_networkPickerExpanded) ...[
+        const SizedBox(height: AppSpacing.xs),
+        Wrap(
+          spacing: AppSpacing.xs,
+          runSpacing: AppSpacing.xs,
+          children: [
+            for (final network in evmPaymentNetworks.values)
+              Semantics(
+                selected: widget.selectedChain == network.chain,
+                child: AppButton(
+                  key: ValueKey('payment_network_${network.chain}'),
+                  onPressed: widget.isPreparingReview
+                      ? null
+                      : () {
+                          setState(() => _networkPickerExpanded = false);
+                          widget.onNetworkSelected(network.chain);
+                        },
+                  variant: widget.selectedChain == network.chain
+                      ? AppButtonVariant.primary
+                      : AppButtonVariant.secondary,
+                  size: AppButtonSize.medium,
+                  height: widget.isMobile ? 44 : null,
+                  child: Text(
+                    widget.request.contractAddress == null
+                        ? '${network.nativeSymbol} · ${network.label}'
+                        : network.label,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ],
+    ],
+  );
+
+  void _toggleAddress() => setState(() => _addressExpanded = !_addressExpanded);
+
+  Widget _recipient(BuildContext context) {
+    final recipient = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (_addressExpanded) ...[
+          FullAddressText(
+            address: widget.request.address,
+            color: context.colors.text.accent,
+          ),
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: _addressAction(context),
+          ),
+        ] else
+          Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: AppSpacing.xxs,
+            children: [
+              Text(
+                truncatedAddress(widget.request.address),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.codeMedium.copyWith(
+                  color: context.colors.text.accent,
+                ),
+              ),
+              _addressAction(context),
+            ],
+          ),
+      ],
+    );
+    return _Detail(
+      label: 'To',
+      // Match ZEC requests: a compact pill with the recipient block tappable.
+      child: widget.isMobile
+          ? GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              excludeFromSemantics: true,
+              onTap: _toggleAddress,
+              child: recipient,
+            )
+          : recipient,
+    );
+  }
+
+  Widget _addressAction(BuildContext context) {
+    final label = _addressExpanded ? 'Hide full address' : 'Show full address';
+    final usesLargeText = MediaQuery.textScalerOf(context).scale(1) >= 1.5;
+    final visibleLabel = usesLargeText
+        ? (_addressExpanded ? 'Hide' : 'Show')
+        : label;
+    return Semantics(
+      button: true,
+      label: label,
+      onTap: _toggleAddress,
+      excludeSemantics: true,
+      child: MediaQuery.withClampedTextScaling(
+        maxScaleFactor: 1.5,
+        child: AppButton(
+          key: const ValueKey('payment_request_show_address'),
+          onPressed: _toggleAddress,
+          variant: AppButtonVariant.ghost,
+          size: AppButtonSize.small,
+          iconGap: 0,
+          leading: usesLargeText
+              ? null
+              : AppIcon(
+                  _addressExpanded ? AppIcons.eyeClosed : AppIcons.eye,
+                  color: context.colors.button.ghost.label,
+                ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+            child: Text(
+              visibleLabel,
+              maxLines: 1,
+              style: AppTypography.labelSmall,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _disclosureButton({
+    required Key key,
+    required String label,
+    required bool expanded,
+    required VoidCallback? onPressed,
+    AppButtonVariant variant = AppButtonVariant.ghost,
+  }) => Semantics(
+    expanded: expanded,
+    child: AppButton(
+      key: key,
+      onPressed: onPressed,
+      variant: variant,
+      size: AppButtonSize.medium,
+      height: widget.isMobile ? 44 : null,
+      expand: true,
+      constrainContent: true,
+      child: Row(
+        children: [
+          Expanded(child: Text(label)),
+          const SizedBox(width: AppSpacing.xs),
+          RotatedBox(
+            quarterTurns: expanded ? 3 : 1,
+            child: AppIcon(
+              AppIcons.chevronForward,
+              size: AppIconSize.medium,
+              color: context.colors.icon.regular,
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _Detail extends StatelessWidget {
+  const _Detail({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        label,
+        style: AppTypography.bodyMedium.copyWith(
+          color: context.colors.text.secondary,
+        ),
+      ),
+      const SizedBox(height: AppSpacing.xxs),
+      child,
+    ],
+  );
+}

--- a/lib/src/features/send/widgets/payment_request_card.dart
+++ b/lib/src/features/send/widgets/payment_request_card.dart
@@ -664,7 +664,7 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
             ],
             if (request.hasRequesterDetails) ...[
               SizedBox(height: sectionGap),
-              _RequesterDetailsCard(
+              PaymentRequestRequesterDetailsCard(
                 requester: request.displayRequesterLabel,
                 note: request.displayNote,
                 expanded: _requesterExpanded,
@@ -753,17 +753,18 @@ class _PaymentRequestCardState extends State<PaymentRequestCard> {
   }
 }
 
-/// Off-chain metadata supplied by the payment link's requester.
+/// Off-chain metadata shared by ZEC and cross-chain payment request cards.
 ///
 /// The name remains visible as the collapsed summary. A requester note is
 /// progressive disclosure because it is context for the request, not content
 /// that will be included in the Zcash transaction.
-class _RequesterDetailsCard extends StatelessWidget {
-  const _RequesterDetailsCard({
+class PaymentRequestRequesterDetailsCard extends StatelessWidget {
+  const PaymentRequestRequesterDetailsCard({
     required this.requester,
     required this.note,
     required this.expanded,
     required this.onToggle,
+    super.key,
   });
 
   final String? requester;

--- a/lib/src/features/send/widgets/payment_request_surface.dart
+++ b/lib/src/features/send/widgets/payment_request_surface.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' show BottomSheet, Material, MaterialType;
+import 'package:flutter/material.dart' show Material, MaterialType;
 import 'package:flutter/widgets.dart';
 
 import '../../../core/layout/app_form_factor.dart';
@@ -6,6 +6,7 @@ import '../../../core/layout/content_overlay_inset.dart';
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_modal_card.dart';
+import '../../../core/widgets/app_modal_overlay_scope.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import 'payment_request_card.dart';
 
@@ -112,7 +113,7 @@ class PaymentRequestSurface extends StatelessWidget {
       ),
     );
 
-    final modal = _ModalOverlayScope(
+    final modal = AppModalOverlayScope(
       child: _isMobile
           ? _mobileModal(context, card)
           : _desktopModal(context, card),
@@ -151,7 +152,7 @@ class PaymentRequestSurface extends StatelessWidget {
           minimum: const EdgeInsets.only(top: AppSpacing.base),
           child: Align(
             alignment: Alignment.bottomCenter,
-            child: _DraggablePaymentRequestSheet(
+            child: AppDraggableMobileSheet(
               key: cardKey,
               onDismiss: onCancel,
               child: MobileModalCard(
@@ -180,102 +181,6 @@ class PaymentRequestSurface extends StatelessWidget {
       ),
     );
   }
-}
-
-/// The app-level host has no sheet route to supply drag motion or dismissal.
-/// Keep Flutter's bottom-sheet gesture thresholds and animate the inline card
-/// with the same controller. Keying this by request also prevents a closing
-/// animation from dismissing a replacement request.
-class _DraggablePaymentRequestSheet extends StatefulWidget {
-  const _DraggablePaymentRequestSheet({
-    required this.onDismiss,
-    required this.child,
-    super.key,
-  });
-
-  final VoidCallback onDismiss;
-  final Widget child;
-
-  @override
-  State<_DraggablePaymentRequestSheet> createState() =>
-      _DraggablePaymentRequestSheetState();
-}
-
-class _DraggablePaymentRequestSheetState
-    extends State<_DraggablePaymentRequestSheet>
-    with SingleTickerProviderStateMixin {
-  late final _controller = BottomSheet.createAnimationController(this)
-    ..value = 1;
-  late final _position = Tween<Offset>(
-    begin: const Offset(0, 1),
-    end: Offset.zero,
-  ).animate(_controller);
-  bool _closing = false;
-
-  void _dismiss() {
-    if (_closing) return;
-    setState(() => _closing = true);
-    _controller.reverse().then((_) {
-      if (mounted) widget.onDismiss();
-    });
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SlideTransition(
-      position: _position,
-      child: IgnorePointer(
-        ignoring: _closing,
-        child: BottomSheet(
-          animationController: _controller,
-          onClosing: _dismiss,
-          showDragHandle: false,
-          backgroundColor: const Color(0x00000000),
-          elevation: 0,
-          builder: (_) => widget.child,
-        ),
-      ),
-    );
-  }
-}
-
-/// Gives the scrim-and-card branch an [Overlay] ancestor.
-///
-/// The live host mounts this surface from `MaterialApp.router`'s `builder`,
-/// above the `Router` — so there is no `Navigator`, and therefore no
-/// `Overlay`, anywhere above the card. The requester help tooltip needs one,
-/// for the same reason the card needs its transparent [Material].
-///
-/// Only the modal branch goes inside. The background stays where it was in
-/// the outer stack, so the app underneath is not re-parented.
-class _ModalOverlayScope extends StatefulWidget {
-  const _ModalOverlayScope({required this.child});
-
-  final Widget child;
-
-  @override
-  State<_ModalOverlayScope> createState() => _ModalOverlayScopeState();
-}
-
-class _ModalOverlayScopeState extends State<_ModalOverlayScope> {
-  // `initialEntries` is read once, so the entry has to read `widget.child`
-  // at build time and be told when a new request replaces it.
-  late final OverlayEntry _entry = OverlayEntry(builder: (_) => widget.child);
-
-  @override
-  void didUpdateWidget(covariant _ModalOverlayScope oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.child, widget.child)) _entry.markNeedsBuild();
-  }
-
-  @override
-  Widget build(BuildContext context) => Overlay(initialEntries: [_entry]);
 }
 
 /// The mobile sheet body: the app's shared modal chrome around the card.

--- a/lib/src/features/swap/widgets/swap_slippage_modal.dart
+++ b/lib/src/features/swap/widgets/swap_slippage_modal.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_modal_card.dart';
 import '../../../core/widgets/comma_to_dot_input_formatter.dart';
@@ -13,6 +14,7 @@ class SwapSlippageModal extends StatefulWidget {
     required this.slippageBps,
     required this.onSubmitted,
     required this.onCancel,
+    this.onBack,
     this.initialCustomText,
     this.paymentMode = false,
     super.key,
@@ -21,6 +23,7 @@ class SwapSlippageModal extends StatefulWidget {
   final int slippageBps;
   final ValueChanged<int> onSubmitted;
   final VoidCallback onCancel;
+  final VoidCallback? onBack;
   final String? initialCustomText;
   final bool paymentMode;
 
@@ -131,7 +134,7 @@ class _SwapSlippageModalState extends State<SwapSlippageModal> {
     final selectedBps = _selectedBps;
     final canSubmit = selectedBps != null;
 
-    return AppModalCard(
+    final card = AppModalCard(
       key: const ValueKey('swap_slippage_modal'),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -197,6 +200,39 @@ class _SwapSlippageModalState extends State<SwapSlippageModal> {
                 : null,
             onCancel: widget.onCancel,
           ),
+        ],
+      ),
+    );
+    if (widget.onBack == null) return card;
+
+    return SizedBox(
+      width: kAppModalCardWidth,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: AppButton(
+              key: const ValueKey('swap_slippage_back_button'),
+              variant: AppButtonVariant.secondary,
+              minWidth: kAppModalButtonHeight,
+              height: kAppModalButtonHeight,
+              contentPadding: EdgeInsets.zero,
+              enabledBackgroundColor: colors.background.base,
+              onPressed: widget.onBack,
+              child: Semantics(
+                label: 'Back',
+                child: AppIcon(
+                  AppIcons.arrowBack,
+                  size: 16,
+                  color: colors.icon.accent,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          card,
         ],
       ),
     );

--- a/lib/widgetbook/cross_chain_payment_request_use_cases.dart
+++ b/lib/widgetbook/cross_chain_payment_request_use_cases.dart
@@ -1,0 +1,436 @@
+import 'package:flutter/material.dart' show Material, MaterialType;
+import 'package:flutter/widgets.dart';
+
+import '../src/core/layout/app_form_factor.dart';
+import '../src/core/layout/mobile/app_mobile_sheet.dart';
+import '../src/core/payments/cross_chain_payment_request.dart';
+import '../src/core/theme/app_theme.dart';
+import '../src/core/widgets/app_modal_card.dart';
+import '../src/core/widgets/app_modal_overlay_scope.dart';
+import '../src/core/widgets/app_pane_modal_overlay.dart';
+import '../src/features/pay/models/payment_request_resolution.dart';
+import '../src/features/pay/widgets/cross_chain_payment_request_card.dart';
+import '../src/features/swap/domain/swap_asset.dart';
+import '../src/features/swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart';
+import '../src/features/swap/widgets/swap_slippage_modal.dart';
+
+const _evmRecipient = '0x52908400098527886E0F7030069857D2E4169EE7';
+const _bitcoinRecipient = '1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo';
+const _litecoinRecipient = 'LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA';
+const _solanaRecipient = 'mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN';
+const _baseUsdc = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const _ethereumUsdc = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const _solanaUsdc = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+/// Offline request and asset metadata. The production resolver and card render
+/// these examples without wallet storage, a Rust runtime, or pricing requests.
+class CrossChainPaymentRequestExample {
+  const CrossChainPaymentRequestExample({
+    required this.id,
+    required this.name,
+    required this.request,
+    required this.assets,
+  });
+
+  final String id;
+  final String name;
+  final CrossChainPaymentRequest request;
+  final List<SwapAsset> assets;
+}
+
+final crossChainPaymentRequestExamples = <CrossChainPaymentRequestExample>[
+  _evmExample(chainId: '8453', contract: _baseUsdc),
+  _evmExample(chainId: '1', contract: _ethereumUsdc),
+  _displayExample(
+    id: 'bitcoin',
+    name: 'Bitcoin - BTC',
+    scheme: 'bitcoin',
+    chain: 'btc',
+    symbol: 'BTC',
+    decimals: 8,
+    address: _bitcoinRecipient,
+    amount: '0.00123456',
+  ),
+  _displayExample(
+    id: 'litecoin',
+    name: 'Litecoin - LTC',
+    scheme: 'litecoin',
+    chain: 'ltc',
+    symbol: 'LTC',
+    decimals: 8,
+    address: _litecoinRecipient,
+    amount: '1.23456789',
+  ),
+  _displayExample(
+    id: 'solana-usdc',
+    name: 'Solana - USDC',
+    scheme: 'solana',
+    chain: 'sol',
+    symbol: 'USDC',
+    decimals: 6,
+    address: _solanaRecipient,
+    amount: '25',
+    contract: _solanaUsdc,
+  ),
+  _displayExample(
+    id: 'solana',
+    name: 'Solana - SOL',
+    scheme: 'solana',
+    chain: 'sol',
+    symbol: 'SOL',
+    decimals: 9,
+    address: _solanaRecipient,
+    amount: '0.125',
+  ),
+  for (final chainId in evmPaymentNetworks.keys) _evmExample(chainId: chainId),
+  _evmExample(chainId: '8453', includeAmount: false),
+  _evmExample(),
+  _evmExample(includeAmount: false),
+  _displayExample(
+    id: 'requester-details',
+    name: 'Requester details',
+    scheme: 'bitcoin',
+    chain: 'btc',
+    symbol: 'BTC',
+    decimals: 8,
+    address: _bitcoinRecipient,
+    amount: '0.000125',
+    label: 'Coffee corner',
+    message: 'Order 1042: two coffees and a pastry.',
+  ),
+  _displayExample(
+    id: 'requester-details-long',
+    name: 'Requester details - long message',
+    scheme: 'bitcoin',
+    chain: 'btc',
+    symbol: 'BTC',
+    decimals: 8,
+    address: _bitcoinRecipient,
+    amount: '0.00125',
+    label: 'Coffee corner catering - invoice 1042',
+    message:
+        'Invoice 1042 covers coffee, tea, pastries, and lunch for the team. '
+        'Delivery is scheduled for the morning of the event at the address '
+        'provided when the order was placed. The order includes vegetarian '
+        'options and individually packed desserts. '
+        'If the delivery time or the number of guests has changed, please '
+        'contact the shop before paying so the order can be updated. '
+        'Keep this invoice number when contacting us about the order.',
+  ),
+];
+
+CrossChainPaymentRequestExample _displayExample({
+  required String id,
+  required String name,
+  required String scheme,
+  required String chain,
+  required String symbol,
+  required int decimals,
+  required String address,
+  required String amount,
+  String? contract,
+  String? label,
+  String? message,
+}) => CrossChainPaymentRequestExample(
+  id: id,
+  name: name,
+  request: CrossChainPaymentRequest(
+    id: 'widgetbook-$id',
+    rawUri:
+        '$scheme:$address?amount=$amount'
+        '${contract == null ? '' : '&spl-token=$contract'}'
+        '${label == null ? '' : '&label=${Uri.encodeComponent(label)}'}'
+        '${message == null ? '' : '&message=${Uri.encodeComponent(message)}'}',
+    address: address,
+    isEvm: false,
+    chain: chain,
+    contractAddress: contract,
+    amount: PaymentRequestAmount.display(amount),
+    label: label,
+    message: message,
+  ),
+  assets: [
+    SwapAsset.live(
+      assetId: 'widgetbook:$id',
+      symbol: symbol,
+      blockchain: chain,
+      decimals: decimals,
+      contractAddress: contract,
+    ),
+  ],
+);
+
+CrossChainPaymentRequestExample _evmExample({
+  String? chainId,
+  String? contract,
+  bool includeAmount = true,
+}) {
+  final network = evmPaymentNetworks[chainId];
+  final symbol = contract == null ? network?.nativeSymbol ?? 'ETH' : 'USDC';
+  final id = network == null
+      ? 'choose-network${includeAmount ? '' : '-no-amount'}'
+      : '${network.chain}-${symbol.toLowerCase()}'
+            '${includeAmount ? '' : '-no-amount'}';
+  final atomicAmount = contract == null ? '10000000000000000' : '25000000';
+  final target = contract ?? _evmRecipient;
+  final suffix = contract == null ? '' : '/transfer?address=$_evmRecipient';
+  final amountQuery = !includeAmount
+      ? ''
+      : contract == null
+      ? '?value=$atomicAmount'
+      : '&uint256=$atomicAmount';
+  return CrossChainPaymentRequestExample(
+    id: id,
+    name: network == null
+        ? 'EVM - choose a network${includeAmount ? '' : ' - no amount'}'
+        : '${network.label} - $symbol'
+              '${includeAmount ? '' : ' - no amount'}',
+    request: CrossChainPaymentRequest(
+      id: 'widgetbook-$id',
+      rawUri:
+          'ethereum:$target${chainId == null ? '' : '@$chainId'}'
+          '$suffix$amountQuery',
+      address: _evmRecipient,
+      isEvm: true,
+      chainId: chainId,
+      contractAddress: contract,
+      amount: includeAmount
+          ? PaymentRequestAmount.atomicHex(
+              '0x${BigInt.parse(atomicAmount).toRadixString(16)}',
+            )
+          : null,
+    ),
+    assets: [
+      if (network != null)
+        SwapAsset.live(
+          assetId: 'widgetbook:$id',
+          symbol: symbol,
+          blockchain: network.chain,
+          decimals: contract == null ? 18 : 6,
+          contractAddress: contract,
+        )
+      else
+        for (final network in evmPaymentNetworks.values)
+          SwapAsset.live(
+            assetId: 'widgetbook:${network.chain}-native',
+            symbol: network.nativeSymbol,
+            blockchain: network.chain,
+            decimals: 18,
+          ),
+    ],
+  );
+}
+
+Widget buildCrossChainPaymentRequestUseCase(
+  BuildContext context,
+  CrossChainPaymentRequestExample example, {
+  required bool isMobile,
+  bool showSlippageSettings = false,
+}) => _RequestPreview(
+  key: ValueKey('${example.id}-$isMobile-$showSlippageSettings'),
+  example: example,
+  isMobile: isMobile,
+  initialSlippageOpen: showSlippageSettings,
+);
+
+Widget buildPaymentRequestSlippageUseCase(BuildContext context) =>
+    _capturePreview(context, 'base-usdc', showSlippageSettings: true);
+
+Widget buildPaymentRequestRequesterDetailsUseCase(BuildContext context) =>
+    _capturePreview(context, 'requester-details');
+
+Widget buildPaymentRequestLongRequesterDetailsUseCase(BuildContext context) =>
+    _capturePreview(context, 'requester-details-long');
+
+// Shared capture entry points select the tokens and shell of the compiled lane.
+Widget buildBaseUsdcPaymentRequestUseCase(BuildContext context) =>
+    _capturePreview(context, 'base-usdc');
+
+Widget buildBitcoinPaymentRequestUseCase(BuildContext context) =>
+    _capturePreview(context, 'bitcoin');
+
+Widget buildLitecoinPaymentRequestUseCase(BuildContext context) =>
+    _capturePreview(context, 'litecoin');
+
+Widget buildSolanaUsdcPaymentRequestUseCase(BuildContext context) =>
+    _capturePreview(context, 'solana-usdc');
+
+Widget _capturePreview(
+  BuildContext context,
+  String id, {
+  bool showSlippageSettings = false,
+}) => buildCrossChainPaymentRequestUseCase(
+  context,
+  crossChainPaymentRequestExamples.singleWhere((example) => example.id == id),
+  isMobile: kAppFormFactor == AppFormFactor.mobile,
+  showSlippageSettings: showSlippageSettings,
+);
+
+class _RequestPreview extends StatefulWidget {
+  const _RequestPreview({
+    required this.example,
+    required this.isMobile,
+    this.initialSlippageOpen = false,
+    super.key,
+  });
+
+  final CrossChainPaymentRequestExample example;
+  final bool isMobile;
+  final bool initialSlippageOpen;
+
+  @override
+  State<_RequestPreview> createState() => _RequestPreviewState();
+}
+
+class _RequestPreviewState extends State<_RequestPreview> {
+  String? _selectedChain;
+  int _slippageBps = 50;
+  late bool _editingSlippage = widget.initialSlippageOpen;
+  bool _dismissed = false;
+  bool _closingRequest = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final example = widget.example;
+    final mobile = widget.isMobile;
+    final size = mobile ? const Size(393, 852) : const Size(800, 720);
+    final resolution = resolveCrossChainPaymentRequest(
+      example.request,
+      example.assets,
+      selectedChain: _selectedChain,
+    );
+    void closeRequest() => setState(() => _dismissed = true);
+    void beginClosingRequest() {
+      if (!_closingRequest) setState(() => _closingRequest = true);
+    }
+
+    void dismissRequest() {
+      if (mobile) {
+        beginClosingRequest();
+      } else {
+        closeRequest();
+      }
+    }
+
+    // Fixed preview rates in external tokens per ZEC, not live market prices.
+    final rates = {
+      for (final asset in example.assets)
+        asset: switch (asset.symbol) {
+          'USDC' => 100.0,
+          'BTC' => 0.001,
+          'LTC' => 1.25,
+          'SOL' => 0.5,
+          'ETH' => 0.025,
+          'BNB' => 0.125,
+          'POL' => 500.0,
+          'OKB' => 1.0,
+          'AVAX' => 5.0,
+          _ => 0.0,
+        },
+    };
+    final card = Material(
+      type: MaterialType.transparency,
+      child: CrossChainPaymentRequestCard(
+        request: example.request,
+        resolution: resolution,
+        estimatedZecAmount: resolution.estimateZecAmount(rates),
+        selectedChain: _selectedChain,
+        isMobile: mobile,
+        slippageBps: _slippageBps,
+        onOpenSlippage: () => setState(() => _editingSlippage = true),
+        onNetworkSelected: (chain) => setState(() => _selectedChain = chain),
+        onContinue: () {},
+        onEdit: () {},
+        onCancel: dismissRequest,
+        onRetry: () {},
+      ),
+    );
+    void closeSlippage() => setState(() => _editingSlippage = false);
+    void updateSlippage(int bps) => setState(() {
+      _slippageBps = bps;
+      _editingSlippage = false;
+    });
+    final editor = !_editingSlippage
+        ? null
+        : Material(
+            type: MaterialType.transparency,
+            child: mobile
+                ? MobileSwapSlippageStepperModal(
+                    slippageBps: _slippageBps,
+                    paymentMode: true,
+                    onSubmitted: updateSlippage,
+                    onCancel: closeSlippage,
+                  )
+                : SwapSlippageModal(
+                    slippageBps: _slippageBps,
+                    paymentMode: true,
+                    onSubmitted: updateSlippage,
+                    onCancel: closeSlippage,
+                    onBack: closeSlippage,
+                  ),
+          );
+    final preview = SizedBox(
+      key: const ValueKey('cross_chain_payment_request_preview_frame'),
+      width: size.width,
+      height: size.height,
+      child: MediaQuery(
+        data: MediaQuery.of(context).copyWith(size: size),
+        child: ColoredBox(
+          color: context.colors.background.ground,
+          child: Stack(
+            children: [
+              if (!_dismissed)
+                AppModalOverlayScope(
+                  child: AppPaneModalOverlay(
+                    onDismiss: dismissRequest,
+                    alignment: mobile
+                        ? Alignment.bottomCenter
+                        : Alignment.center,
+                    child: mobile
+                        ? SafeArea(
+                            bottom: false,
+                            minimum: const EdgeInsets.only(
+                              top: AppSpacing.base,
+                            ),
+                            child: AppDraggableMobileSheet(
+                              key: ValueKey((
+                                example.request.id,
+                                _editingSlippage,
+                              )),
+                              dismissRequested: _closingRequest,
+                              onClosing: beginClosingRequest,
+                              onDismiss: closeRequest,
+                              child: MobileModalCard(
+                                onBack: _editingSlippage ? closeSlippage : null,
+                                child:
+                                    editor ??
+                                    Padding(
+                                      padding: const EdgeInsets.fromLTRB(
+                                        AppSpacing.sm,
+                                        AppSpacing.md,
+                                        AppSpacing.sm,
+                                        AppSpacing.base,
+                                      ),
+                                      child: card,
+                                    ),
+                              ),
+                            ),
+                          )
+                        : editor == null
+                        ? AppModalCard(width: 396, child: card)
+                        : SizedBox(width: 396, child: editor),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+    return Center(
+      // Keep the phone viewport intact when Widgetbook's canvas is shorter.
+      child: mobile
+          ? FittedBox(fit: BoxFit.scaleDown, child: preview)
+          : preview,
+    );
+  }
+}

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -14,6 +14,7 @@ import 'button_use_cases.dart';
 import 'carousel_use_cases.dart';
 import 'chip_use_cases.dart';
 import 'context_menu_use_cases.dart';
+import 'cross_chain_payment_request_use_cases.dart';
 import 'color_use_cases.dart';
 import 'icon_use_cases.dart';
 import 'keystone_use_cases.dart';
@@ -895,6 +896,56 @@ class WidgetbookApp extends StatelessWidget {
             WidgetbookFolder(
               name: 'Pay',
               children: [
+                WidgetbookComponent(
+                  name: 'Payment request card',
+                  useCases: [
+                    for (final example in crossChainPaymentRequestExamples)
+                      WidgetbookUseCase(
+                        name: example.name,
+                        builder: (context) =>
+                            buildCrossChainPaymentRequestUseCase(
+                              context,
+                              example,
+                              isMobile: false,
+                            ),
+                      ),
+                    WidgetbookUseCase(
+                      name: 'Slippage settings',
+                      builder: (context) =>
+                          buildCrossChainPaymentRequestUseCase(
+                            context,
+                            crossChainPaymentRequestExamples.first,
+                            isMobile: false,
+                            showSlippageSettings: true,
+                          ),
+                    ),
+                  ],
+                ),
+                WidgetbookComponent(
+                  name: 'Mobile payment request card',
+                  useCases: [
+                    for (final example in crossChainPaymentRequestExamples)
+                      WidgetbookUseCase(
+                        name: example.name,
+                        builder: (context) =>
+                            buildCrossChainPaymentRequestUseCase(
+                              context,
+                              example,
+                              isMobile: true,
+                            ),
+                      ),
+                    WidgetbookUseCase(
+                      name: 'Slippage settings',
+                      builder: (context) =>
+                          buildCrossChainPaymentRequestUseCase(
+                            context,
+                            crossChainPaymentRequestExamples.first,
+                            isMobile: true,
+                            showSlippageSettings: true,
+                          ),
+                    ),
+                  ],
+                ),
                 WidgetbookComponent(
                   name: 'Desktop wizard',
                   useCases: [

--- a/test/features/pay/cross_chain_payment_request_card_test.dart
+++ b/test/features/pay/cross_chain_payment_request_card_test.dart
@@ -1,0 +1,3 @@
+import 'cross_chain_payment_request_card_test_support.dart';
+
+void main() => runCrossChainPaymentRequestCardTests(isMobile: false);

--- a/test/features/pay/cross_chain_payment_request_card_test_support.dart
+++ b/test/features/pay/cross_chain_payment_request_card_test_support.dart
@@ -1,0 +1,672 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart' show Material, MaterialApp;
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/formatting/address_display.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_modal_card.dart';
+import 'package:zcash_wallet/src/core/widgets/review_list_row.dart'
+    show kPaymentRequestRequesterTooltip;
+import 'package:zcash_wallet/src/features/send/widgets/payment_request_card.dart'
+    show kPaymentRequestRequesterNoteScrollViewKey;
+import 'package:zcash_wallet/src/features/pay/models/payment_request_resolution.dart';
+import 'package:zcash_wallet/src/features/pay/widgets/cross_chain_payment_request_card.dart';
+import 'package:zcash_wallet/src/features/swap/domain/swap_asset.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/swap_asset_icon.dart';
+
+import '../../figma_compare/figma_compare_font_loader.dart';
+
+const _recipient = '0x52908400098527886E0F7030069857D2E4169EE7';
+const _contract = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const _continueKey = ValueKey('cross_chain_payment_request_continue');
+const _cancelKey = ValueKey('cross_chain_payment_request_cancel');
+const _editKey = ValueKey('cross_chain_payment_request_edit');
+const _captureKey = ValueKey('cross_chain_card_capture');
+final _baseUsdc = SwapAsset.live(
+  assetId: 'base-usdc',
+  symbol: 'USDC',
+  blockchain: 'base',
+  decimals: 6,
+  contractAddress: _contract,
+);
+
+void runCrossChainPaymentRequestCardTests({required bool isMobile}) {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(loadFigmaCompareFonts);
+
+  Future<void> pump(
+    WidgetTester tester, {
+    CrossChainPaymentRequest? request,
+    PaymentRequestResolution? resolution,
+    VoidCallback? onContinue,
+    VoidCallback? onCancel,
+    VoidCallback? onRetry,
+    VoidCallback? onEdit,
+    ValueChanged<String>? onNetworkSelected,
+    String? selectedChain,
+    String? availabilityMessage,
+    double? estimatedZecAmount = 0.25,
+    int? slippageBps = 50,
+    VoidCallback? onOpenSlippage,
+    bool isLoading = false,
+    bool isPreparingReview = false,
+    Size? viewport,
+    AppThemeData theme = AppThemeData.dark,
+  }) async {
+    tester.view.physicalSize =
+        viewport ?? (isMobile ? const Size(360, 740) : const Size(600, 800));
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: theme,
+          child: Material(
+            color: theme.colors.background.ground,
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                child: RepaintBoundary(
+                  key: _captureKey,
+                  child: AppModalCard(
+                    width: isMobile ? 360 : 396,
+                    child: CrossChainPaymentRequestCard(
+                      request: request ?? _request(),
+                      resolution:
+                          resolution ??
+                          PaymentRequestResolution(
+                            asset: _baseUsdc,
+                            amountText: '25',
+                          ),
+                      onContinue: onContinue ?? () {},
+                      onCancel: onCancel ?? () {},
+                      onRetry: onRetry ?? () {},
+                      onEdit: onEdit ?? () {},
+                      onNetworkSelected: onNetworkSelected ?? (_) {},
+                      selectedChain: selectedChain,
+                      availabilityMessage: availabilityMessage,
+                      estimatedZecAmount: estimatedZecAmount,
+                      slippageBps: slippageBps,
+                      onOpenSlippage: onOpenSlippage ?? () {},
+                      isLoading: isLoading,
+                      isPreparingReview: isPreparingReview,
+                      isMobile: isMobile,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('reviews exact recipient amount and network before continuing', (
+    tester,
+  ) async {
+    var continued = 0;
+    var cancelled = 0;
+    var openedSlippage = 0;
+    await pump(
+      tester,
+      onContinue: () => continued++,
+      onCancel: () => cancelled++,
+      onOpenSlippage: () => openedSlippage++,
+    );
+
+    expect(find.text('Payment request'), findsOneWidget);
+    expect(find.text('Recipient gets'), findsOneWidget);
+    expect(find.text('25'), findsOneWidget);
+    expect(find.text('USDC'), findsOneWidget);
+    expect(find.text('Base'), findsOneWidget);
+    expect(find.text('Selected by you'), findsNothing);
+    expect(find.text('Pay with ZEC'), findsNothing);
+    expect(find.text('Review payment'), findsOneWidget);
+    expect(find.text('Slippage'), findsOneWidget);
+    expect(find.text('0.5%'), findsOneWidget);
+    await tester.tap(
+      find.byKey(const ValueKey('cross_chain_payment_request_slippage')),
+    );
+    expect(openedSlippage, 1);
+    expect(find.text('Estimated spend'), findsOneWidget);
+    expect(find.text('≈ 0.2500 ZEC'), findsOneWidget);
+    expect(
+      find.text('Before fees. Actual payment may be higher.'),
+      findsNothing,
+    );
+    expect(find.text('Cancel'), findsNothing);
+    expect(find.text(_contract), findsNothing);
+    expect(find.text('Token details'), findsNothing);
+    expect(find.text(_recipient), findsNothing);
+    if (isMobile) {
+      await tester.tap(find.text(truncatedAddress(_recipient)));
+      await tester.pumpAndSettle();
+      expect(find.text(_recipient), findsOneWidget);
+      await tester.tap(find.text('Hide full address'));
+      await tester.pumpAndSettle();
+      expect(find.text(_recipient), findsNothing);
+    }
+    await tester.tap(find.text('Show full address'));
+    await tester.pumpAndSettle();
+    expect(find.text(_recipient), findsOneWidget);
+    await tester.tap(find.byKey(_continueKey));
+    expect(continued, 1);
+    await tester.tap(find.byKey(_cancelKey));
+    expect(cancelled, 1);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('amountless requests lead to entering an amount', (tester) async {
+    var continued = false;
+    await pump(
+      tester,
+      request: _request(includeAmount: false),
+      resolution: PaymentRequestResolution(asset: _baseUsdc),
+      onContinue: () => continued = true,
+    );
+    expect(find.text('Amount not specified'), findsOneWidget);
+    expect(find.text('Enter amount'), findsOneWidget);
+    expect(find.text('Estimated spend'), findsNothing);
+    expect(find.text('USDC'), findsOneWidget);
+    expect(find.byKey(_editKey), findsNothing);
+    await _capture(tester, isMobile: isMobile, state: 'no-amount');
+    await tester.tap(find.byKey(_continueKey));
+    expect(continued, isTrue);
+  });
+
+  testWidgets(
+    'missing prices hide the estimate and tiny costs never show zero',
+    (tester) async {
+      await pump(tester, estimatedZecAmount: null);
+      expect(find.text('Estimated spend'), findsNothing);
+      expect(_primary(tester).onPressed, isNotNull);
+      await pump(tester, estimatedZecAmount: 0.000001);
+      expect(find.text('< 0.0001 ZEC'), findsOneWidget);
+      expect(find.text('≈ 0.0000 ZEC'), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('requires an explicit missing network and hides atomic amounts', (
+    tester,
+  ) async {
+    String? selected;
+    await pump(
+      tester,
+      request: _request(chainId: null),
+      resolution: const PaymentRequestResolution(
+        needsNetwork: true,
+        message: 'Select the receiving network to see the payment amount.',
+      ),
+      onNetworkSelected: (chain) => selected = chain,
+    );
+    expect(find.text('Select network'), findsOneWidget);
+    expect(find.text('Selected by you'), findsNothing);
+    expect(find.text('Network not specified'), findsOneWidget);
+    expect(find.textContaining('25000000'), findsNothing);
+    expect(_primary(tester).onPressed, isNull);
+    expect(
+      find.byKey(const ValueKey('payment_request_asset_icon')),
+      findsNothing,
+    );
+    expect(find.byKey(const ValueKey('payment_network_base')), findsNothing);
+    await _capture(tester, isMobile: isMobile, state: 'choose-network');
+    await tester.tap(
+      find.byKey(const ValueKey('payment_request_select_network')),
+    );
+    await tester.pumpAndSettle();
+    for (final network in evmPaymentNetworks.values) {
+      final button = tester.widget<AppButton>(
+        find.byKey(ValueKey('payment_network_${network.chain}')),
+      );
+      expect(button.variant, AppButtonVariant.secondary);
+      expect(
+        find.text('${network.nativeSymbol} · ${network.label}'),
+        findsNothing,
+      );
+    }
+    await _capture(tester, isMobile: isMobile, state: 'network-options');
+    await tester.tap(find.byKey(const ValueKey('payment_network_base')));
+    expect(selected, 'base');
+
+    await pump(
+      tester,
+      request: _request(chainId: null),
+      selectedChain: selected,
+    );
+    expect(find.text('25'), findsOneWidget);
+    expect(_primary(tester).onPressed, isNotNull);
+    expect(find.byKey(const ValueKey('payment_network_base')), findsNothing);
+    expect(find.text('Selected by you'), findsOneWidget);
+    await _capture(tester, isMobile: isMobile, state: 'network-selected');
+    await tester.tap(
+      find.byKey(const ValueKey('payment_request_select_network')),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .widget<AppButton>(find.byKey(const ValueKey('payment_network_base')))
+          .variant,
+      AppButtonVariant.primary,
+    );
+
+    final nativeRequest = CrossChainPaymentRequest(
+      id: 'native-network-request',
+      rawUri: 'ethereum:$_recipient?value=10000000000000000',
+      address: _recipient,
+      isEvm: true,
+      amount: PaymentRequestAmount.atomicHex('0x2386f26fc10000'),
+    );
+    final nativeAssets = [
+      for (final network in evmPaymentNetworks.values)
+        SwapAsset.live(
+          assetId: 'native-${network.chain}',
+          symbol: network.nativeSymbol,
+          blockchain: network.chain,
+          decimals: 18,
+        ),
+    ];
+    selected = null;
+    await pump(
+      tester,
+      request: nativeRequest,
+      resolution: resolveCrossChainPaymentRequest(nativeRequest, nativeAssets),
+      onNetworkSelected: (chain) => selected = chain,
+    );
+    expect(_primary(tester).onPressed, isNull);
+    await tester.tap(
+      find.byKey(const ValueKey('payment_request_select_network')),
+    );
+    await tester.pumpAndSettle();
+    for (final network in evmPaymentNetworks.values) {
+      expect(
+        find.text('${network.nativeSymbol} · ${network.label}'),
+        findsOneWidget,
+      );
+    }
+    await _capture(tester, isMobile: isMobile, state: 'native-network-options');
+    await tester.tap(find.byKey(const ValueKey('payment_network_bsc')));
+    expect(selected, 'bsc');
+    await pump(
+      tester,
+      request: nativeRequest,
+      selectedChain: selected,
+      resolution: resolveCrossChainPaymentRequest(
+        nativeRequest,
+        nativeAssets,
+        selectedChain: selected,
+      ),
+    );
+    expect(find.text('0.01'), findsOneWidget);
+    expect(find.text('BNB'), findsOneWidget);
+    expect(find.text('BNB Chain'), findsOneWidget);
+    expect(find.text('USDC'), findsNothing);
+    expect(find.text('Network not specified'), findsNothing);
+    expect(_primary(tester).onPressed, isNotNull);
+    await _capture(
+      tester,
+      isMobile: isMobile,
+      state: 'native-network-selected',
+    );
+    await pump(
+      tester,
+      request: nativeRequest,
+      selectedChain: selected,
+      resolution: resolveCrossChainPaymentRequest(
+        nativeRequest,
+        nativeAssets,
+        selectedChain: selected,
+      ),
+      theme: AppThemeData.light,
+    );
+    await _capture(
+      tester,
+      isMobile: isMobile,
+      state: 'native-network-selected-light',
+    );
+  });
+
+  testWidgets('unsupported requests cannot continue or become raw addresses', (
+    tester,
+  ) async {
+    const reason =
+        'This request needs tracking details that Vizor cannot send.';
+    const uri = 'solana:https://merchant.example/transaction';
+    await pump(
+      tester,
+      request: const CrossChainPaymentRequest(
+        id: 'unsupported',
+        rawUri: uri,
+        address: '',
+        isEvm: false,
+        chain: 'sol',
+        unsupportedReason: reason,
+      ),
+      resolution: const PaymentRequestResolution(message: reason),
+    );
+    expect(find.text(reason), findsOneWidget);
+    expect(find.text('Solana'), findsOneWidget);
+    expect(find.text(uri), findsNothing);
+    expect(find.text('To'), findsNothing);
+    expect(find.text('Pay with ZEC'), findsNothing);
+    expect(find.text('Estimated spend'), findsNothing);
+    expect(_primary(tester).onPressed, isNull);
+    await _capture(tester, isMobile: isMobile, state: 'unsupported');
+  });
+
+  testWidgets('loading preserves request details and blocks continuing', (
+    tester,
+  ) async {
+    await pump(tester, isLoading: true);
+    expect(find.text('25'), findsOneWidget);
+    expect(find.text('Checking payment options…'), findsOneWidget);
+    expect(find.text('Checking…'), findsOneWidget);
+    expect(
+      tester
+          .widget<AppButton>(
+            find.byKey(const ValueKey('cross_chain_payment_request_slippage')),
+          )
+          .onPressed,
+      isNull,
+    );
+    expect(find.text('Estimated spend'), findsNothing);
+    expect(_primary(tester).onPressed, isNull);
+  });
+
+  testWidgets('lookup failure offers retry instead of continuing', (
+    tester,
+  ) async {
+    var continued = 0;
+    var retried = 0;
+    await pump(
+      tester,
+      availabilityMessage: 'Could not load payment assets. Try again.',
+      onContinue: () => continued++,
+      onRetry: () => retried++,
+    );
+    expect(find.text('25'), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+    await tester.tap(find.byKey(_continueKey));
+    expect(retried, 1);
+    expect(continued, 0);
+  });
+
+  testWidgets('preparing a review disables Review and Edit but allows Cancel', (
+    tester,
+  ) async {
+    var cancelled = false;
+    await pump(
+      tester,
+      request: _request(chainId: null),
+      selectedChain: 'base',
+      isPreparingReview: true,
+      onCancel: () => cancelled = true,
+    );
+    expect(find.text('Preparing payment review…'), findsOneWidget);
+    expect(find.text('Preparing…'), findsOneWidget);
+    expect(_primary(tester).onPressed, isNull);
+    expect(tester.widget<AppButton>(find.byKey(_editKey)).onPressed, isNull);
+    expect(
+      tester
+          .widget<AppButton>(
+            find.byKey(const ValueKey('payment_request_select_network')),
+          )
+          .onPressed,
+      isNull,
+    );
+    await tester.tap(find.byKey(_cancelKey));
+    expect(cancelled, isTrue);
+    await _capture(tester, isMobile: isMobile, state: 'preparing');
+  });
+
+  testWidgets('Edit remains available after a failed review', (tester) async {
+    var edited = false;
+    await pump(
+      tester,
+      availabilityMessage:
+          'Payment review could not be prepared. Try again or edit the payment.',
+      onEdit: () => edited = true,
+    );
+    expect(find.text('Try again'), findsOneWidget);
+    await tester.tap(find.byKey(_editKey));
+    expect(edited, isTrue);
+    await _capture(tester, isMobile: isMobile, state: 'review-failed');
+  });
+
+  testWidgets(
+    'long requester details stay separate and leave actions visible',
+    (tester) async {
+      final note = List.filled(50, 'Please pay this invoice.').join(' ');
+      await pump(
+        tester,
+        viewport: const Size(320, 600),
+        request: _request(label: 'Merchant supplied label', message: note),
+        availabilityMessage: 'Could not load payment assets. Try again.',
+      );
+      expect(find.text('Requester'), findsOneWidget);
+      expect(find.text('Merchant supplied label'), findsOneWidget);
+      expect(find.text(note), findsNothing);
+      expect(find.text(kPaymentRequestRequesterTooltip), findsNothing);
+      await tester.tap(
+        find.byKey(const ValueKey('payment_request_requester_help')),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text(kPaymentRequestRequesterTooltip), findsOneWidget);
+      expect(find.text(note), findsNothing);
+      await tester.ensureVisible(
+        find.byKey(const ValueKey('payment_request_requester_toggle')),
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('payment_request_requester_toggle')),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Note from requester'), findsOneWidget);
+      final noteScroll = tester.widget<SingleChildScrollView>(
+        find.byKey(kPaymentRequestRequesterNoteScrollViewKey),
+      );
+      expect(noteScroll.controller!.position.maxScrollExtent, greaterThan(0));
+      expect(tester.takeException(), isNull);
+      expect(tester.getRect(find.byKey(_continueKey)).bottom, lessThan(600));
+      expect(tester.getRect(find.byKey(_cancelKey)).bottom, lessThan(600));
+      expect(
+        tester
+            .getRect(
+              find.byKey(const ValueKey('cross_chain_payment_request_status')),
+            )
+            .bottom,
+        lessThan(tester.getRect(find.byKey(_continueKey)).top),
+      );
+      expect(find.text(note), findsOneWidget);
+      await _capture(tester, isMobile: isMobile, state: 'long-requester');
+    },
+  );
+
+  testWidgets('captures a representative reviewed request', (tester) async {
+    final mouse = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+    await mouse.addPointer(location: Offset.zero);
+    addTearDown(mouse.removePointer);
+    Future<void> captureHover(Key key, String state) async {
+      await mouse.moveTo(tester.getCenter(find.byKey(key)));
+      await tester.pumpAndSettle();
+      await _capture(tester, isMobile: isMobile, state: state);
+      await mouse.moveTo(Offset.zero);
+      await tester.pumpAndSettle();
+    }
+
+    await pump(tester);
+    await _capture(tester, isMobile: isMobile, state: 'ready');
+    await captureHover(
+      const ValueKey('payment_request_show_address'),
+      'address-hover',
+    );
+    await tester.tap(find.text('Show full address'));
+    await tester.pumpAndSettle();
+    await _capture(tester, isMobile: isMobile, state: 'address-expanded');
+    await captureHover(
+      const ValueKey('payment_request_show_address'),
+      'address-expanded-hover',
+    );
+    await tester.tap(find.text('Hide full address'));
+    await tester.pumpAndSettle();
+    await pump(tester, theme: AppThemeData.light);
+    await _capture(tester, isMobile: isMobile, state: 'ready-light');
+    await captureHover(
+      const ValueKey('payment_request_show_address'),
+      'address-hover-light',
+    );
+    await pump(
+      tester,
+      request: _request(label: 'Coffee corner', message: 'Order 1042'),
+    );
+    expect(tester.takeException(), isNull);
+    await _capture(tester, isMobile: isMobile, state: 'requester');
+    await captureHover(
+      const ValueKey('payment_request_requester_toggle'),
+      'requester-hover',
+    );
+    await pump(
+      tester,
+      request: _request(label: 'Coffee corner', message: 'Order 1042'),
+      theme: AppThemeData.light,
+    );
+    await _capture(tester, isMobile: isMobile, state: 'requester-light');
+  });
+
+  testWidgets('asset identity follows the resolved network and native asset', (
+    tester,
+  ) async {
+    await pump(tester);
+    final assetIconFinder = find.byKey(
+      const ValueKey('payment_request_asset_icon'),
+    );
+    final baseIcon = tester.widget<SwapAssetIcon>(assetIconFinder);
+    expect(baseIcon.asset, _baseUsdc);
+    expect(baseIcon.showChainBadge, isTrue);
+
+    const mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    final solUsdc = SwapAsset.live(
+      assetId: 'sol-usdc',
+      symbol: 'USDC',
+      blockchain: 'sol',
+      decimals: 6,
+      contractAddress: mint,
+    );
+    await pump(
+      tester,
+      request: CrossChainPaymentRequest(
+        id: 'sol-request',
+        rawUri: 'solana:recipient?amount=25&spl-token=$mint',
+        address: 'So11111111111111111111111111111111111111112',
+        isEvm: false,
+        chain: 'sol',
+        contractAddress: mint,
+        amount: PaymentRequestAmount.display('25'),
+      ),
+      resolution: PaymentRequestResolution(asset: solUsdc, amountText: '25'),
+    );
+    expect(tester.widget<SwapAssetIcon>(assetIconFinder).asset, solUsdc);
+    expect(find.text('USDC'), findsOneWidget);
+    expect(find.text('Solana'), findsOneWidget);
+    expect(find.text('Base'), findsNothing);
+    await _capture(tester, isMobile: isMobile, state: 'solana-usdc');
+    expect(find.text('Token details'), findsNothing);
+    expect(find.text(mint), findsNothing);
+
+    await pump(
+      tester,
+      viewport: const Size(320, 600),
+      request: CrossChainPaymentRequest(
+        id: 'btc-request',
+        rawUri: 'bitcoin:recipient?amount=0.00123456',
+        address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+        isEvm: false,
+        chain: 'btc',
+        amount: PaymentRequestAmount.display('0.00123456'),
+      ),
+      resolution: const PaymentRequestResolution(
+        asset: SwapAsset.btc,
+        amountText: '0.00123456',
+      ),
+      estimatedZecAmount: 1.23456,
+    );
+    expect(find.text('0.00123456'), findsOneWidget);
+    expect(find.text('BTC'), findsOneWidget);
+    expect(find.text('Bitcoin'), findsOneWidget);
+    expect(
+      tester.widget<SwapAssetIcon>(assetIconFinder).showChainBadge,
+      isFalse,
+    );
+    expect(
+      find.byKey(const ValueKey('payment_request_show_token')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+    await _capture(tester, isMobile: isMobile, state: 'bitcoin-narrow');
+  });
+}
+
+Future<void> _capture(
+  WidgetTester tester, {
+  required bool isMobile,
+  required String state,
+}) async {
+  const captureDirectory = String.fromEnvironment('VIZOR_CAPTURE_DIR');
+  if (captureDirectory.isEmpty) return;
+  final context = tester.element(find.byKey(_captureKey));
+  final imagePaths = <String>{
+    for (final icon in tester.widgetList<SwapAssetIcon>(
+      find.byType(SwapAssetIcon),
+    )) ...[
+      icon.asset.tokenIconAsset,
+      if (icon.showChainBadge) icon.asset.chainIconAsset,
+    ],
+  };
+  await tester.runAsync(() async {
+    await Future.wait([
+      for (final path in imagePaths) precacheImage(AssetImage(path), context),
+    ]);
+  });
+  await tester.pumpAndSettle();
+  await tester.runAsync(() async {
+    final boundary = tester.renderObject<RenderRepaintBoundary>(
+      find.byKey(_captureKey),
+    );
+    final image = await boundary.toImage(pixelRatio: 1);
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+    final file = File(
+      '$captureDirectory/cross-chain-payment-${isMobile ? 'mobile' : 'desktop'}-$state.png',
+    );
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(data!.buffer.asUint8List());
+    image.dispose();
+  });
+}
+
+AppButton _primary(WidgetTester tester) =>
+    tester.widget<AppButton>(find.byKey(_continueKey));
+
+CrossChainPaymentRequest _request({
+  String? chainId = '8453',
+  bool includeAmount = true,
+  String? label,
+  String? message,
+}) => CrossChainPaymentRequest(
+  id: 'request',
+  rawUri:
+      'ethereum:$_contract@8453/transfer?address=$_recipient&uint256=25000000',
+  address: _recipient,
+  isEvm: true,
+  chainId: chainId,
+  contractAddress: _contract,
+  amount: includeAmount ? PaymentRequestAmount.atomicHex('0x17d7840') : null,
+  label: label,
+  message: message,
+);

--- a/test/features/pay/mobile_cross_chain_payment_request_card_test.dart
+++ b/test/features/pay/mobile_cross_chain_payment_request_card_test.dart
@@ -1,0 +1,8 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'cross_chain_payment_request_card_test_support.dart';
+
+void main() => runCrossChainPaymentRequestCardTests(isMobile: true);

--- a/test/features/send/payment_request_host_test.dart
+++ b/test/features/send/payment_request_host_test.dart
@@ -457,7 +457,8 @@ void main() {
 
     expect(
       find.text(
-        "Name supplied by the payment link. Vizor can't verify who sent it.",
+        'The requester provided this name. '
+        "It may differ from the recipient's name.",
       ),
       findsOneWidget,
     );

--- a/test/widgetbook/payment_request_use_cases_test.dart
+++ b/test/widgetbook/payment_request_use_cases_test.dart
@@ -77,7 +77,8 @@ void main() {
 
     expect(
       find.text(
-        "Name supplied by the payment link. Vizor can't verify who sent it.",
+        'The requester provided this name. '
+        "It may differ from the recipient's name.",
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
Cross-chain requests need a reviewable card before entering the existing Pay flow. This PR adds the shared request content in a desktop modal and a mobile bottom sheet, with recipient asset/network/amount, expandable address and requester details, and a slippage editor.

This is **step 3 of 5** in draft integration PR #654, following merged #655 and #658. It targets `rowan/cross-chain-payments-integration`. The new card uses supplied state and callbacks and is available in deterministic Widgetbook/capture scenarios. The production request host, shared Dart URI intake, and Pay review routing are explicitly part of step 4; their absence here is the planned domain boundary. This PR is not intended for release independently.

## Implementation

- Adds `CrossChainPaymentRequestCard` with exact requested amounts, resolved token/network identity, an expandable recipient address, network selection when required, and blocked/loading/retry states. The primary action reflects whether the request can be reviewed or needs an amount.
- Shows an optional approximate ZEC spend estimate supplied by the caller; missing or invalid price data hides the estimate. This card does not fetch executable quotes or initiate payment.
- Reuses the ZEC requester-details component for an unverified requester name and an expandable note. Long notes have a bounded inner scroll area, and actions remain outside the scrolling card content. Updates the shared requester tooltip and its existing fixture/test expectations.
- Extracts the existing mobile request sheet into `AppDraggableMobileSheet` and reuses it from the ZEC request surface. Provides dismissal/closing hooks, blocks input while closing, and respects reduced motion. Adds `AppModalOverlayScope` for tooltips without moving the underlying router subtree.
- Adds optional Back controls to the existing slippage modal/sheet. The request preview keeps slippage local; Back/Cancel returns to the card, while dismissing the sheet closes the request.
- Adds desktop/mobile Widgetbook examples and registered captures for Base USDC, Bitcoin, Litecoin, Solana USDC, slippage, and requester details. Fixtures require no wallet storage, network connection, or Rust initialization.

## Review focus

1. Readable asset, network, recipient, and amount identity across supported, unspecified-network, and blocked states.
2. Stable actions and scrolling with long addresses/notes and narrow viewports.
3. Existing ZEC requester details and mobile sheet dismissal after the shared-component extraction.
4. Tooltip overlays and slippage Back/Cancel/outside-tap behavior without route changes or payment side effects.

## Validation

Validated the tree committed as `8e6bf98584`:

- Desktop: `fvm flutter test --no-pub test/features/pay/cross_chain_payment_request_card_test.dart test/features/send/payment_request_host_test.dart test/widgetbook/payment_request_use_cases_test.dart` — **78 passed**.
- Mobile: `fvm flutter test --no-pub --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/pay/mobile_cross_chain_payment_request_card_test.dart test/features/swap/mobile_swap_modal_route_test.dart test/features/send/mobile_send_scan_sheet_test.dart` — **31 passed**.
- `fvm flutter analyze --no-pub` scoped to all 15 changed Dart files — no issues.
- Four `scripts/figma-compare.sh widget` captures: desktop Base USDC/dark, desktop requester/light, mobile long-requester/dark, and mobile slippage/light. Inspected every resulting image.
- Re-ran the mobile long-requester test with `VIZOR_CAPTURE_DIR` to inspect the expanded note at 320×600. Verified inner note scrolling and visible action buttons; the test passed. This is an additional capture run of an already-counted regression test.
- `git diff --check` — passed.

The captures use the widget-test renderer with deterministic fixtures. No native app/device build or live URI-to-Pay check was performed for this UI PR; production intake and Pay lifecycle checks belong to step 4.
