### PR TITLE
Connect cross-chain payment requests to the Pay lifecycle

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -16,6 +16,11 @@ import 'src/core/navigation/mobile_exit_back_guard.dart';
 import 'src/core/navigation/mobile_onboarding_routes.dart';
 import 'src/core/navigation/mobile_routes.dart';
 import 'src/core/navigation/incoming_link_dispatch.dart';
+import 'src/core/navigation/payment_request_intake.dart';
+import 'src/core/navigation/present_payment_request.dart';
+import 'src/core/payments/cross_chain_payment_request.dart';
+import 'src/features/pay/providers/cross_chain_payment_request_provider.dart';
+import 'src/features/pay/widgets/cross_chain_payment_request_host.dart';
 import 'src/core/navigation/payment_uri_busy_surface_provider.dart';
 import 'src/core/navigation/payment_uri_drain_policy.dart';
 import 'src/core/navigation/payload_page_key.dart';
@@ -275,6 +280,10 @@ final _routerProvider = Provider<_AppRouter>((ref) {
     // to reach the card here or it would navigate — and on the second press
     // exit the app — underneath a modal the user is still looking at.
     handleBackAboveRouter: () {
+      if (ref.read(crossChainPaymentFlowProvider) != null) {
+        ref.read(crossChainPaymentFlowProvider.notifier).clear();
+        return true;
+      }
       if (ref.read(paymentRequestFlowProvider) == null) return false;
       ref.read(paymentRequestFlowProvider.notifier).dismiss();
       return true;
@@ -1046,8 +1055,18 @@ List<RouteBase> _desktopRoutes(Ref ref) => [
     builder: (_, state) {
       final args = state.extra;
       return PayScreen(
+        key: args is PayComposerNavigationArgs && args.paymentRequestId != null
+            ? ValueKey(args.paymentRequestId)
+            : null,
         preservePreparedComposer:
             args is PayComposerNavigationArgs && args.preservePreparedComposer,
+        paymentRequestId: args is PayComposerNavigationArgs
+            ? args.paymentRequestId
+            : null,
+        showPreparedReview:
+            args is PayComposerNavigationArgs && args.showPreparedReview,
+        reviewAfterAmount:
+            args is PayComposerNavigationArgs && args.reviewAfterAmount,
       );
     },
   ),
@@ -1269,9 +1288,12 @@ class ZcashWalletApp extends ConsumerWidget {
                                     // and the keep-awake hosts above it. The
                                     // link intake that feeds it lives further
                                     // up, in `_IncomingLinkHost`.
-                                    child: PaymentRequestHost(
+                                    child: CrossChainPaymentRequestHost(
                                       router: router,
-                                      child: child!,
+                                      child: PaymentRequestHost(
+                                        router: router,
+                                        child: child!,
+                                      ),
                                     ),
                                   ),
                                 ),
@@ -1351,7 +1373,7 @@ Widget buildIncomingLinkHostForTest({
 /// in the ZIP-321 rejection snackbar. `classifyIncomingLink` picks the lane;
 /// everything below is per-lane and unchanged from the two hosts this replaced:
 ///
-/// * **payment request** (`zcash:`) — parks in `paymentUriPrefillProvider` and
+/// * **payment request** (Zcash or cross-chain) — parks in `paymentUriPrefillProvider` and
 ///   drains through `decidePaymentUriDrain` into a card over the current
 ///   screen. Route-agnostic: it never navigates on delivery.
 /// * **gift card** (`https://` on the Vizor origin) — queues in
@@ -1388,7 +1410,6 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   bool _navigationScheduled = false;
 
   // --- payment request lane ---
-  var _paymentSequence = 0;
 
   /// Last wallet-existence value seen from [walletProvider]. Used to spot the
   /// true -> false transition of a wallet reset, which must drop a parked link
@@ -1449,14 +1470,16 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
           hasWallet: wallet.hasWallet,
         )) {
           // Wallet reset (uninstall, lost-password reset). Drop the parked
-          // ZIP-321 link quietly: draining it here would follow the wipe with
+          // payment request quietly: draining it here would follow the wipe with
           // a "Set up or import a wallet" notice and a jump to /welcome.
           //
-          // Only the ZIP-321 park and its card. A Gift Card is a bearer claim
+          // Only the payment-request park and its card. A Gift Card is a bearer claim
           // on funds that do not belong to this wallet, so it survives a reset
           // by design — see `paymentLinkIntakeProvider`.
+          ref.read(paymentRequestIntakeProvider).invalidate();
           ref.read(paymentUriPrefillProvider.notifier).clear();
           ref.read(paymentRequestFlowProvider.notifier).clear();
+          ref.read(crossChainPaymentFlowProvider.notifier).clear();
           return;
         }
       }
@@ -1480,6 +1503,15 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
     ) {
       if (next == null && previous != null) _openPendingPaymentLink();
     });
+    ref.listen<CrossChainPaymentFlowState?>(crossChainPaymentFlowProvider, (
+      previous,
+      next,
+    ) {
+      if (next == null && previous != null) _openPendingPaymentLink();
+    });
+    ref.listen<int>(paymentRequestArrivalProvider, (_, _) {
+      _schedulePendingDrain();
+    });
     // No appSecurityProvider listener: the unlock screens own the post-unlock
     // navigation for a parked prefill (claim + present the card). Draining
     // here on unlock too would race and clobber that navigation. The wallet
@@ -1493,7 +1525,7 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   void _handleIncomingUri(String rawUri) {
     switch (classifyIncomingLink(rawUri)) {
       case IncomingPaymentRequestLink(:final raw):
-        _handlePaymentRequestLink(raw);
+        unawaited(_handlePaymentRequestLink(raw));
       case IncomingGiftCardLink():
         _handleGiftCardLink(rawUri);
       case IncomingVizorHomeLink():
@@ -1591,7 +1623,8 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   }
 
   bool get _paymentRequestCardPresented =>
-      ref.read(paymentRequestFlowProvider) != null;
+      ref.read(paymentRequestFlowProvider) != null ||
+      ref.read(crossChainPaymentFlowProvider) != null;
 
   void _showDeferredPaymentLinkMessage(VizorPaymentLink link, String message) {
     if (identical(_lastDeferredLink, link)) return;
@@ -1606,53 +1639,23 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
   // Payment request lane
   // ---------------------------------------------------------------------
 
-  void _handlePaymentRequestLink(String rawUri) {
+  Future<void> _handlePaymentRequestLink(String rawUri) async {
     try {
-      final replacedParkedPrefill = ref
-          .read(paymentUriPrefillProvider.notifier)
-          .set(_prefillFromUri(rawUri));
+      final replaced = await ref
+          .read(paymentRequestIntakeProvider)
+          .receive(rawUri);
+      if (!mounted) return;
       _schedulePendingDrain();
-      if (replacedParkedPrefill) {
-        // A batch of links from native on cold start, or a second link while
-        // the first is still parked (locked wallet, wallet still loading).
-        // Only the newest survives, so say so instead of silently dropping
-        // the earlier one.
-        _showPaymentUriMessage(kPaymentUriReplacedMessage);
-      }
-    } on Zip321UnsupportedRequestException catch (e) {
-      // Do not clear here: a refused link must not wipe a prefill already
-      // parked from an earlier valid one.
-      log('Payment URI: unsupported: ${e.reason}');
-      _showPaymentUriMessage(paymentUriRejectionMessage(e));
-    } on Zip321ParseException catch (e) {
-      // The parser's message is spec wording written for us, and it echoes
-      // fragments of the link's own text; keep it in the log and show the
-      // payer one sentence they can act on.
-      log('Payment URI: rejected: ${e.message}');
-      _showPaymentUriMessage(paymentUriRejectionMessage(e));
-    } catch (e) {
-      // Defensive: no current parse path reaches this. It shares the drain
-      // policy's constant rather than a literal of its own so the two cannot
-      // drift into two different sentences for the same "the link is gone".
-      // Only `zcash:` links reach this lane, so `$e` cannot carry a Gift
-      // Card's mnemonic fragment.
-      log('Payment URI: failed to parse: $e');
+      if (replaced) _showPaymentUriMessage(kPaymentUriReplacedMessage);
+    } on Zip321UnsupportedRequestException catch (error) {
+      _showPaymentUriMessage(paymentUriRejectionMessage(error));
+    } on Zip321ParseException catch (error) {
+      _showPaymentUriMessage(paymentUriRejectionMessage(error));
+    } on CrossChainPaymentParseException catch (error) {
+      _showPaymentUriMessage(error.toString());
+    } catch (_) {
       _showPaymentUriMessage(kPaymentUriUnavailableMessage);
     }
-  }
-
-  SendPrefillArgs _prefillFromUri(String rawUri) {
-    final request = Zip321PaymentRequest.parse(rawUri);
-    if (!request.isSupported) {
-      // Its own type, not a parse exception: the link is well-formed and the
-      // payer needs a different sentence than a broken one gets.
-      throw Zip321UnsupportedRequestException(request.unsupportedReason!);
-    }
-    final payment = request.primaryPayment;
-    return sendPrefillArgsFromZip321Payment(
-      id: 'payment-uri-${++_paymentSequence}',
-      payment: payment,
-    );
   }
 
   void _schedulePendingDrain() {
@@ -1728,9 +1731,7 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
       case PaymentUriDrainAction.deliver:
         prefillNotifier.clear();
         // The request is presented over the current screen, not navigated to.
-        ref
-            .read(paymentRequestFlowProvider.notifier)
-            .present(prefill!, source: PaymentRequestSource.link);
+        presentPaymentRequest(ref, prefill!);
     }
   }
 

--- a/lib/src/core/navigation/incoming_link_dispatch.dart
+++ b/lib/src/core/navigation/incoming_link_dispatch.dart
@@ -1,7 +1,7 @@
 /// The single classifier for everything the native runners hand to Dart on
 /// `com.zcash.wallet/payment_uri`.
 ///
-/// Two products arrive on one pipe: ZIP-321 `zcash:` payment requests (all
+/// Two products arrive on one pipe: Zcash and cross-chain payment requests (all
 /// five platforms) and Vizor Gift Card `https://` deeplinks (Android and iOS —
 /// the desktop runners never register a handler for them). One classifier, one
 /// subscription, so a link can only ever be handled by one of them.
@@ -20,15 +20,15 @@
 library;
 
 import 'vizor_deep_link.dart';
+import '../payments/cross_chain_payment_request.dart';
 
 /// What an incoming link turned out to be.
 sealed class IncomingLinkTarget {
   const IncomingLinkTarget();
 }
 
-/// A ZIP-321 `zcash:` payment request. [raw] is the trimmed link, still
-/// unparsed — parsing stays with the payment-URI park/drain path so its two
-/// rejection sentences keep living in one place.
+/// A payment request. [raw] is the trimmed link, still unparsed; the common
+/// intake owns parsing and the park/drain lifecycle.
 final class IncomingPaymentRequestLink extends IncomingLinkTarget {
   const IncomingPaymentRequestLink(this.raw);
 
@@ -75,7 +75,8 @@ IncomingLinkTarget classifyIncomingLink(String raw) {
         }
     }
 
-    if (uri.scheme.toLowerCase() == _zcashScheme) {
+    if (uri.scheme.toLowerCase() == _zcashScheme ||
+        crossChainPaymentSchemes.contains(uri.scheme.toLowerCase())) {
       return IncomingPaymentRequestLink(trimmed);
     }
     return const IncomingLinkUnknown();
@@ -85,7 +86,8 @@ IncomingLinkTarget classifyIncomingLink(String raw) {
   // so it cannot be a Gift Card link. A malformed `zcash:` link still has to
   // reach the payment-URI path, which is the only one that can tell the payer
   // their link is broken.
-  return trimmed.toLowerCase().startsWith('$_zcashScheme:')
+  return trimmed.toLowerCase().startsWith('$_zcashScheme:') ||
+          isCrossChainPaymentUri(trimmed)
       ? IncomingPaymentRequestLink(trimmed)
       : const IncomingLinkUnknown();
 }

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -265,6 +265,9 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
           child: MobileSwapReviewScreen(
             payMode: true,
             recipientSelection: extra is PayRecipientSelection ? extra : null,
+            paymentRequestId: extra is PayComposerNavigationArgs
+                ? extra.paymentRequestId
+                : null,
           ),
         );
       },
@@ -285,9 +288,19 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
         return CupertinoPage(
           key: state.pageKey,
           child: MobilePayScreen(
+            key:
+                args is PayComposerNavigationArgs &&
+                    args.paymentRequestId != null
+                ? ValueKey(args.paymentRequestId)
+                : null,
             preservePreparedComposer:
                 args is PayComposerNavigationArgs &&
                 args.preservePreparedComposer,
+            reviewAfterAmount:
+                args is PayComposerNavigationArgs && args.reviewAfterAmount,
+            paymentRequestId: args is PayComposerNavigationArgs
+                ? args.paymentRequestId
+                : null,
           ),
         );
       },

--- a/lib/src/core/navigation/payment_request_intake.dart
+++ b/lib/src/core/navigation/payment_request_intake.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/pay/providers/cross_chain_payment_request_provider.dart';
+import '../../features/send/models/send_prefill_args.dart';
+import '../../providers/payment_uri_prefill_provider.dart';
+import '../payments/cross_chain_payment_request.dart';
+import '../widgets/app_toast.dart';
+import '../zcash/zip321_payment_request.dart';
+import 'payment_request_draft.dart';
+import 'payment_uri_drain_policy.dart';
+
+bool isPaymentRequestUri(String raw) =>
+    raw.trim().toLowerCase().startsWith('zcash:') ||
+    isCrossChainPaymentUri(raw.trim());
+
+/// One arrival order across native links, QR scans and pasted requests.
+/// A slow parser cannot replace a newer request or re-park after a reset.
+class PaymentRequestIntake {
+  PaymentRequestIntake(this.ref);
+  final Ref ref;
+  var _generation = 0;
+
+  void invalidate() => _generation++;
+
+  Future<bool> receive(String raw) async {
+    final generation = ++_generation;
+    final uri = raw.trim();
+    try {
+      final PaymentRequestDraft draft;
+      if (isCrossChainPaymentUri(uri)) {
+        draft = await ref.read(crossChainPaymentParserProvider)(uri);
+      } else {
+        final request = Zip321PaymentRequest.parse(uri);
+        if (!request.isSupported) {
+          throw Zip321UnsupportedRequestException(request.unsupportedReason!);
+        }
+        draft = sendPrefillArgsFromZip321Payment(
+          id: 'payment-uri-$generation',
+          payment: request.primaryPayment,
+        );
+      }
+      if (generation != _generation) return false;
+      final replaced = ref.read(paymentUriPrefillProvider.notifier).set(draft);
+      ref.read(paymentRequestArrivalProvider.notifier).arrived();
+      return replaced;
+    } catch (_) {
+      if (generation != _generation) return false;
+      rethrow;
+    }
+  }
+}
+
+final paymentRequestIntakeProvider = Provider<PaymentRequestIntake>((ref) {
+  final intake = PaymentRequestIntake(ref);
+  ref.onDispose(intake.invalidate);
+  return intake;
+});
+
+/// Returns false for a plain address. Parsing failures remain explicit so the
+/// input surface can show them without silently treating a request as an address.
+Future<bool> intakePaymentRequest(WidgetRef ref, String raw) async {
+  if (!isPaymentRequestUri(raw)) return false;
+  final replaced = await ref.read(paymentRequestIntakeProvider).receive(raw);
+  if (replaced && ref.context.mounted) {
+    showAppToast(ref.context, kPaymentUriReplacedMessage);
+  }
+  return true;
+}
+
+class PaymentRequestArrivalNotifier extends Notifier<int> {
+  @override
+  int build() => 0;
+  void arrived() => state++;
+}
+
+final paymentRequestArrivalProvider =
+    NotifierProvider<PaymentRequestArrivalNotifier, int>(
+      PaymentRequestArrivalNotifier.new,
+    );

--- a/lib/src/core/navigation/payment_uri_unlock_claim.dart
+++ b/lib/src/core/navigation/payment_uri_unlock_claim.dart
@@ -9,7 +9,7 @@ library;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app_bootstrap.dart';
-import '../../features/send/models/send_prefill_args.dart';
+import 'payment_request_draft.dart';
 import '../../providers/migration_send_gate_provider.dart'
     show migrationSendGateProvider;
 import '../../providers/payment_uri_prefill_provider.dart';
@@ -22,7 +22,7 @@ class PaymentUriUnlockClaim {
 
   /// Present this as a payment-request card. Null when nothing was parked, or
   /// when the link cannot be shown.
-  final SendPrefillArgs? prefill;
+  final PaymentRequestDraft? prefill;
 
   /// Say this instead — the link was claimed but is not being delivered.
   /// Null when there is nothing to say (nothing was parked).

--- a/lib/src/core/navigation/present_payment_request.dart
+++ b/lib/src/core/navigation/present_payment_request.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../payments/cross_chain_payment_request.dart';
+import '../../features/pay/providers/cross_chain_payment_request_provider.dart';
+import '../../features/send/models/send_prefill_args.dart';
+import '../../providers/payment_request_flow_provider.dart';
+import 'payment_request_draft.dart';
+
+/// A single request can own the overlay. Switching execution lanes releases
+/// the previous Zcash proposal instead of leaving an invisible reservation.
+void presentPaymentRequest(
+  WidgetRef ref,
+  PaymentRequestDraft request, {
+  PaymentRequestSource source = PaymentRequestSource.link,
+}) {
+  if (request is SendPrefillArgs) {
+    ref.read(crossChainPaymentFlowProvider.notifier).clear();
+    ref
+        .read(paymentRequestFlowProvider.notifier)
+        .present(request, source: source);
+  } else if (request is CrossChainPaymentRequest) {
+    ref.read(paymentRequestFlowProvider.notifier).clear();
+    ref.read(crossChainPaymentFlowProvider.notifier).present(request);
+  }
+}

--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -19,7 +19,7 @@ import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/biometric_unlock_provider.dart';
 import '../../../providers/device_owner_auth_provider.dart';
-import '../../../providers/payment_request_flow_provider.dart';
+import '../../../core/navigation/present_payment_request.dart';
 import '../../../providers/router_refresh_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../services/biometric_unlock.dart';
@@ -237,9 +237,7 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
         if (pendingPrefill != null) {
           // The link becomes a card over the wallet the user just unlocked,
           // not a jump into the composer.
-          ref
-              .read(paymentRequestFlowProvider.notifier)
-              .present(pendingPrefill, source: PaymentRequestSource.link);
+          presentPaymentRequest(ref, pendingPrefill);
         } else if (notice != null) {
           // The link outlived its park window while the user was finding their
           // passcode, or the wallet it landed on cannot open it. Landing with

--- a/lib/src/features/onboarding/unlock_screen.dart
+++ b/lib/src/features/onboarding/unlock_screen.dart
@@ -14,7 +14,7 @@ import '../../core/widgets/app_toast.dart';
 import '../../core/widgets/password_text_field.dart';
 import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
-import '../../providers/payment_request_flow_provider.dart';
+import '../../core/navigation/present_payment_request.dart';
 import '../../providers/router_refresh_provider.dart';
 import '../../providers/sync_provider.dart';
 import 'shared/onboarding_auth_shell.dart';
@@ -91,9 +91,7 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
         if (pendingPrefill != null) {
           // The link becomes a card over the wallet the user just unlocked,
           // not a jump into the composer.
-          ref
-              .read(paymentRequestFlowProvider.notifier)
-              .present(pendingPrefill, source: PaymentRequestSource.link);
+          presentPaymentRequest(ref, pendingPrefill);
         } else if (notice != null) {
           // The link outlived its park window while the user was finding their
           // password, or the wallet it landed on cannot open it. Landing on

--- a/lib/src/features/pay/providers/cross_chain_payment_request_provider.dart
+++ b/lib/src/features/pay/providers/cross_chain_payment_request_provider.dart
@@ -1,0 +1,177 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/config/swap_feature_config.dart';
+import '../../../core/payments/cross_chain_payment_request.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
+import '../../../providers/payment_uri_prefill_provider.dart';
+import '../../../rust/api/payment_uri.dart' as rust_payment;
+import '../../swap/providers/swap_state_provider.dart';
+import '../models/payment_request_resolution.dart';
+
+typedef CrossChainPaymentParser =
+    Future<CrossChainPaymentRequest> Function(String raw);
+
+var _requestSequence = 0;
+final crossChainPaymentParserProvider = Provider<CrossChainPaymentParser>((
+  ref,
+) {
+  return (raw) async {
+    try {
+      final json = await rust_payment.parseCrossChainPaymentUri(uri: raw);
+      return CrossChainPaymentRequest.fromParserJson(
+        id: 'cross-chain-${++_requestSequence}',
+        rawUri: raw,
+        json: json,
+      );
+    } catch (_) {
+      throw const CrossChainPaymentParseException();
+    }
+  };
+});
+
+class CrossChainPaymentFlowState {
+  const CrossChainPaymentFlowState(
+    this.request, {
+    this.selectedChain,
+    this.slippageBps,
+    this.isPreparingReview = false,
+    this.reviewError,
+  });
+  final CrossChainPaymentRequest request;
+  final String? selectedChain;
+  final int? slippageBps;
+  final bool isPreparingReview;
+  final String? reviewError;
+}
+
+class CrossChainPaymentFlowNotifier
+    extends Notifier<CrossChainPaymentFlowState?> {
+  @override
+  CrossChainPaymentFlowState? build() {
+    ref.listen(appSecurityProvider, (previous, next) {
+      if (previous?.isUnlocked == true && !next.isUnlocked) {
+        final request = state?.request;
+        // A newer request parked during lock wins over the visible card.
+        if (request != null && ref.read(paymentUriPrefillProvider) == null) {
+          ref.read(paymentUriPrefillProvider.notifier).set(request);
+        }
+        clear();
+      }
+    });
+    ref.listen(accountProvider, (previous, next) {
+      if (previous?.value?.activeAccountUuid != next.value?.activeAccountUuid) {
+        clear();
+      }
+    });
+    return null;
+  }
+
+  void present(CrossChainPaymentRequest request) {
+    clear();
+    state = CrossChainPaymentFlowState(request);
+  }
+
+  void chooseNetwork(String chain) {
+    final current = state;
+    if (current == null ||
+        current.isPreparingReview ||
+        !current.request.needsNetwork) {
+      return;
+    }
+    if (!evmPaymentNetworks.values.any((network) => network.chain == chain)) {
+      return;
+    }
+    state = CrossChainPaymentFlowState(
+      current.request,
+      selectedChain: chain,
+      slippageBps: current.slippageBps,
+    );
+  }
+
+  void chooseSlippage(int bps) {
+    final current = state;
+    if (current == null || current.isPreparingReview) return;
+    state = CrossChainPaymentFlowState(
+      current.request,
+      selectedChain: current.selectedChain,
+      slippageBps: bps.clamp(10, 500),
+    );
+  }
+
+  Future<bool> preparePay({required bool review}) async {
+    final current = state;
+    if (current == null ||
+        current.isPreparingReview ||
+        !ref.read(appSecurityProvider).isUnlocked ||
+        !ref.read(swapFeatureEnabledProvider)) {
+      return false;
+    }
+    final swap = ref.read(swapStateProvider);
+    final resolution = resolveCrossChainPaymentRequest(
+      current.request,
+      swap.supportedExternalAssets,
+      selectedChain: current.selectedChain,
+    );
+    final account = ref.read(accountProvider).value?.activeAccountUuid;
+    if (!resolution.isReady || account == null) return false;
+    final notifier = ref.read(swapStateProvider.notifier);
+    if (!notifier.preparePayPaymentRequest(
+      asset: resolution.asset!,
+      destination: current.request.address,
+      amountText: resolution.amountText,
+      expectedAccountUuid: account,
+    )) {
+      return false;
+    }
+    if (current.slippageBps case final bps?) {
+      notifier.updateSlippageBps(bps);
+    }
+    if (!review || resolution.amountText == null) return true;
+
+    final pending = CrossChainPaymentFlowState(
+      current.request,
+      selectedChain: current.selectedChain,
+      slippageBps: current.slippageBps,
+      isPreparingReview: true,
+    );
+    state = pending;
+    await notifier.showReview();
+    if (!ref.mounted || !identical(state, pending)) return false;
+    final prepared = ref.read(swapStateProvider);
+    final ready =
+        prepared.reviewVisible &&
+        prepared.reviewQuote != null &&
+        prepared.reviewAddressPlan != null &&
+        prepared.reviewAccountUuid == account &&
+        prepared.externalAssetIsAvailable &&
+        ref.read(swapFeatureEnabledProvider) &&
+        ref.read(appSecurityProvider).isUnlocked &&
+        ref.read(accountProvider).value?.activeAccountUuid == account;
+    if (!ready) notifier.cancelReviewQuote();
+    state = CrossChainPaymentFlowState(
+      current.request,
+      selectedChain: current.selectedChain,
+      slippageBps: current.slippageBps,
+      reviewError: ready
+          ? null
+          : prepared.externalAssetSupportError ??
+                prepared.quoteError ??
+                'Payment review could not be prepared. Try again or edit the payment.',
+    );
+    return ready;
+  }
+
+  void clear() {
+    if (state?.isPreparingReview == true) {
+      ref.read(swapStateProvider.notifier).cancelReviewQuote();
+    }
+    state = null;
+  }
+}
+
+final crossChainPaymentFlowProvider =
+    NotifierProvider<
+      CrossChainPaymentFlowNotifier,
+      CrossChainPaymentFlowState?
+    >(CrossChainPaymentFlowNotifier.new);

--- a/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
+++ b/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
@@ -35,9 +35,16 @@ enum _PayModalSurface { assetSelector, addressScanner, addContact, slippage }
 enum _MobilePayStep { amount, recipient }
 
 class MobilePayScreen extends ConsumerStatefulWidget {
-  const MobilePayScreen({this.preservePreparedComposer = false, super.key});
+  const MobilePayScreen({
+    this.preservePreparedComposer = false,
+    this.paymentRequestId,
+    this.reviewAfterAmount = false,
+    super.key,
+  });
 
   final bool preservePreparedComposer;
+  final String? paymentRequestId;
+  final bool reviewAfterAmount;
 
   @override
   ConsumerState<MobilePayScreen> createState() => _MobilePayScreenState();
@@ -52,6 +59,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
   bool _modalRouteOpen = false;
   bool _reviewRequestInFlight = false;
   int _reviewRequestGeneration = 0;
+  bool _reviewAfterAmount = false;
   var _step = _MobilePayStep.amount;
 
   @override
@@ -60,6 +68,10 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
     _amountController = TextEditingController();
     _amountFocusNode = FocusNode(debugLabel: 'MobilePayAmount');
     _recipientController = TextEditingController();
+    _reviewAfterAmount =
+        widget.preservePreparedComposer &&
+        widget.paymentRequestId != null &&
+        widget.reviewAfterAmount;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final preparedState = ref.read(swapStateProvider);
@@ -265,6 +277,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
     if (next.reviewVisible &&
         next.reviewQuote != null &&
         next.reviewAddressPlan != null) {
+      _reviewAfterAmount = false;
       await context.push('/pay/review', extra: selection);
     }
   }
@@ -365,7 +378,11 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
                     onOpenSlippage: () => _openModal(_PayModalSurface.slippage),
                     onContinue: () {
                       _amountFocusNode.unfocus();
-                      setState(() => _step = _MobilePayStep.recipient);
+                      if (_reviewAfterAmount && swapState.canReviewQuote) {
+                        unawaited(_openReview(effectiveSelection));
+                      } else {
+                        setState(() => _step = _MobilePayStep.recipient);
+                      }
                     },
                   ),
                   _MobilePayStep.recipient => MobilePayRecipientStep(

--- a/lib/src/features/pay/screens/pay_screen.dart
+++ b/lib/src/features/pay/screens/pay_screen.dart
@@ -47,9 +47,18 @@ enum _PayModalSurface {
 enum _PayWizardStep { amount, recipient, review }
 
 class PayScreen extends ConsumerStatefulWidget {
-  const PayScreen({this.preservePreparedComposer = false, super.key});
+  const PayScreen({
+    this.preservePreparedComposer = false,
+    this.paymentRequestId,
+    this.showPreparedReview = false,
+    this.reviewAfterAmount = false,
+    super.key,
+  });
 
   final bool preservePreparedComposer;
+  final String? paymentRequestId;
+  final bool showPreparedReview;
+  final bool reviewAfterAmount;
 
   @override
   ConsumerState<PayScreen> createState() => _PayScreenState();
@@ -64,6 +73,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   var _wizardStep = _PayWizardStep.amount;
   var _startingIntent = false;
   var _reviewRequestGeneration = 0;
+  var _reviewAfterAmount = false;
   Timer? _expiryTimer;
   DateTime? _expiryDeadline;
   Duration? _expiryRemaining;
@@ -75,13 +85,25 @@ class _PayScreenState extends ConsumerState<PayScreen> {
     _amountController = TextEditingController();
     _amountFocusNode = FocusNode(debugLabel: 'PayWizardAmount');
     _recipientController = TextEditingController();
+    _reviewAfterAmount =
+        widget.preservePreparedComposer &&
+        widget.paymentRequestId != null &&
+        widget.reviewAfterAmount;
+    final initial = ref.read(swapStateProvider);
+    if (widget.preservePreparedComposer &&
+        widget.showPreparedReview &&
+        initial.payMode &&
+        initial.reviewVisible &&
+        initial.reviewQuote != null &&
+        initial.reviewAddressPlan != null) {
+      _wizardStep = _PayWizardStep.review;
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final preparedState = ref.read(swapStateProvider);
       if (!widget.preservePreparedComposer || !preparedState.payMode) {
         ref.read(swapStateProvider.notifier).preparePayFromShieldedZec();
       }
-      setState(() => _wizardStep = _PayWizardStep.amount);
     });
   }
 
@@ -146,6 +168,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   }
 
   Future<void> _openReview() async {
+    if (ref.read(swapStateProvider).quoteLoading) return;
     final requestGeneration = ++_reviewRequestGeneration;
     final originStep = _wizardStep;
     final notifier = ref.read(swapStateProvider.notifier);
@@ -159,7 +182,10 @@ class _PayScreenState extends ConsumerState<PayScreen> {
     if (next.reviewVisible &&
         next.reviewQuote != null &&
         next.reviewAddressPlan != null) {
-      setState(() => _wizardStep = _PayWizardStep.review);
+      setState(() {
+        _reviewAfterAmount = false;
+        _wizardStep = _PayWizardStep.review;
+      });
     }
   }
 
@@ -352,7 +378,14 @@ class _PayScreenState extends ConsumerState<PayScreen> {
     final actions = switch (_wizardStep) {
       _PayWizardStep.amount => PayAmountAction(
         state: swapState,
-        onContinue: () => _goToStep(_PayWizardStep.recipient),
+        onContinue: () {
+          _amountFocusNode.unfocus();
+          if (_reviewAfterAmount && swapState.canReviewQuote) {
+            unawaited(_openReview());
+          } else {
+            _goToStep(_PayWizardStep.recipient);
+          }
+        },
       ),
       _PayWizardStep.recipient =>
         recipientActions.visible ? recipientActions : null,

--- a/lib/src/features/pay/widgets/cross_chain_payment_request_host.dart
+++ b/lib/src/features/pay/widgets/cross_chain_payment_request_host.dart
@@ -1,0 +1,254 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/config/swap_feature_config.dart';
+import '../../../core/layout/app_form_factor.dart';
+import '../../../core/layout/content_overlay_inset.dart';
+import '../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_modal_card.dart';
+import '../../../core/widgets/app_modal_overlay_scope.dart';
+import '../../../core/widgets/app_pane_modal_overlay.dart';
+import '../../../providers/network_privacy_provider.dart';
+import '../../send/services/send_flow.dart';
+import '../../swap/models/swap_activity_navigation.dart';
+import '../../swap/providers/swap_state_provider.dart';
+import '../../swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart';
+import '../../swap/widgets/swap_slippage_modal.dart';
+import '../models/payment_request_resolution.dart';
+import '../providers/cross_chain_payment_request_provider.dart';
+import 'cross_chain_payment_request_card.dart';
+
+class CrossChainPaymentRequestHost extends ConsumerWidget {
+  const CrossChainPaymentRequestHost({
+    required this.router,
+    required this.child,
+    super.key,
+  });
+  final GoRouter router;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final flow = ref.watch(crossChainPaymentFlowProvider);
+    return Stack(
+      fit: StackFit.passthrough,
+      children: [
+        child,
+        if (flow != null)
+          AppModalOverlayScope(
+            child: _RequestOverlay(
+              key: ValueKey(flow.request.id),
+              router: router,
+              flow: flow,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _RequestOverlay extends ConsumerStatefulWidget {
+  const _RequestOverlay({required this.router, required this.flow, super.key});
+  final GoRouter router;
+  final CrossChainPaymentFlowState flow;
+
+  @override
+  ConsumerState<_RequestOverlay> createState() => _RequestOverlayState();
+}
+
+class _RequestOverlayState extends ConsumerState<_RequestOverlay> {
+  bool _editingSlippage = false;
+  bool _closingRequest = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final flow = widget.flow;
+    final enabled = ref.watch(swapFeatureEnabledProvider);
+    // Respect the feature gate before initializing the pricing/network lane.
+    final swap = enabled ? ref.watch(swapStateProvider) : null;
+    final notifier = enabled ? ref.read(swapStateProvider.notifier) : null;
+    final privacy = enabled ? ref.watch(networkPrivacyProvider) : null;
+    final connectingTor =
+        privacy?.isBusy == true &&
+        (privacy?.targetTorEnabled ?? privacy?.torEnabled) == true;
+    final torFailed =
+        privacy?.torRouteRetained == true &&
+        privacy?.status == NetworkPrivacyConnectionStatus.failed;
+    final loading =
+        !torFailed && (connectingTor || (swap?.pricingLoading ?? false));
+    final availability = torFailed
+        ? 'Could not connect to Tor. Try again to load payment options.'
+        : flow.reviewError ??
+              (!enabled
+                  ? null
+                  : swap!.supportedAssetsError ??
+                        (!loading && !notifier!.paymentRequestAssetsReady
+                            ? 'Payment options could not be loaded. Check your connection and try again.'
+                            : null));
+    final resolution = !enabled
+        ? const PaymentRequestResolution(
+            message: 'Pay is not available for this wallet.',
+          )
+        : resolveCrossChainPaymentRequest(
+            flow.request,
+            swap!.supportedExternalAssets,
+            selectedChain: flow.selectedChain,
+          );
+    final flowNotifier = ref.read(crossChainPaymentFlowProvider.notifier);
+    final mobile = kAppFormFactor == AppFormFactor.mobile;
+    final slippageBps = flow.slippageBps ?? swap?.slippageBps;
+    final editingSlippage = _editingSlippage && enabled && slippageBps != null;
+    void closeSlippage() {
+      if (mounted) setState(() => _editingSlippage = false);
+    }
+
+    void closeRequest() {
+      if (!mounted) return;
+      if (ref.read(crossChainPaymentFlowProvider)?.request.id ==
+          flow.request.id) {
+        flowNotifier.clear();
+      }
+    }
+
+    void beginClosingRequest() {
+      if (!mounted || _closingRequest) return;
+      setState(() => _closingRequest = true);
+      if (flow.isPreparingReview) notifier?.cancelReviewQuote();
+    }
+
+    void dismissRequest() {
+      if (mobile) {
+        beginClosingRequest();
+      } else {
+        closeRequest();
+      }
+    }
+
+    Future<void> continueToPay({required bool review}) async {
+      if (_closingRequest ||
+          !identical(ref.read(crossChainPaymentFlowProvider), flow)) {
+        return;
+      }
+      if (!await flowNotifier.preparePay(review: review) ||
+          !context.mounted ||
+          _closingRequest) {
+        return;
+      }
+      final prepared = ref.read(swapStateProvider);
+      final showReview = review && prepared.reviewVisible;
+      flowNotifier.clear();
+      ref.read(sendStatusRoutePayloadProvider.notifier).clear();
+      widget.router.go(
+        mobile && showReview ? '/pay/review' : '/pay',
+        extra: PayComposerNavigationArgs(
+          preservePreparedComposer: true,
+          paymentRequestId: flow.request.id,
+          showPreparedReview: showReview,
+          reviewAfterAmount: review && !showReview,
+        ),
+      );
+    }
+
+    final card = Material(
+      type: MaterialType.transparency,
+      child: CrossChainPaymentRequestCard(
+        key: ValueKey(flow.request.id),
+        request: flow.request,
+        resolution: resolution,
+        estimatedZecAmount: swap == null
+            ? null
+            : resolution.estimateZecAmount(swap.indicativeExternalPerZec),
+        selectedChain: flow.selectedChain,
+        isLoading: loading,
+        loadingMessage: connectingTor
+            ? 'Connecting to Tor…'
+            : 'Checking payment options…',
+        isPreparingReview: flow.isPreparingReview,
+        availabilityMessage: availability,
+        isMobile: mobile,
+        slippageBps: slippageBps,
+        onOpenSlippage: () => setState(() => _editingSlippage = true),
+        onCancel: dismissRequest,
+        onNetworkSelected: flowNotifier.chooseNetwork,
+        onRetry: () {
+          if (torFailed) {
+            unawaited(ref.read(networkPrivacyProvider.notifier).retry());
+          } else if (flow.reviewError != null) {
+            unawaited(continueToPay(review: true));
+          } else if (notifier != null) {
+            unawaited(notifier.refreshPaymentRequestAssets());
+          }
+        },
+        onContinue: () => unawaited(continueToPay(review: true)),
+        onEdit: () => unawaited(continueToPay(review: false)),
+      ),
+    );
+    void updateSlippage(int bps) {
+      if (!mounted ||
+          ref.read(crossChainPaymentFlowProvider)?.request.id !=
+              flow.request.id) {
+        return;
+      }
+      flowNotifier.chooseSlippage(bps);
+      closeSlippage();
+    }
+
+    final editor = !editingSlippage
+        ? null
+        : Material(
+            type: MaterialType.transparency,
+            child: mobile
+                ? MobileSwapSlippageStepperModal(
+                    slippageBps: slippageBps,
+                    paymentMode: true,
+                    onSubmitted: updateSlippage,
+                    onCancel: closeSlippage,
+                  )
+                : SwapSlippageModal(
+                    slippageBps: slippageBps,
+                    paymentMode: true,
+                    onSubmitted: updateSlippage,
+                    onCancel: closeSlippage,
+                    onBack: closeSlippage,
+                  ),
+          );
+    return AppPaneModalOverlay(
+      onDismiss: dismissRequest,
+      alignment: mobile ? Alignment.bottomCenter : Alignment.center,
+      child: mobile
+          ? SafeArea(
+              bottom: false,
+              minimum: const EdgeInsets.only(top: AppSpacing.base),
+              child: AppDraggableMobileSheet(
+                key: ValueKey((flow.request.id, editingSlippage)),
+                dismissRequested: _closingRequest,
+                onClosing: beginClosingRequest,
+                onDismiss: closeRequest,
+                child: MobileModalCard(
+                  onBack: editingSlippage ? closeSlippage : null,
+                  child:
+                      editor ??
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(
+                          AppSpacing.sm,
+                          AppSpacing.md,
+                          AppSpacing.sm,
+                          AppSpacing.base,
+                        ),
+                        child: card,
+                      ),
+                ),
+              ),
+            )
+          : ContentPaneCenteringPadding(
+              child: editor == null
+                  ? AppModalCard(width: 396, child: card)
+                  : SizedBox(width: 396, child: editor),
+            ),
+    );
+  }
+}

--- a/lib/src/features/send/models/send_prefill_args.dart
+++ b/lib/src/features/send/models/send_prefill_args.dart
@@ -1,11 +1,12 @@
 import '../../../core/zcash/zip321_payment_request.dart';
+import '../../../core/navigation/payment_request_draft.dart';
 
 /// [SendPrefillArgs.source] for a prefill that came from a ZIP-321 payment
 /// request (a `zcash:` link today, an in-app QR scan later). The send flow
 /// reads it to keep the payment-request framing on the review screen.
 const kPaymentUriPrefillSource = 'zcash-uri';
 
-class SendPrefillArgs {
+class SendPrefillArgs implements PaymentRequestDraft {
   const SendPrefillArgs({
     required this.id,
     required this.source,
@@ -17,6 +18,7 @@ class SendPrefillArgs {
     this.message,
   });
 
+  @override
   final String id;
   final String source;
   final String address;

--- a/lib/src/features/swap/models/swap_activity_navigation.dart
+++ b/lib/src/features/swap/models/swap_activity_navigation.dart
@@ -36,9 +36,20 @@ enum SwapActivityReturnTarget {
 }
 
 class PayComposerNavigationArgs {
-  const PayComposerNavigationArgs({required this.preservePreparedComposer});
+  const PayComposerNavigationArgs({
+    required this.preservePreparedComposer,
+    this.paymentRequestId,
+    this.showPreparedReview = false,
+    this.reviewAfterAmount = false,
+  });
 
   final bool preservePreparedComposer;
+  final String? paymentRequestId;
+  final bool showPreparedReview;
+
+  /// A request's missing amount may go straight to review once. Explicit
+  /// editing and returning from review must leave recipient selection reachable.
+  final bool reviewAfterAmount;
 }
 
 const swapActivityReturnQueryKey = 'from';

--- a/lib/src/features/swap/models/swap_state.dart
+++ b/lib/src/features/swap/models/swap_state.dart
@@ -73,6 +73,7 @@ class SwapState {
     this.depositSubmitting = false,
     this.selectedIntentId,
     this.payMode = false,
+    this.paymentRequestAssetId,
     this.userExternalContactId,
   });
 
@@ -113,6 +114,7 @@ class SwapState {
   final bool depositSubmitting;
   final String? selectedIntentId;
   final bool payMode;
+  final String? paymentRequestAssetId;
   final String? userExternalContactId;
 
   SwapIntent? get selectedIntentOrNull {
@@ -202,6 +204,10 @@ class SwapState {
   }
 
   bool get externalAssetIsSupported {
+    if ((paymentRequestAssetId ?? externalAsset.assetId) case final assetId?) {
+      return externalAsset.assetId == assetId &&
+          supportedExternalAssets.any((asset) => asset.assetId == assetId);
+    }
     for (final candidate in supportedExternalAssets) {
       if (candidate == externalAsset ||
           candidate.hasSameMarketAs(externalAsset)) {
@@ -319,6 +325,8 @@ class SwapState {
     bool? depositSubmitting,
     String? selectedIntentId,
     bool? payMode,
+    String? paymentRequestAssetId,
+    bool clearPaymentRequest = false,
     String? userExternalContactId,
     bool clearReview = false,
     bool clearQuoteError = false,
@@ -379,6 +387,9 @@ class SwapState {
           ? null
           : selectedIntentId ?? this.selectedIntentId,
       payMode: payMode ?? this.payMode,
+      paymentRequestAssetId: clearPaymentRequest
+          ? null
+          : paymentRequestAssetId ?? this.paymentRequestAssetId,
       userExternalContactId: clearUserExternalContactId
           ? null
           : userExternalContactId ?? this.userExternalContactId,

--- a/lib/src/features/swap/providers/swap_state_provider.dart
+++ b/lib/src/features/swap/providers/swap_state_provider.dart
@@ -273,6 +273,63 @@ class SwapNotifier extends Notifier<SwapState> {
     );
   }
 
+  bool get paymentRequestAssetsReady => _hasResolvedSupportedAssets;
+
+  Future<void> refreshPaymentRequestAssets() =>
+      _loadSupportedExternalAssets(forceRefreshPrices: true);
+
+  /// Applies the reviewed request atomically. There is no remembered-asset or
+  /// symbol fallback for a payment to a specific asset on a specific chain.
+  bool preparePayPaymentRequest({
+    required SwapAsset asset,
+    required String destination,
+    required String? amountText,
+    required String expectedAccountUuid,
+  }) {
+    if (!_isAccountActive(expectedAccountUuid) ||
+        !_hasResolvedSupportedAssets ||
+        state.pricingLoading ||
+        state.supportedAssetsError != null ||
+        asset.assetId == null) {
+      return false;
+    }
+    final matches = state.supportedExternalAssets.where(
+      (candidate) =>
+          candidate.assetId == asset.assetId &&
+          candidate.chainTicker == asset.chainTicker,
+    );
+    if (matches.length != 1) return false;
+    _clearReviewState();
+    _payEntryGeneration++;
+    _payRetryAsset = null;
+    state = swapStateWithDerivedFiatTexts(
+      swapStateWithIndicativeCounterpart(
+        state.copyWith(
+          direction: SwapDirection.zecToExternal,
+          quoteMode: SwapQuoteMode.exactOutput,
+          externalAsset: matches.single,
+          paymentRequestAssetId: asset.assetId,
+          amountText: '',
+          receiveAmountText: amountText ?? '',
+          amountInputMode: SwapAmountInputMode.token,
+          receiveAmountInputMode: SwapAmountInputMode.token,
+          amountFiatText: '',
+          receiveFiatText: '',
+          destinationText: destination,
+          clearUserExternalContactId: true,
+          reviewVisible: false,
+          depositTxHashText: '',
+          payMode: true,
+          clearReview: true,
+          clearQuoteError: true,
+          clearStatusError: true,
+          clearMaxAmountError: true,
+        ),
+      ),
+    );
+    return true;
+  }
+
   bool preparePayFromShieldedZec({
     SwapAsset? preferredAsset,
     String? expectedAccountUuid,
@@ -298,6 +355,7 @@ class SwapNotifier extends Notifier<SwapState> {
     state = swapStateWithDerivedFiatTexts(
       swapStateWithIndicativeCounterpart(
         state.copyWith(
+          clearPaymentRequest: true,
           direction: SwapDirection.zecToExternal,
           quoteMode: SwapQuoteMode.exactOutput,
           amountText: '',
@@ -351,6 +409,7 @@ class SwapNotifier extends Notifier<SwapState> {
     state = swapStateWithDerivedFiatTexts(
       swapStateWithIndicativeCounterpart(
         state.copyWith(
+          clearPaymentRequest: true,
           direction: SwapDirection.zecToExternal,
           externalAsset: defaultSwapAsset,
           quoteMode: SwapQuoteMode.exactInput,
@@ -427,6 +486,7 @@ class SwapNotifier extends Notifier<SwapState> {
       swapStateWithIndicativeCounterpart(
         swapStateWithTokenAmountsForFiatModes(
           state.copyWith(
+            clearPaymentRequest: true,
             externalAsset: supportedAsset,
             reviewVisible: false,
             destinationText: chainChanged ? '' : null,
@@ -468,6 +528,7 @@ class SwapNotifier extends Notifier<SwapState> {
       swapStateWithIndicativeCounterpart(
         swapStateWithTokenAmountsForFiatModes(
           state.copyWith(
+            clearPaymentRequest: true,
             externalAsset: supportedAsset,
             reviewVisible: false,
             destinationText: clearDestinationOnChainChange && chainChanged
@@ -618,7 +679,13 @@ class SwapNotifier extends Notifier<SwapState> {
         for (final asset in liveAssets)
           if (asset != SwapAsset.zec) asset,
       ];
-      if (supported.isEmpty) return;
+      if (supported.isEmpty) {
+        state = state.copyWith(
+          supportedExternalAssets: const [],
+          clearReview: true,
+        );
+        return;
+      }
       final retryAsset = state.payMode ? _payRetryAsset : null;
       final supportedRetryAsset = retryAsset == null
           ? null
@@ -628,12 +695,20 @@ class SwapNotifier extends Notifier<SwapState> {
           : state.externalAsset;
       final retryUnsupported =
           retryAsset != null && supportedRetryAsset == null;
-      final selected = retryUnsupported
+      final requestAssetId = state.paymentRequestAssetId;
+      final requestMatches = supported.where(
+        (asset) => asset.assetId == requestAssetId,
+      );
+      final selected = requestAssetId != null
+          ? (requestMatches.length == 1
+                ? requestMatches.single
+                : state.externalAsset)
+          : retryUnsupported
           ? retryAsset
           : supportedRetryAsset ??
                 _supportedAssetFor(rememberedAsset, supported) ??
                 supported.first;
-      if (state.payMode) {
+      if (state.payMode && requestAssetId == null) {
         ref.read(paySelectedAssetProvider.notifier).select(selected);
         if (supportedRetryAsset != null && selected != rememberedAsset) {
           unawaited(_persistPaySelectedAsset(selected));
@@ -1062,6 +1137,7 @@ class SwapNotifier extends Notifier<SwapState> {
 
     _quoteGeneration++;
     state = state.copyWith(
+      clearPaymentRequest: true,
       direction: direction,
       externalAsset: selectedExternalAsset,
       quoteMode: retryingPay
@@ -1677,6 +1753,7 @@ class SwapNotifier extends Notifier<SwapState> {
     _payAssetRestoreAccountUuid = null;
     _payAssetRestoreFuture = null;
     state = state.copyWith(
+      clearPaymentRequest: true,
       amountText: '',
       receiveAmountText: '',
       quoteMode: _inputQuoteModeForDirection(state.direction),
@@ -1976,7 +2053,8 @@ class SwapNotifier extends Notifier<SwapState> {
       // A retry is pinned to the intent's original payout rail. Ignore a
       // slower restore of the ordinary Pay preference so it cannot overwrite
       // the prepared retry after navigation.
-      if (state.payMode && _payRetryAsset != null) {
+      if (state.payMode &&
+          (_payRetryAsset != null || state.paymentRequestAssetId != null)) {
         if (loadSucceeded) {
           _restoredPayAssetAccountUuid = accountUuid;
         }
@@ -2148,6 +2226,9 @@ SwapAsset? _supportedAssetFor(SwapAsset asset, List<SwapAsset> supported) {
   for (final candidate in supported) {
     if (candidate == asset) return candidate;
   }
+  // A persisted or requested token ID must not become a same-symbol token.
+  // Static selections without an ID still resolve against the live list.
+  if (asset.assetId != null) return null;
   for (final candidate in supported) {
     if (candidate.hasSameMarketAs(asset)) return candidate;
   }

--- a/lib/src/features/swap/screens/mobile/mobile_swap_review_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_review_screen.dart
@@ -34,11 +34,13 @@ class MobileSwapReviewScreen extends ConsumerStatefulWidget {
   const MobileSwapReviewScreen({
     this.payMode = false,
     this.recipientSelection,
+    this.paymentRequestId,
     super.key,
   });
 
   final bool payMode;
   final PayRecipientSelection? recipientSelection;
+  final String? paymentRequestId;
 
   @override
   ConsumerState<MobileSwapReviewScreen> createState() =>
@@ -48,6 +50,7 @@ class MobileSwapReviewScreen extends ConsumerStatefulWidget {
 class _MobileSwapReviewScreenState
     extends ConsumerState<MobileSwapReviewScreen> {
   var _hadReviewState = false;
+  var _returningToComposer = false;
   var _startingIntent = false;
   var _startIntentInFlight = false;
   SwapState? _startingReviewSnapshot;
@@ -84,12 +87,21 @@ class _MobileSwapReviewScreenState
   }
 
   void _returnToSwap() {
+    _returningToComposer = true;
     ref.read(swapStateProvider.notifier).cancelReviewQuote();
     if (widget.payMode && context.canPop()) {
       context.pop();
       return;
     }
-    context.go(widget.payMode ? '/pay' : '/swap');
+    context.go(
+      widget.payMode ? '/pay' : '/swap',
+      extra: widget.payMode && widget.paymentRequestId != null
+          ? PayComposerNavigationArgs(
+              preservePreparedComposer: true,
+              paymentRequestId: widget.paymentRequestId,
+            )
+          : null,
+    );
   }
 
   void _ensureExpiryTicker(SwapQuote? quote) {
@@ -138,6 +150,7 @@ class _MobileSwapReviewScreenState
       if (!next.reviewVisible ||
           next.reviewQuote == null ||
           next.reviewAddressPlan == null) {
+        _returningToComposer = true;
         if (!widget.payMode) {
           context.go('/swap');
         } else if (context.canPop()) {
@@ -145,8 +158,9 @@ class _MobileSwapReviewScreenState
         } else {
           context.go(
             '/pay',
-            extra: const PayComposerNavigationArgs(
+            extra: PayComposerNavigationArgs(
               preservePreparedComposer: true,
+              paymentRequestId: widget.paymentRequestId,
             ),
           );
         }
@@ -273,9 +287,11 @@ class _MobileSwapReviewScreenState
     final addressBookContacts =
         ref.watch(addressBookProvider).value?.contacts ?? const [];
     if (!swapState.reviewVisible || quote == null || addressPlan == null) {
-      if (!_hadReviewState || !_startingIntent) {
+      if (!_returningToComposer && (!_hadReviewState || !_startingIntent)) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) context.go(widget.payMode ? '/pay' : '/swap');
+          if (!mounted || _returningToComposer) return;
+          if (ModalRoute.of(context)?.isCurrent != true) return;
+          _returnToSwap();
         });
       }
       return const SizedBox.shrink();

--- a/lib/src/providers/payment_uri_prefill_provider.dart
+++ b/lib/src/providers/payment_uri_prefill_provider.dart
@@ -2,12 +2,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/navigation/payment_uri_drain_policy.dart';
-import '../features/send/models/send_prefill_args.dart';
+import '../core/navigation/payment_request_draft.dart';
 
-/// Holds a ZIP-321 payment-URI prefill that has been parsed from a `zcash:`
-/// link but not yet delivered.
+/// Holds a parsed Zcash or cross-chain payment request awaiting its card.
 ///
-/// This exists so the prefill survives the lock screen. A `zcash:` link opened
+/// This exists so the prefill survives the lock screen. A payment link opened
 /// while the wallet is locked routes to `/unlock` and parks the prefill here;
 /// the unlock flow then claims it (via [PaymentUriPrefillNotifier.takeIfFresh])
 /// and presents it as a card over the wallet it just unlocked, so the payment
@@ -23,7 +22,7 @@ import '../features/send/models/send_prefill_args.dart';
 /// Card is a bearer claim on funds held elsewhere, so it queues, never
 /// expires, and outlives a reset. Merging the two would have to pick one set
 /// of those answers and would be wrong for the other product.
-class PaymentUriPrefillNotifier extends Notifier<SendPrefillArgs?> {
+class PaymentUriPrefillNotifier extends Notifier<PaymentRequestDraft?> {
   /// A parked prefill older than this is treated as stale and dropped on the
   /// next unlock. Without it, a link opened then left parked (the user never
   /// unlocks) would fire as a payment on a much later, unrelated unlock.
@@ -32,7 +31,7 @@ class PaymentUriPrefillNotifier extends Notifier<SendPrefillArgs?> {
   DateTime? _parkedAtUtc;
 
   @override
-  SendPrefillArgs? build() => null;
+  PaymentRequestDraft? build() => null;
 
   /// How long the current prefill has been parked, or null when nothing is
   /// parked. The drain policy uses this to drop a prefill that outlived
@@ -50,7 +49,7 @@ class PaymentUriPrefillNotifier extends Notifier<SendPrefillArgs?> {
   /// caller can tell the user the earlier link was dropped. A duplicate
   /// delivery of the same link counts as a replacement too; the caller does
   /// not compare fingerprints.
-  bool set(SendPrefillArgs prefill) {
+  bool set(PaymentRequestDraft prefill) {
     final replacedParkedPrefill = state != null;
     _parkedAtUtc = DateTime.now().toUtc();
     state = prefill;
@@ -76,7 +75,7 @@ class PaymentUriPrefillNotifier extends Notifier<SendPrefillArgs?> {
   /// second is something to tell them about — the unlock flow shows
   /// `kPaymentUriExpiredMessage` for it, matching what the drain policy does
   /// with the same age on every other screen.
-  ({SendPrefillArgs? prefill, bool expired}) takeIfFresh() {
+  ({PaymentRequestDraft? prefill, bool expired}) takeIfFresh() {
     final prefill = state;
     final parkedAt = _parkedAtUtc;
     clear();
@@ -100,6 +99,6 @@ class PaymentUriPrefillNotifier extends Notifier<SendPrefillArgs?> {
 }
 
 final paymentUriPrefillProvider =
-    NotifierProvider<PaymentUriPrefillNotifier, SendPrefillArgs?>(
+    NotifierProvider<PaymentUriPrefillNotifier, PaymentRequestDraft?>(
       PaymentUriPrefillNotifier.new,
     );

--- a/test/app_incoming_link_host_test.dart
+++ b/test/app_incoming_link_host_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/app.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/payment_links/models/vizor_payment_link.dart';
@@ -81,6 +83,15 @@ void main() {
           syncProvider.overrideWith(FakeSyncNotifier.new),
           paymentRequestPrecheckProvider.overrideWithValue(_readyPrecheck()),
           incomingUriServiceProvider.overrideWithValue(incomingUris),
+          crossChainPaymentParserProvider.overrideWithValue(
+            (raw) async => CrossChainPaymentRequest(
+              id: raw,
+              rawUri: raw,
+              address: 'bc1recipient',
+              isEvm: false,
+              chain: 'btc',
+            ),
+          ),
         ],
         child: Consumer(
           builder: (context, ref, _) {
@@ -102,6 +113,44 @@ void main() {
     await tester.pumpAndSettle();
     return (container, router, incomingUris);
   }
+
+  testWidgets('external request uses the card lane and defers a Gift Card', (
+    tester,
+  ) async {
+    final (container, router, incomingUris) = await pumpHost(tester);
+    incomingUris.emit('bitcoin:bc1recipient?amount=0.01');
+    await tester.pumpAndSettle();
+    expect(container.read(crossChainPaymentFlowProvider)?.request.chain, 'btc');
+    expect(container.read(paymentRequestFlowProvider), isNull);
+    expect(router.routerDelegate.currentConfiguration.uri.path, '/home');
+    incomingUris.emit(_paymentLink.toUri().toString());
+    await tester.pumpAndSettle();
+    expect(router.routerDelegate.currentConfiguration.uri.path, '/home');
+    container.read(crossChainPaymentFlowProvider.notifier).clear();
+    await tester.pumpAndSettle();
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      '/payment-links',
+    );
+  });
+
+  testWidgets(
+    'replacing Zcash with an external request leaves one active card',
+    (tester) async {
+      final (container, _, incomingUris) = await pumpHost(tester);
+      incomingUris.emit('zcash:u1recipient?amount=0.5');
+      await tester.pumpAndSettle();
+      expect(container.read(paymentRequestFlowProvider), isNotNull);
+      incomingUris.emit('bitcoin:bc1recipient?amount=0.01');
+      await tester.pumpAndSettle();
+      expect(container.read(crossChainPaymentFlowProvider), isNotNull);
+      expect(container.read(paymentRequestFlowProvider), isNull);
+      incomingUris.emit('zcash:u1newrecipient?amount=0.25');
+      await tester.pumpAndSettle();
+      expect(container.read(crossChainPaymentFlowProvider), isNull);
+      expect(container.read(paymentRequestFlowProvider), isNotNull);
+    },
+  );
 
   testWidgets('one host routes each link kind to its own intake', (
     tester,

--- a/test/app_payment_uri_unlock_claim_test.dart
+++ b/test/app_payment_uri_unlock_claim_test.dart
@@ -1,3 +1,4 @@
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -107,7 +108,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        container.read(paymentUriPrefillProvider)?.address,
+        (container.read(paymentUriPrefillProvider) as SendPrefillArgs?)
+            ?.address,
         'u1parked',
         reason: 'the link stays parked for the unlock flow to claim',
       );
@@ -120,7 +122,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        container.read(paymentUriPrefillProvider)?.address,
+        (container.read(paymentUriPrefillProvider) as SendPrefillArgs?)
+            ?.address,
         'u1parked',
         reason: 'a route change alone must not be mistaken for a claim',
       );
@@ -132,7 +135,10 @@ void main() {
       expect(claim.notice, isNull);
       container
           .read(paymentRequestFlowProvider.notifier)
-          .present(claim.prefill!, source: PaymentRequestSource.link);
+          .present(
+            claim.prefill! as SendPrefillArgs,
+            source: PaymentRequestSource.link,
+          );
       await tester.pumpAndSettle();
 
       expect(container.read(paymentUriPrefillProvider), isNull);

--- a/test/app_payment_uri_wallet_reset_test.dart
+++ b/test/app_payment_uri_wallet_reset_test.dart
@@ -207,7 +207,7 @@ void main() {
 
       final parked = container.read(paymentUriPrefillProvider);
       expect(
-        parked?.address,
+        (parked as SendPrefillArgs?)?.address,
         'u1secondlink',
         reason: 'latest wins: the second link must be the parked one',
       );

--- a/test/core/navigation/incoming_link_dispatch_test.dart
+++ b/test/core/navigation/incoming_link_dispatch_test.dart
@@ -8,6 +8,21 @@ import 'package:zcash_wallet/src/core/navigation/vizor_deep_link.dart';
 // fragment carries a 24-word mnemonic, and the ZIP-321 parser puts fragments
 // of what it rejected into a log line.
 void main() {
+  test(
+    'standard external payment schemes enter the payment lane, even malformed',
+    () {
+      for (final raw in [
+        'bitcoin:broken',
+        'litecoin:broken',
+        'ethereum:broken',
+        'solana:broken',
+        'ETHEREUM:broken',
+      ]) {
+        expect(classifyIncomingLink(raw), isA<IncomingPaymentRequestLink>());
+      }
+    },
+  );
+
   final host = VizorDeepLink.host;
 
   group('host is tested before scheme', () {

--- a/test/core/navigation/payment_request_intake_test.dart
+++ b/test/core/navigation/payment_request_intake_test.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_request_intake.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/core/zcash/zip321_payment_request.dart';
+import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
+import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+
+void main() {
+  ProviderContainer containerFor(CrossChainPaymentParser parser) {
+    final container = ProviderContainer(
+      overrides: [crossChainPaymentParserProvider.overrideWithValue(parser)],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('a slow older parse cannot replace a newer accepted request', () async {
+    final older = _request('older');
+    final newer = _request('newer', solana: true);
+    final olderParse = Completer<CrossChainPaymentRequest>();
+    final newerParse = Completer<CrossChainPaymentRequest>();
+    final received = <String>[];
+    final container = containerFor((raw) {
+      received.add(raw);
+      return raw == older.rawUri ? olderParse.future : newerParse.future;
+    });
+    final intake = container.read(paymentRequestIntakeProvider);
+
+    final pendingOlder = intake.receive('  ${older.rawUri}  ');
+    final pendingNewer = intake.receive(newer.rawUri);
+    newerParse.complete(newer);
+
+    expect(await pendingNewer, isFalse);
+    expect(container.read(paymentUriPrefillProvider), same(newer));
+    expect(container.read(paymentRequestArrivalProvider), 1);
+
+    olderParse.complete(older);
+    expect(await pendingOlder, isFalse);
+    expect(container.read(paymentUriPrefillProvider), same(newer));
+    expect(container.read(paymentRequestArrivalProvider), 1);
+    expect(received, [older.rawUri, newer.rawUri]);
+  });
+
+  test(
+    'an invalid new request preserves the park and supersedes old work',
+    () async {
+      final parked = _request('parked');
+      final older = _request('older');
+      final olderParse = Completer<CrossChainPaymentRequest>();
+      final container = containerFor((raw) {
+        if (raw == parked.rawUri) return Future.value(parked);
+        if (raw == older.rawUri) return olderParse.future;
+        return Future.error(const CrossChainPaymentParseException());
+      });
+      final intake = container.read(paymentRequestIntakeProvider);
+      await intake.receive(parked.rawUri);
+      final pendingOlder = intake.receive(older.rawUri);
+
+      await expectLater(
+        intake.receive('bitcoin:invalid-new-request'),
+        throwsA(isA<CrossChainPaymentParseException>()),
+      );
+      expect(container.read(paymentUriPrefillProvider), same(parked));
+      expect(container.read(paymentRequestArrivalProvider), 1);
+
+      // Even a late error from the superseded parse must not become a new error
+      // on the input surface after the latest request was already rejected.
+      olderParse.completeError(const CrossChainPaymentParseException());
+      expect(await pendingOlder, isFalse);
+      expect(container.read(paymentUriPrefillProvider), same(parked));
+      expect(container.read(paymentRequestArrivalProvider), 1);
+    },
+  );
+
+  test(
+    'reset invalidation prevents an in-flight parse from re-parking',
+    () async {
+      final beforeReset = _request('before-reset');
+      final afterReset = _request('after-reset');
+      final pendingParse = Completer<CrossChainPaymentRequest>();
+      final container = containerFor((raw) {
+        return raw == beforeReset.rawUri
+            ? pendingParse.future
+            : Future.value(afterReset);
+      });
+      final intake = container.read(paymentRequestIntakeProvider);
+      final pending = intake.receive(beforeReset.rawUri);
+
+      intake.invalidate();
+      container.read(paymentUriPrefillProvider.notifier).clear();
+      pendingParse.complete(beforeReset);
+
+      expect(await pending, isFalse);
+      expect(container.read(paymentUriPrefillProvider), isNull);
+      expect(container.read(paymentRequestArrivalProvider), 0);
+
+      expect(await intake.receive(afterReset.rawUri), isFalse);
+      expect(container.read(paymentUriPrefillProvider), same(afterReset));
+      expect(container.read(paymentRequestArrivalProvider), 1);
+    },
+  );
+
+  test(
+    'provider disposal invalidates a parse before it can read disposed state',
+    () async {
+      final request = _request('during-dispose');
+      final parser = Completer<CrossChainPaymentRequest>();
+      final container = ProviderContainer(
+        overrides: [
+          crossChainPaymentParserProvider.overrideWithValue(
+            (_) => parser.future,
+          ),
+        ],
+      );
+      final pending = container
+          .read(paymentRequestIntakeProvider)
+          .receive(request.rawUri);
+
+      container.dispose();
+      parser.complete(request);
+
+      expect(await pending, isFalse);
+    },
+  );
+
+  test(
+    'cross-chain parking keeps identity, replacement, and expiry semantics',
+    () async {
+      final first = _request('first');
+      final second = _request('second', solana: true);
+      final container = containerFor(
+        (raw) => Future.value(raw == first.rawUri ? first : second),
+      );
+      final intake = container.read(paymentRequestIntakeProvider);
+      final park = container.read(paymentUriPrefillProvider.notifier);
+
+      expect(await intake.receive(first.rawUri), isFalse);
+      expect(await intake.receive(second.rawUri), isTrue);
+      final fresh = park.takeIfFresh();
+      expect(fresh.prefill, same(second));
+      expect(fresh.expired, isFalse);
+      expect(container.read(paymentUriPrefillProvider), isNull);
+
+      expect(await intake.receive(first.rawUri), isFalse);
+      park.debugAgePark(
+        PaymentUriPrefillNotifier.parkTtl + const Duration(seconds: 1),
+      );
+      final stale = park.takeIfFresh();
+      expect(stale.prefill, isNull);
+      expect(stale.expired, isTrue);
+      expect(container.read(paymentUriPrefillProvider), isNull);
+      expect(park.takeIfFresh().expired, isFalse);
+      expect(container.read(paymentRequestArrivalProvider), 3);
+    },
+  );
+
+  test(
+    'generic URI detection retains Zcash and rejects unrelated inputs',
+    () async {
+      for (final uri in [
+        'zcash:u1recipient',
+        'bitcoin:recipient',
+        'litecoin:recipient',
+        '  ETHEREUM:recipient  ',
+        'solana:recipient',
+      ]) {
+        expect(isPaymentRequestUri(uri), isTrue, reason: uri);
+      }
+      for (final input in [
+        'u1recipient',
+        '0x1111111111111111111111111111111111111111',
+        'https://example.com/request',
+        'lightning:invoice',
+        'bitcoin-cash:recipient',
+        '',
+      ]) {
+        expect(isPaymentRequestUri(input), isFalse, reason: input);
+      }
+
+      var crossChainParses = 0;
+      final container = containerFor((_) {
+        crossChainParses++;
+        return Future.error(StateError('Zcash must use its existing parser'));
+      });
+      final intake = container.read(paymentRequestIntakeProvider);
+      expect(await intake.receive(' ZCASH:u1recipient?amount=0.25 '), isFalse);
+      final parked = container.read(paymentUriPrefillProvider);
+      expect(parked, isA<SendPrefillArgs>());
+      final zcashPrefill = parked! as SendPrefillArgs;
+      expect(zcashPrefill.address, 'u1recipient');
+      expect(zcashPrefill.amountText, '0.25');
+
+      await expectLater(
+        intake.receive('https://example.com/request'),
+        throwsA(isA<Zip321ParseException>()),
+      );
+      expect(container.read(paymentUriPrefillProvider), same(parked));
+      expect(container.read(paymentRequestArrivalProvider), 1);
+      expect(crossChainParses, 0);
+    },
+  );
+}
+
+CrossChainPaymentRequest _request(String id, {bool solana = false}) {
+  final address = solana
+      ? 'mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN'
+      : '1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo';
+  return CrossChainPaymentRequest(
+    id: id,
+    rawUri: '${solana ? 'solana' : 'bitcoin'}:$address?label=$id',
+    address: address,
+    isEvm: false,
+    chain: solana ? 'sol' : 'btc',
+  );
+}

--- a/test/features/pay/cross_chain_payment_request_host_test.dart
+++ b/test/features/pay/cross_chain_payment_request_host_test.dart
@@ -1,0 +1,3 @@
+import 'cross_chain_payment_request_host_test_support.dart';
+
+void main() => runCrossChainPaymentRequestHostTests(isMobile: false);

--- a/test/features/pay/cross_chain_payment_request_host_test_support.dart
+++ b/test/features/pay/cross_chain_payment_request_host_test_support.dart
@@ -1,0 +1,1583 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
+import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
+import 'package:zcash_wallet/src/features/pay/screens/mobile/mobile_pay_screen.dart';
+import 'package:zcash_wallet/src/features/pay/screens/pay_screen.dart';
+import 'package:zcash_wallet/src/features/pay/widgets/cross_chain_payment_request_host.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_activity_navigation.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
+import 'package:zcash_wallet/src/features/swap/providers/pay_selected_asset_store.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_activity_store.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_composer_preferences_store.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_state_provider.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_zec_staging_address_service.dart';
+import 'package:zcash_wallet/src/features/swap/screens/mobile/mobile_swap_review_screen.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/swap_asset_icon.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/swap_slippage_modal.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+import '../../figma_compare/figma_compare_font_loader.dart';
+
+const _recipient = '0x52908400098527886E0F7030069857D2E4169EE7';
+const _contract = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const _continueKey = ValueKey('cross_chain_payment_request_continue');
+const _cancelKey = ValueKey('cross_chain_payment_request_cancel');
+const _editKey = ValueKey('cross_chain_payment_request_edit');
+const _slippageKey = ValueKey('cross_chain_payment_request_slippage');
+const _account = AccountState(
+  accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+  activeAccountUuid: 'account-1',
+);
+final _usdc = SwapAsset.live(
+  assetId: 'live-base-usdc',
+  symbol: 'USDC',
+  blockchain: 'base',
+  decimals: 6,
+  contractAddress: _contract,
+);
+final _btc = SwapAsset.live(
+  assetId: 'live-btc',
+  symbol: 'BTC',
+  blockchain: 'btc',
+  decimals: 8,
+);
+
+void runCrossChainPaymentRequestHostTests({required bool isMobile}) {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(loadFigmaCompareFonts);
+  testWidgets('request slippage is staged and applied to the review quote', (
+    tester,
+  ) async {
+    final harness = await _readyHarness(
+      tester,
+      isMobile: isMobile,
+      holdQuotes: true,
+    );
+    final original = _composerValues(harness.state);
+    final originalSlippage = harness.state.slippageBps;
+    await tester.tap(find.byKey(_slippageKey));
+    await tester.pumpAndSettle();
+    expect(
+      find.text(
+        'Allows this much extra ZEC for quote movement before execution fails. Network fees are separate.',
+      ),
+      findsOneWidget,
+    );
+    await _captureHost(tester, isMobile: isMobile, state: 'slippage');
+    await _enterSlippage(tester, isMobile: isMobile, value: '1.25');
+    await tester.tap(find.byKey(const ValueKey('swap_slippage_update_button')));
+    await tester.pumpAndSettle();
+    expect(find.text('1.25%'), findsOneWidget);
+    expect(
+      harness.container.read(crossChainPaymentFlowProvider)?.slippageBps,
+      125,
+    );
+    expect(harness.state.slippageBps, originalSlippage);
+    expect(_composerValues(harness.state), original);
+    expect(harness.provider.quoteCalls, 0);
+    await _captureHost(tester, isMobile: isMobile, state: 'slippage-selected');
+
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pump();
+    await tester.pump();
+    expect(harness.provider.requests.single.slippageBps, 125);
+    expect(
+      tester.widget<AppButton>(find.byKey(_slippageKey)).onPressed,
+      isNull,
+    );
+    harness.container
+        .read(crossChainPaymentFlowProvider.notifier)
+        .chooseSlippage(250);
+    expect(
+      harness.container.read(crossChainPaymentFlowProvider)?.slippageBps,
+      125,
+    );
+    harness.provider.completeQuote(0);
+    await tester.pumpAndSettle();
+    expect(harness.state.slippageBps, 125);
+    expect(harness.state.reviewVisible, isTrue);
+    expect(harness.location, isMobile ? '/pay/review' : '/pay');
+    expect(tester.takeException(), isNull);
+    await harness.dispose(tester);
+  });
+
+  testWidgets(
+    'cancelling settings or the request preserves existing slippage',
+    (tester) async {
+      final harness = await _readyHarness(tester, isMobile: isMobile);
+      final originalSlippage = harness.state.slippageBps;
+      await tester.tap(find.byKey(_slippageKey));
+      await tester.pumpAndSettle();
+      await _enterSlippage(tester, isMobile: isMobile, value: '2');
+      await tester.tap(
+        find.byKey(const ValueKey('swap_slippage_cancel_button')),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byKey(_slippageKey), findsOneWidget);
+      expect(
+        harness.container.read(crossChainPaymentFlowProvider)?.slippageBps,
+        isNull,
+      );
+
+      await tester.tap(find.byKey(_slippageKey));
+      await tester.pumpAndSettle();
+      await _enterSlippage(tester, isMobile: isMobile, value: '1.5');
+      if (isMobile) {
+        final back = tester.getRect(
+          find.byKey(const ValueKey('mobile_modal_back_button')),
+        );
+        final sheet = tester.getRect(
+          find.byType(MobileSwapSlippageStepperModal),
+        );
+        expect(back.bottom, lessThan(sheet.top));
+        expect(back.width, 44);
+        expect(back.height, 44);
+      }
+      await tester.tap(
+        find.byKey(
+          ValueKey(
+            isMobile ? 'mobile_modal_back_button' : 'swap_slippage_back_button',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Payment request'), findsOneWidget);
+      expect(
+        harness.container.read(crossChainPaymentFlowProvider)?.slippageBps,
+        isNull,
+      );
+      expect(harness.provider.quoteCalls, 0);
+
+      await tester.tap(find.byKey(_slippageKey));
+      await tester.pumpAndSettle();
+      await _enterSlippage(tester, isMobile: isMobile, value: '2');
+      final slippageTop = tester.getTopLeft(find.text('Slippage')).dy;
+      await tester.tapAt(const Offset(4, 40));
+      if (isMobile) {
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 60));
+        expect(find.text('Slippage'), findsOneWidget);
+        expect(
+          tester.getTopLeft(find.text('Slippage')).dy,
+          greaterThan(slippageTop),
+        );
+        await _captureHost(
+          tester,
+          isMobile: true,
+          state: 'outside-closing',
+          settle: false,
+        );
+      }
+      await tester.pumpAndSettle();
+      expect(find.text('Slippage'), findsNothing);
+      expect(find.text('Payment request'), findsNothing);
+      expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+      expect(harness.state.slippageBps, originalSlippage);
+      expect(harness.provider.quoteCalls, 0);
+      await _captureHost(
+        tester,
+        isMobile: isMobile,
+        state: 'outside-dismissed',
+      );
+
+      harness.present(id: 'request-after-outside-dismissal');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(_slippageKey));
+      await tester.pumpAndSettle();
+      await _enterSlippage(tester, isMobile: isMobile, value: '1');
+      await tester.tap(
+        find.byKey(const ValueKey('swap_slippage_update_button')),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        harness.container.read(crossChainPaymentFlowProvider)?.slippageBps,
+        100,
+      );
+      await tester.tap(find.byKey(_cancelKey));
+      await tester.pumpAndSettle();
+      expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+      expect(harness.state.slippageBps, originalSlippage);
+      expect(harness.provider.quoteCalls, 0);
+      harness.present(id: 'next-request');
+      await tester.pumpAndSettle();
+      expect(
+        harness.container.read(crossChainPaymentFlowProvider)?.slippageBps,
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+      await harness.dispose(tester);
+    },
+  );
+
+  testWidgets('a slippage editor cannot update a replacement request', (
+    tester,
+  ) async {
+    final harness = await _readyHarness(tester, isMobile: isMobile);
+    await tester.tap(find.byKey(_slippageKey));
+    await tester.pumpAndSettle();
+    final submit = isMobile
+        ? tester
+              .widget<MobileSwapSlippageStepperModal>(
+                find.byType(MobileSwapSlippageStepperModal),
+              )
+              .onSubmitted
+        : tester
+              .widget<SwapSlippageModal>(find.byType(SwapSlippageModal))
+              .onSubmitted;
+    harness.present(id: 'replacement');
+    await tester.pumpAndSettle();
+    submit(200);
+    await tester.pumpAndSettle();
+    final flow = harness.container.read(crossChainPaymentFlowProvider)!;
+    expect(flow.request.id, 'replacement');
+    expect(flow.slippageBps, isNull);
+    expect(find.byKey(_slippageKey), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('swap_slippage_update_button')),
+      findsNothing,
+    );
+    expect(harness.provider.quoteCalls, 0);
+    expect(tester.takeException(), isNull);
+    await harness.dispose(tester);
+  });
+
+  if (isMobile) {
+    testWidgets('outside dismissal respects reduced motion', (tester) async {
+      tester.platformDispatcher.accessibilityFeaturesTestValue =
+          const FakeAccessibilityFeatures(disableAnimations: true);
+      addTearDown(
+        tester.platformDispatcher.clearAccessibilityFeaturesTestValue,
+      );
+      final harness = await _readyHarness(tester, isMobile: true);
+      await tester.tapAt(const Offset(4, 40));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(find.text('Payment request'), findsNothing);
+      expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+      expect(tester.takeException(), isNull);
+      await harness.dispose(tester);
+    });
+
+    testWidgets(
+      'dragging slippage settings closes the entire payment request',
+      (tester) async {
+        final harness = await _readyHarness(tester, isMobile: true);
+        final original = _composerValues(harness.state);
+        await tester.tap(find.byKey(_slippageKey));
+        await tester.pumpAndSettle();
+        await _enterSlippage(tester, isMobile: true, value: '1.5');
+        await tester.fling(find.text('Slippage'), const Offset(0, 500), 1200);
+        await tester.pumpAndSettle();
+        expect(find.byType(MobileSwapSlippageStepperModal), findsNothing);
+        expect(find.text('Payment request'), findsNothing);
+        expect(find.byKey(_continueKey), findsNothing);
+        expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+        expect(_composerValues(harness.state), original);
+        expect(harness.location, '/swap');
+        expect(harness.provider.quoteCalls, 0);
+        await _captureHost(tester, isMobile: true, state: 'slippage-dismissed');
+
+        harness.present(id: 'request-after-slippage-dismissal');
+        await tester.pumpAndSettle();
+        expect(find.text('Payment request'), findsOneWidget);
+        expect(
+          harness.container.read(crossChainPaymentFlowProvider)?.slippageBps,
+          isNull,
+        );
+        expect(
+          tester.widget<AppButton>(find.byKey(_continueKey)).onPressed,
+          isNotNull,
+        );
+        expect(tester.takeException(), isNull);
+        await harness.dispose(tester);
+      },
+    );
+    testWidgets('a short drag restores the payment request sheet', (
+      tester,
+    ) async {
+      final harness = await _readyHarness(tester, isMobile: true);
+      final title = find.text('Payment request');
+      final start = tester.getCenter(title);
+      final gesture = await tester.startGesture(start);
+      await gesture.moveBy(const Offset(0, 20));
+      await gesture.moveBy(const Offset(0, 40));
+      await tester.pump();
+
+      expect(tester.getCenter(title).dy, greaterThan(start.dy));
+      await _captureHost(tester, isMobile: true, state: 'dragging');
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(tester.getCenter(title), start);
+      expect(harness.container.read(crossChainPaymentFlowProvider), isNotNull);
+      expect(harness.location, '/swap');
+      expect(harness.provider.quoteCalls, 0);
+      expect(tester.takeException(), isNull);
+      await harness.dispose(tester);
+    });
+
+    testWidgets('drag dismissal cancels a pending payment review', (
+      tester,
+    ) async {
+      final harness = await _readyHarness(
+        tester,
+        isMobile: true,
+        holdQuotes: true,
+      );
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pump();
+      await tester.pump();
+      expect(harness.provider.quoteCalls, 1);
+
+      await tester.fling(
+        find.text('Payment request'),
+        const Offset(0, 400),
+        1000,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Payment request'), findsNothing);
+      expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+
+      harness.provider.completeQuote(0);
+      await tester.pumpAndSettle();
+      expect(harness.location, '/swap');
+      expect(harness.state.reviewQuote, isNull);
+      expect(harness.state.quoteLoading, isFalse);
+      expect(harness.payExtra, isNull);
+
+      harness.present();
+      await tester.pumpAndSettle();
+      expect(find.text('Payment request'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+      await harness.dispose(tester);
+    });
+
+    testWidgets('a closing sheet cannot dismiss a replacement request', (
+      tester,
+    ) async {
+      final harness = await _readyHarness(tester, isMobile: true);
+      final title = find.text('Payment request');
+      final originalTop = tester.getTopLeft(title).dy;
+      await tester.fling(title, const Offset(0, 100), 1000);
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(tester.getTopLeft(title).dy, greaterThan(originalTop));
+
+      harness.present(id: 'replacement');
+      // Finish the old animation in the same frame that mounts the new request.
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Payment request'), findsOneWidget);
+      expect(
+        harness.container.read(crossChainPaymentFlowProvider)!.request.id,
+        'replacement',
+      );
+      expect(tester.getTopLeft(title).dy, originalTop);
+      expect(harness.provider.quoteCalls, 0);
+      expect(tester.takeException(), isNull);
+      await harness.dispose(tester);
+    });
+  }
+
+  for (final newerParked in [false, true]) {
+    testWidgets(
+      'locking during a quote preserves ${newerParked ? 'the newer parked request' : 'the visible request'} for unlock',
+      (tester) async {
+        final harness = await _readyHarness(
+          tester,
+          isMobile: isMobile,
+          holdQuotes: true,
+          controlledSecurity: true,
+        );
+        final flow = harness.container.read(crossChainPaymentFlowProvider)!;
+        final pending = newerParked
+            ? const CrossChainPaymentRequest(
+                id: 'newer-during-lock',
+                rawUri: 'bitcoin:bc1newer?amount=0.1',
+                address: 'bc1newer',
+                isEvm: false,
+                chain: 'btc',
+              )
+            : flow.request;
+        await tester.tap(find.byKey(_continueKey));
+        await tester.pump();
+        await tester.pump();
+        expect(harness.provider.quoteCalls, 1);
+        if (newerParked) {
+          harness.container
+              .read(paymentUriPrefillProvider.notifier)
+              .set(pending);
+        }
+        final security =
+            harness.container.read(appSecurityProvider.notifier)
+                as _ControlledSecurityNotifier;
+        security.setUnlocked(false);
+        await tester.pumpAndSettle();
+        expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+        expect(
+          harness.container.read(paymentUriPrefillProvider),
+          same(pending),
+        );
+        expect(find.byKey(_continueKey), findsNothing);
+
+        harness.provider.completeQuote(0);
+        await tester.pumpAndSettle();
+        expect(harness.location, '/swap');
+        expect(harness.payExtra, isNull);
+        expect(harness.state.reviewVisible, isFalse);
+        expect(harness.state.reviewQuote, isNull);
+        expect(
+          harness.container.read(paymentUriPrefillProvider),
+          same(pending),
+        );
+
+        security.setUnlocked(true);
+        final claimed = harness.container
+            .read(paymentUriPrefillProvider.notifier)
+            .takeIfFresh();
+        harness.container
+            .read(crossChainPaymentFlowProvider.notifier)
+            .present(claimed.prefill! as CrossChainPaymentRequest);
+        await tester.pumpAndSettle();
+        expect(
+          harness.container.read(crossChainPaymentFlowProvider)?.request,
+          same(pending),
+        );
+        expect(find.byKey(_continueKey), findsOneWidget);
+        expect(harness.provider.quoteCalls, 1);
+        expect(tester.takeException(), isNull);
+        await harness.dispose(tester);
+      },
+    );
+  }
+
+  testWidgets('switching accounts during a quote removes the old request', (
+    tester,
+  ) async {
+    final harness = await _readyHarness(
+      tester,
+      isMobile: isMobile,
+      holdQuotes: true,
+    );
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pump();
+    await tester.pump();
+    expect(harness.provider.quoteCalls, 1);
+    (harness.container.read(accountProvider.notifier) as _AccountNotifier)
+        .switchToSecondAccount();
+    await tester.pumpAndSettle();
+    expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+    expect(harness.container.read(paymentUriPrefillProvider), isNull);
+    expect(find.byKey(_continueKey), findsNothing);
+    harness.provider.completeQuote(0);
+    await tester.pumpAndSettle();
+    expect(harness.location, '/swap');
+    expect(harness.payExtra, isNull);
+    expect(harness.state.reviewVisible, isFalse);
+    expect(harness.state.reviewQuote, isNull);
+    expect(
+      harness.container.read(accountProvider).value?.activeAccountUuid,
+      'account-2',
+    );
+    expect(tester.takeException(), isNull);
+    await harness.dispose(tester);
+  });
+
+  testWidgets('Tor startup waits for connected pricing before review', (
+    tester,
+  ) async {
+    final harness = await _pump(
+      tester,
+      isMobile: isMobile,
+      privacy: const NetworkPrivacyState(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+      ),
+    );
+    harness.present();
+    await tester.pumpAndSettle();
+    expect(find.text('Connecting to Tor…'), findsOneWidget);
+    expect(find.text('Loading amount…'), findsOneWidget);
+    expect(_primary(tester).onPressed, isNull);
+    expect(find.textContaining('not available in Vizor'), findsNothing);
+    await _captureHost(tester, isMobile: isMobile, state: 'tor-connecting');
+
+    // Even cached metadata does not enable review before the route is ready.
+    harness.provider.initial.complete(_pricing([_btc, _usdc]));
+    await tester.pumpAndSettle();
+    expect(find.text('Connecting to Tor…'), findsOneWidget);
+    expect(_primary(tester).onPressed, isNull);
+    final privacy =
+        harness.container.read(networkPrivacyProvider.notifier)
+            as _NetworkPrivacyNotifier;
+    privacy.setStatus(NetworkPrivacyConnectionStatus.connected);
+    await tester.pumpAndSettle();
+    expect(find.text('Checking payment options…'), findsOneWidget);
+    expect(harness.provider.pricingCalls, 2);
+    harness.provider.refresh.complete(_pricing([_btc, _usdc]));
+    await tester.pumpAndSettle();
+    expect(find.text('25.000001'), findsOneWidget);
+    expect(_primary(tester).onPressed, isNotNull);
+    expect(harness.provider.quoteCalls, 0);
+    await harness.dispose(tester);
+  });
+
+  testWidgets('Tor failure retries the connection and keeps the request', (
+    tester,
+  ) async {
+    final harness = await _pump(
+      tester,
+      isMobile: isMobile,
+      privacy: const NetworkPrivacyState(
+        torEnabled: true,
+        status: NetworkPrivacyConnectionStatus.connecting,
+      ),
+    );
+    harness.present();
+    await tester.pumpAndSettle();
+    harness.provider.initial.completeError(StateError('Tor bootstrap failed'));
+    final privacy =
+        harness.container.read(networkPrivacyProvider.notifier)
+            as _NetworkPrivacyNotifier;
+    privacy.setStatus(NetworkPrivacyConnectionStatus.failed);
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Could not connect to Tor. Try again to load payment options.'),
+      findsOneWidget,
+    );
+    expect(find.text('Try again'), findsOneWidget);
+    expect(find.text('Amount unavailable'), findsOneWidget);
+    await _captureHost(tester, isMobile: isMobile, state: 'tor-failed');
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pumpAndSettle();
+    expect(privacy.retryCalls, 1);
+    expect(find.text('Connecting to Tor…'), findsOneWidget);
+    expect(harness.location, '/swap');
+    privacy.setStatus(NetworkPrivacyConnectionStatus.connected);
+    await tester.pumpAndSettle();
+    harness.provider.refresh.complete(_pricing([_btc, _usdc]));
+    await tester.pumpAndSettle();
+    expect(find.text('25.000001'), findsOneWidget);
+    expect(_primary(tester).onPressed, isNotNull);
+    expect(
+      harness.container.read(crossChainPaymentFlowProvider)?.request.address,
+      _recipient,
+    );
+    await harness.dispose(tester);
+  });
+
+  testWidgets('token query failure retries without replacing the request', (
+    tester,
+  ) async {
+    final harness = await _pump(tester, isMobile: isMobile);
+    harness.present();
+    await tester.pumpAndSettle();
+    harness.provider.initial.completeError(const SocketException('Offline'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text(
+        'Payment options could not be loaded. Check your connection and try again.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('not available in Vizor'), findsNothing);
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pumpAndSettle();
+    expect(find.text('Checking payment options…'), findsOneWidget);
+    harness.provider.refresh.complete(_pricing([_btc, _usdc]));
+    await tester.pumpAndSettle();
+    expect(find.text('25.000001'), findsOneWidget);
+    expect(_primary(tester).onPressed, isNotNull);
+    expect(harness.provider.quoteCalls, 0);
+    await harness.dispose(tester);
+  });
+
+  testWidgets('loading and cancellation preserve the existing composer', (
+    tester,
+  ) async {
+    final harness = await _pump(tester, isMobile: isMobile);
+    final notifier = harness.container.read(swapStateProvider.notifier);
+    harness.provider.initial.complete(_pricing([_btc, _usdc]));
+    await tester.pumpAndSettle();
+    notifier.selectExternalAsset(_btc);
+    notifier.updateAmount('1.25');
+    notifier.updateDestination('existing draft recipient');
+    final original = _composerValues(harness.state);
+
+    final refresh = notifier.refreshPaymentRequestAssets();
+    harness.present();
+    await tester.pumpAndSettle();
+    expect(find.text('Checking payment options…'), findsOneWidget);
+    expect(find.text('Estimated spend'), findsNothing);
+    expect(_primary(tester).onPressed, isNull);
+    expect(_composerValues(harness.state), original);
+    expect(harness.location, '/swap');
+
+    harness.provider.refresh.complete(
+      SwapPricingSnapshot(usdPrices: {SwapAsset.zec: 200, _btc: 1, _usdc: 1}),
+    );
+    await refresh;
+    await tester.pumpAndSettle();
+    expect(find.text('25.000001'), findsOneWidget);
+    expect(find.text('USDC'), findsOneWidget);
+    expect(find.text('≈ 0.1250 ZEC'), findsOneWidget);
+    expect(_composerValues(harness.state), original);
+    expect(harness.provider.quoteCalls, 0);
+
+    await tester.tap(find.byKey(_cancelKey));
+    await tester.pumpAndSettle();
+    expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+    expect(_composerValues(harness.state), original);
+    expect(harness.location, '/swap');
+    expect(harness.payExtra, isNull);
+    expect(tester.takeException(), isNull);
+    await harness.dispose(tester);
+  });
+
+  testWidgets(
+    'Review prepares one exact-output quote before routing to payment review',
+    (tester) async {
+      final harness = await _pump(tester, isMobile: isMobile, holdQuotes: true);
+      harness.present();
+      await tester.pumpAndSettle();
+      harness.provider.initial.complete(_pricing([_btc, _usdc]));
+      await tester.pumpAndSettle();
+      expect(harness.state.payMode, isFalse);
+      expect(harness.state.destinationText, isEmpty);
+      expect(harness.state.receiveAmountText, isEmpty);
+      expect(find.text('≈ 0.2500 ZEC'), findsOneWidget);
+      expect(find.text('Token details'), findsNothing);
+      expect(harness.provider.quoteCalls, 0);
+
+      await _captureHost(tester, isMobile: isMobile);
+
+      final originalReviewCallback = _primary(tester).onPressed!;
+      await tester.tap(find.byKey(_continueKey));
+      originalReviewCallback();
+      await tester.pump();
+      await tester.pump();
+
+      expect(harness.provider.quoteCalls, 1);
+      expect(harness.location, '/swap');
+      expect(_primary(tester).onPressed, isNull);
+      expect(tester.widget<AppButton>(find.byKey(_editKey)).onPressed, isNull);
+      expect(find.text('Preparing payment review…'), findsOneWidget);
+      expect(
+        harness.container
+            .read(crossChainPaymentFlowProvider)
+            ?.isPreparingReview,
+        isTrue,
+      );
+      final request = harness.provider.requests.single;
+      expect(request.mode, SwapQuoteMode.exactOutput);
+      expect(request.amountText, '25.000001');
+      expect(request.amountAsset, _usdc);
+      expect(request.destination, _recipient);
+      expect(request.refundAddress, 'u1test-orchard-staging-account-1');
+      await _captureHost(tester, isMobile: isMobile, state: 'preparing');
+      harness.provider.completeQuote(0);
+      await tester.pumpAndSettle();
+
+      expect(harness.location, isMobile ? '/pay/review' : '/pay');
+      expect(harness.payExtra, isA<PayComposerNavigationArgs>());
+      final extra = harness.payExtra! as PayComposerNavigationArgs;
+      expect(extra.preservePreparedComposer, isTrue);
+      expect(extra.paymentRequestId, 'request-25-usdc');
+      expect(extra.showPreparedReview, isTrue);
+      expect(extra.reviewAfterAmount, isFalse);
+      expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+      expect(harness.state.direction, SwapDirection.zecToExternal);
+      expect(harness.state.payMode, isTrue);
+      expect(harness.state.quoteMode, SwapQuoteMode.exactOutput);
+      expect(harness.state.receiveAmountText, '25.000001');
+      expect(harness.state.receiveAmountInputMode, SwapAmountInputMode.token);
+      expect(harness.state.destinationText, _recipient);
+      expect(harness.state.externalAsset.assetId, _usdc.assetId);
+      expect(harness.state.externalAsset.contractAddress, _contract);
+      expect(harness.state.paymentRequestAssetId, _usdc.assetId);
+      expect(harness.state.externalAssetIsSupported, isTrue);
+      expect(harness.state.reviewVisible, isTrue);
+      expect(harness.state.reviewQuote, isNotNull);
+      expect(harness.provider.quoteCalls, 1);
+      expect(tester.takeException(), isNull);
+      await harness.dispose(tester);
+    },
+  );
+
+  testWidgets('a refreshed lookalike asset cannot replace the reviewed asset', (
+    tester,
+  ) async {
+    final harness = await _pump(tester, isMobile: isMobile);
+    harness.present();
+    await tester.pumpAndSettle();
+    harness.provider.initial.complete(_pricing([_usdc]));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pumpAndSettle();
+    final original = _composerValues(harness.state);
+    final lookalike = SwapAsset.live(
+      assetId: 'another-base-usdc',
+      symbol: 'USDC',
+      blockchain: 'base',
+      decimals: 6,
+      contractAddress: '0x1111111111111111111111111111111111111111',
+    );
+
+    final refresh = harness.container
+        .read(swapStateProvider.notifier)
+        .refreshPaymentRequestAssets();
+    await tester.pump();
+    expect(harness.state.pricingLoading, isTrue);
+    harness.provider.refresh.complete(_pricing([lookalike]));
+    await refresh;
+    await tester.pumpAndSettle();
+
+    expect(harness.state.paymentRequestAssetId, _usdc.assetId);
+    expect(harness.state.externalAsset, _usdc);
+    expect(_composerValues(harness.state), original);
+    expect(harness.state.supportedExternalAssets, [lookalike]);
+    expect(harness.state.externalAssetIsSupported, isFalse);
+    expect(
+      harness.state.externalAssetSupportError,
+      contains('not currently supported'),
+    );
+    expect(harness.state.canReviewQuote, isFalse);
+    expect(harness.provider.quoteCalls, 1);
+    await harness.dispose(tester);
+  });
+
+  testWidgets(
+    'an asset removed during a pending quote cannot open an actionable review',
+    (tester) async {
+      final harness = await _readyHarness(
+        tester,
+        isMobile: isMobile,
+        holdQuotes: true,
+      );
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pump();
+      await tester.pump();
+      expect(harness.provider.quoteCalls, 1);
+      final impostor = SwapAsset.live(
+        assetId: 'impostor-base-usdc',
+        symbol: 'USDC',
+        blockchain: 'base',
+        decimals: 6,
+        contractAddress: '0x1111111111111111111111111111111111111111',
+      );
+      final refresh = harness.container
+          .read(swapStateProvider.notifier)
+          .refreshPaymentRequestAssets();
+      await tester.pump();
+      harness.provider.refresh.complete(_pricing([impostor]));
+      await refresh;
+      await tester.pumpAndSettle();
+      expect(harness.state.externalAsset, _usdc);
+      expect(harness.state.externalAssetIsAvailable, isFalse);
+
+      harness.provider.completeQuote(0);
+      await tester.pumpAndSettle();
+
+      expect(harness.location, '/swap');
+      expect(harness.payExtra, isNull);
+      expect(harness.state.paymentRequestAssetId, _usdc.assetId);
+      expect(harness.state.reviewVisible, isFalse);
+      expect(harness.state.reviewQuote, isNull);
+      expect(harness.state.reviewAddressPlan, isNull);
+      expect(harness.state.quoteLoading, isFalse);
+      expect(harness.state.canReviewQuote, isFalse);
+      final flow = harness.container.read(crossChainPaymentFlowProvider);
+      expect(flow?.isPreparingReview, isFalse);
+      expect(flow?.reviewError, contains('not currently supported'));
+      expect(find.textContaining('not currently supported'), findsOneWidget);
+      expect(find.byKey(_editKey), findsNothing);
+      expect(harness.provider.quoteCalls, 1);
+      await harness.dispose(tester);
+    },
+  );
+
+  testWidgets('missing network and amount go from selection to amount entry', (
+    tester,
+  ) async {
+    final harness = await _pump(tester, isMobile: isMobile);
+    final eth = SwapAsset.live(
+      assetId: 'live-base-eth',
+      symbol: 'ETH',
+      blockchain: 'base',
+      decimals: 18,
+    );
+    harness.provider.initial.complete(_pricing([_btc, _usdc, eth]));
+    harness.container
+        .read(crossChainPaymentFlowProvider.notifier)
+        .present(
+          const CrossChainPaymentRequest(
+            id: 'no-network-or-amount',
+            rawUri: 'ethereum:$_recipient',
+            address: _recipient,
+            isEvm: true,
+          ),
+        );
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Select the receiving network, then enter an amount.'),
+      findsOneWidget,
+    );
+    expect(_primary(tester).onPressed, isNull);
+    await _captureHost(
+      tester,
+      isMobile: isMobile,
+      state: 'no-network-or-amount',
+    );
+    await tester.tap(find.text('Select network'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('ETH · Base'));
+    await tester.pumpAndSettle();
+    expect(find.text('Amount not specified'), findsOneWidget);
+    expect(find.text('Enter amount'), findsOneWidget);
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pumpAndSettle();
+    expect(harness.location, '/pay');
+    expect(harness.state.receiveAmountText, isEmpty);
+    expect(harness.state.destinationText, _recipient);
+    expect(harness.state.externalAsset, eth);
+    expect(harness.provider.quoteCalls, 0);
+    await harness.dispose(tester);
+  });
+
+  testWidgets('amountless requests enter Pay without preparing a quote', (
+    tester,
+  ) async {
+    final harness = await _readyHarness(
+      tester,
+      isMobile: isMobile,
+      includeAmount: false,
+    );
+    expect(find.text('Enter amount'), findsOneWidget);
+    harness.container
+        .read(crossChainPaymentFlowProvider.notifier)
+        .chooseSlippage(125);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pumpAndSettle();
+
+    expect(harness.location, '/pay');
+    expect(harness.provider.quoteCalls, 0);
+    expect(harness.state.reviewQuote, isNull);
+    expect(harness.state.receiveAmountText, isEmpty);
+    expect(harness.state.destinationText, _recipient);
+    expect(harness.state.externalAsset, _usdc);
+    expect(harness.state.slippageBps, 125);
+    expect(
+      (harness.payExtra! as PayComposerNavigationArgs).showPreparedReview,
+      isFalse,
+    );
+    await harness.dispose(tester);
+  });
+
+  testWidgets('Edit opens the prepared composer with editable payment fields', (
+    tester,
+  ) async {
+    final harness = await _readyHarness(
+      tester,
+      isMobile: isMobile,
+      useRealPayScreens: true,
+    );
+    await tester.tap(find.byKey(_editKey));
+    await tester.pumpAndSettle();
+
+    expect(harness.location, '/pay');
+    expect(harness.provider.quoteCalls, 0);
+    expect(harness.state.reviewQuote, isNull);
+    expect(harness.state.receiveAmountText, '25.000001');
+    expect(harness.state.destinationText, _recipient);
+    expect(harness.state.paymentRequestAssetId, _usdc.assetId);
+    final extra = harness.payExtra! as PayComposerNavigationArgs;
+    expect(extra.preservePreparedComposer, isTrue);
+    expect(extra.showPreparedReview, isFalse);
+    expect(extra.reviewAfterAmount, isFalse);
+    final prefix = isMobile ? 'mobile_pay' : 'pay';
+    await tester.enterText(
+      find.byKey(ValueKey('${prefix}_amount_input')),
+      '12',
+    );
+    await tester.tap(find.byKey(ValueKey('${prefix}_amount_continue_button')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(ValueKey('${prefix}_recipient_step')), findsOneWidget);
+    expect(harness.provider.quoteCalls, 0);
+    await tester.enterText(
+      find.byKey(
+        ValueKey(
+          isMobile
+              ? 'mobile_pay_recipient_input'
+              : 'pay_recipient_search_field',
+        ),
+      ),
+      '0x1111111111111111111111111111111111111111',
+    );
+    await tester.pump();
+    expect(harness.state.receiveAmountText, '12');
+    expect(
+      harness.state.destinationText,
+      '0x1111111111111111111111111111111111111111',
+    );
+    await tester.tap(
+      find.byKey(
+        ValueKey(
+          isMobile
+              ? 'mobile_pay_recipient_continue_button'
+              : 'pay_select_recipient_button',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Review Payment'), findsOneWidget);
+    expect(harness.provider.requests.single.amountText, '12');
+    expect(
+      harness.provider.requests.single.destination,
+      '0x1111111111111111111111111111111111111111',
+    );
+    expect(
+      find.byKey(
+        ValueKey(
+          isMobile ? 'mobile_pay_review_confirm_button' : 'pay_confirm_button',
+        ),
+      ),
+      findsOneWidget,
+    );
+    await _captureHost(tester, isMobile: isMobile, state: 'edited-review');
+    expect(tester.takeException(), isNull);
+    await harness.dispose(tester);
+  });
+
+  testWidgets(
+    'cancelling a pending quote prevents late review and permits reopening',
+    (tester) async {
+      final harness = await _readyHarness(
+        tester,
+        isMobile: isMobile,
+        holdQuotes: true,
+      );
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pump();
+      await tester.pump();
+      expect(harness.provider.quoteCalls, 1);
+      await tester.tapAt(const Offset(4, 40));
+      await tester.pump();
+      if (isMobile) {
+        await tester.pump(const Duration(milliseconds: 60));
+        expect(find.text('Payment request'), findsOneWidget);
+      }
+      harness.provider.completeQuote(0);
+      await tester.pump();
+      expect(harness.location, '/swap');
+      expect(harness.payExtra, isNull);
+      await tester.pumpAndSettle();
+
+      expect(harness.location, '/swap');
+      expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+      expect(harness.state.reviewQuote, isNull);
+      expect(harness.state.quoteLoading, isFalse);
+      expect(harness.payExtra, isNull);
+
+      harness.present();
+      await tester.pumpAndSettle();
+      expect(find.text('Review payment'), findsOneWidget);
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pump();
+      await tester.pump();
+      expect(harness.provider.quoteCalls, 2);
+      harness.provider.completeQuote(1);
+      await tester.pumpAndSettle();
+      expect(harness.location, isMobile ? '/pay/review' : '/pay');
+      await harness.dispose(tester);
+    },
+  );
+
+  testWidgets(
+    'replacement during quote preparation cannot navigate the earlier request',
+    (tester) async {
+      final harness = await _readyHarness(
+        tester,
+        isMobile: isMobile,
+        holdQuotes: true,
+      );
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pump();
+      await tester.pump();
+      const replacementRecipient = '0x1111111111111111111111111111111111111111';
+      harness.present(id: 'replacement', address: replacementRecipient);
+      await tester.pumpAndSettle();
+      harness.provider.completeQuote(0);
+      await tester.pumpAndSettle();
+
+      expect(harness.location, '/swap');
+      expect(harness.payExtra, isNull);
+      expect(harness.state.reviewQuote, isNull);
+      expect(
+        harness.container.read(crossChainPaymentFlowProvider)?.request.id,
+        'replacement',
+      );
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pump();
+      await tester.pump();
+      expect(harness.provider.requests.last.destination, replacementRecipient);
+      harness.provider.completeQuote(1);
+      await tester.pumpAndSettle();
+      expect(
+        (harness.payExtra! as PayComposerNavigationArgs).paymentRequestId,
+        'replacement',
+      );
+      expect(harness.state.destinationText, replacementRecipient);
+      await harness.dispose(tester);
+    },
+  );
+
+  testWidgets('quote failures stay on the card with Retry and Edit', (
+    tester,
+  ) async {
+    final harness = await _readyHarness(
+      tester,
+      isMobile: isMobile,
+      holdQuotes: true,
+    );
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pump();
+    await tester.pump();
+    harness.provider.pendingQuotes[0].completeError(
+      StateError('Quote unavailable'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(harness.location, '/swap');
+    expect(
+      harness.container.read(crossChainPaymentFlowProvider)?.reviewError,
+      isNotNull,
+    );
+    expect(find.text('Try again'), findsOneWidget);
+    expect(tester.widget<AppButton>(find.byKey(_editKey)).onPressed, isNotNull);
+    await tester.tap(find.byKey(_continueKey));
+    await tester.pump();
+    await tester.pump();
+    expect(harness.provider.quoteCalls, 2);
+    expect(harness.provider.requests.last.amountText, '25.000001');
+    expect(harness.provider.requests.last.destination, _recipient);
+    harness.provider.pendingQuotes[1].completeError(
+      StateError('Quote still unavailable'),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(_editKey));
+    await tester.pumpAndSettle();
+    expect(harness.location, '/pay');
+    expect(
+      (harness.payExtra! as PayComposerNavigationArgs).showPreparedReview,
+      isFalse,
+    );
+    expect(harness.provider.quoteCalls, 2);
+    expect(harness.state.receiveAmountText, '25.000001');
+    expect(harness.state.destinationText, _recipient);
+    await harness.dispose(tester);
+  });
+
+  testWidgets(
+    'the same request may be reviewed again after completing a review',
+    (tester) async {
+      final harness = await _readyHarness(tester, isMobile: isMobile);
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pumpAndSettle();
+      expect(harness.provider.quoteCalls, 1);
+      final firstQuote = harness.state.reviewQuote;
+
+      harness.present();
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pumpAndSettle();
+      expect(harness.provider.quoteCalls, 2);
+      expect(harness.state.reviewQuote, isNot(same(firstQuote)));
+      expect(harness.container.read(crossChainPaymentFlowProvider), isNull);
+      expect(harness.location, isMobile ? '/pay/review' : '/pay');
+      await harness.dispose(tester);
+    },
+  );
+
+  testWidgets(
+    'disabled Pay never starts pricing or navigates to the composer',
+    (tester) async {
+      final harness = await _pump(tester, isMobile: isMobile, enabled: false);
+      harness.present();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Pay is not available for this wallet.'),
+        findsOneWidget,
+      );
+      expect(harness.provider.pricingCalls, 0);
+      expect(harness.container.exists(swapStateProvider), isFalse);
+      expect(_primary(tester).onPressed, isNull);
+      await tester.tap(find.byKey(_continueKey));
+      await tester.pumpAndSettle();
+      expect(harness.location, '/swap');
+      expect(harness.payExtra, isNull);
+      expect(harness.provider.pricingCalls, 0);
+      expect(harness.container.exists(swapStateProvider), isFalse);
+      expect(tester.takeException(), isNull);
+      await harness.dispose(tester);
+    },
+  );
+}
+
+AppButton _primary(WidgetTester tester) =>
+    tester.widget<AppButton>(find.byKey(_continueKey));
+
+Object _composerValues(SwapState state) => (
+  state.direction,
+  state.quoteMode == SwapQuoteMode.exactOutput
+      ? state.receiveAmountText
+      : state.amountText,
+  state.destinationText,
+  state.externalAsset,
+  state.quoteMode,
+  state.payMode,
+  state.paymentRequestAssetId,
+);
+
+Future<_Harness> _pump(
+  WidgetTester tester, {
+  required bool isMobile,
+  bool enabled = true,
+  bool holdQuotes = false,
+  bool useRealPayScreens = false,
+  bool controlledSecurity = false,
+  NetworkPrivacyState privacy = const NetworkPrivacyState.off(),
+}) async {
+  tester.view.physicalSize = isMobile
+      ? const Size(390, 844)
+      : const Size(1000, 900);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  final provider = _ControlledPricingProvider(holdQuotes: holdQuotes);
+  final storage = _NoOpSwapStore();
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(
+        AppBootstrapState(
+          initialLocation: '/swap',
+          initialAccountState: _account,
+          initialSyncSnapshot: AppSyncSnapshot.empty,
+          network: 'main',
+          rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+          themeMode: ThemeMode.dark,
+          privacyModeEnabled: false,
+          isPasswordConfigured: true,
+          isUnlocked: true,
+          passwordRotationRecoveryFailed: false,
+        ),
+      ),
+      accountProvider.overrideWith(_AccountNotifier.new),
+      if (controlledSecurity)
+        appSecurityProvider.overrideWith(_ControlledSecurityNotifier.new),
+      if (useRealPayScreens) ...[
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            SyncState(
+              accountUuid: 'account-1',
+              hasAccountScopedData: true,
+              spendableBalance: BigInt.from(10000000000),
+              totalBalance: BigInt.from(10000000000),
+            ),
+          ),
+        ),
+        addressBookRepositoryProvider.overrideWithValue(
+          _EmptyAddressBookRepository(),
+        ),
+      ],
+      networkPrivacyProvider.overrideWith(
+        () => _NetworkPrivacyNotifier(privacy),
+      ),
+      swapFeatureEnabledProvider.overrideWithValue(enabled),
+      swapIntentProvider.overrideWithValue(provider),
+      swapActivityStoreProvider.overrideWithValue(storage),
+      swapComposerPreferencesStoreProvider.overrideWithValue(storage),
+      paySelectedAssetStoreProvider.overrideWithValue(storage),
+      swapZecStagingAddressServiceProvider.overrideWithValue(
+        SwapZecStagingAddressService(
+          reserveFreshOrchardAddress: ({required accountUuid}) async =>
+              'u1test-orchard-staging-$accountUuid',
+        ),
+      ),
+      swapPriceRefreshIntervalProvider.overrideWithValue(
+        const Duration(days: 1),
+      ),
+      swapStatusPollIntervalProvider.overrideWithValue(const Duration(days: 1)),
+    ],
+  );
+  late _Harness harness;
+  final router = GoRouter(
+    initialLocation: '/swap',
+    routes: [
+      GoRoute(
+        path: '/swap',
+        builder: (_, _) => const Scaffold(body: Text('Swap composer')),
+      ),
+      GoRoute(
+        path: '/pay',
+        builder: (_, state) {
+          harness.payExtra = state.extra;
+          if (useRealPayScreens) {
+            final args = state.extra! as PayComposerNavigationArgs;
+            return isMobile
+                ? MobilePayScreen(
+                    key: ValueKey(args.paymentRequestId),
+                    preservePreparedComposer: args.preservePreparedComposer,
+                    paymentRequestId: args.paymentRequestId,
+                    reviewAfterAmount: args.reviewAfterAmount,
+                  )
+                : PayScreen(
+                    key: ValueKey(args.paymentRequestId),
+                    preservePreparedComposer: args.preservePreparedComposer,
+                    paymentRequestId: args.paymentRequestId,
+                    showPreparedReview: args.showPreparedReview,
+                    reviewAfterAmount: args.reviewAfterAmount,
+                  );
+          }
+          return const Scaffold(body: Text('Pay composer'));
+        },
+      ),
+      GoRoute(
+        path: '/pay/review',
+        builder: (_, state) {
+          harness.payExtra = state.extra;
+          if (useRealPayScreens) {
+            return MobileSwapReviewScreen(
+              payMode: true,
+              paymentRequestId: state.extra is PayComposerNavigationArgs
+                  ? (state.extra! as PayComposerNavigationArgs).paymentRequestId
+                  : null,
+            );
+          }
+          return const Scaffold(body: Text('Pay review'));
+        },
+      ),
+    ],
+  );
+  harness = _Harness(container, router, provider);
+  addTearDown(() => harness.dispose(tester));
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        routerConfig: router,
+        builder: (_, child) => AppTheme(
+          data: AppThemeData.dark,
+          child: RepaintBoundary(
+            key: const ValueKey('payment_request_host_capture'),
+            child: CrossChainPaymentRequestHost(router: router, child: child!),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return harness;
+}
+
+Future<void> _captureHost(
+  WidgetTester tester, {
+  required bool isMobile,
+  String state = 'ready',
+  bool settle = true,
+}) async {
+  const directory = String.fromEnvironment('VIZOR_CAPTURE_DIR');
+  if (directory.isEmpty) return;
+  final context = tester.element(
+    find.byKey(const ValueKey('payment_request_host_capture')),
+  );
+  final imagePaths = <String>{
+    for (final icon in tester.widgetList<SwapAssetIcon>(
+      find.byType(SwapAssetIcon),
+    )) ...[
+      icon.asset.tokenIconAsset,
+      if (icon.showChainBadge) icon.asset.chainIconAsset,
+    ],
+  };
+  await tester.runAsync(() async {
+    await Future.wait([
+      for (final path in imagePaths) precacheImage(AssetImage(path), context),
+    ]);
+  });
+  if (settle) {
+    await tester.pumpAndSettle();
+  } else {
+    await tester.pump();
+  }
+  await tester.runAsync(() async {
+    final boundary = tester.renderObject<RenderRepaintBoundary>(
+      find.byKey(const ValueKey('payment_request_host_capture')),
+    );
+    final image = await boundary.toImage(pixelRatio: isMobile ? 1 : 0.6);
+    final bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+    final file = File(
+      '$directory/payment-request-host-${isMobile ? 'mobile' : 'desktop'}${state == 'ready' ? '' : '-$state'}.png',
+    );
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(bytes!.buffer.asUint8List());
+    image.dispose();
+  });
+}
+
+Future<void> _enterSlippage(
+  WidgetTester tester, {
+  required bool isMobile,
+  required String value,
+}) async {
+  if (!isMobile) {
+    await tester.tap(find.byKey(const ValueKey('swap_slippage_custom_card')));
+    await tester.pumpAndSettle();
+  }
+  await tester.enterText(
+    find.byKey(
+      ValueKey(
+        isMobile ? 'mobile_swap_slippage_value' : 'swap_slippage_custom_input',
+      ),
+    ),
+    value,
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<_Harness> _readyHarness(
+  WidgetTester tester, {
+  required bool isMobile,
+  bool holdQuotes = false,
+  bool includeAmount = true,
+  bool useRealPayScreens = false,
+  bool controlledSecurity = false,
+}) async {
+  final harness = await _pump(
+    tester,
+    isMobile: isMobile,
+    holdQuotes: holdQuotes,
+    useRealPayScreens: useRealPayScreens,
+    controlledSecurity: controlledSecurity,
+  );
+  harness.present(includeAmount: includeAmount);
+  await tester.pumpAndSettle();
+  harness.provider.initial.complete(_pricing([_btc, _usdc]));
+  await tester.pumpAndSettle();
+  return harness;
+}
+
+class _Harness {
+  _Harness(this.container, this.router, this.provider);
+  final ProviderContainer container;
+  final GoRouter router;
+  final _ControlledPricingProvider provider;
+  Object? payExtra;
+  bool _disposed = false;
+
+  Future<void> dispose(WidgetTester tester) async {
+    if (_disposed) return;
+    _disposed = true;
+    await tester.pumpWidget(const SizedBox.shrink());
+    container.dispose();
+    router.dispose();
+    await tester.pump();
+  }
+
+  String get location => router.routeInformationProvider.value.uri.path;
+  SwapState get state => container.read(swapStateProvider);
+
+  void present({
+    String id = 'request-25-usdc',
+    String address = _recipient,
+    bool includeAmount = true,
+  }) => container
+      .read(crossChainPaymentFlowProvider.notifier)
+      .present(
+        CrossChainPaymentRequest(
+          id: id,
+          rawUri:
+              'ethereum:$_contract@8453/transfer?address=$address${includeAmount ? '&uint256=25000001' : ''}',
+          address: address,
+          isEvm: true,
+          chainId: '8453',
+          contractAddress: _contract,
+          amount: includeAmount
+              ? PaymentRequestAmount.atomicHex('0x17d7841')
+              : null,
+        ),
+      );
+}
+
+class _AccountNotifier extends AccountNotifier {
+  @override
+  AccountState build() => _account;
+
+  void switchToSecondAccount() {
+    state = AsyncData(
+      state.value!.copyWith(
+        accounts: [
+          ...state.value!.accounts,
+          const AccountInfo(uuid: 'account-2', name: 'Account 2', order: 1),
+        ],
+        activeAccountUuid: 'account-2',
+      ),
+    );
+  }
+}
+
+class _ControlledSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() =>
+      const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+
+  void setUnlocked(bool value) => state = state.copyWith(isUnlocked: value);
+}
+
+class _NetworkPrivacyNotifier extends NetworkPrivacyNotifier {
+  _NetworkPrivacyNotifier(this.initialState);
+  final NetworkPrivacyState initialState;
+  int retryCalls = 0;
+  @override
+  NetworkPrivacyState build() => initialState;
+
+  void setStatus(NetworkPrivacyConnectionStatus status) {
+    state = NetworkPrivacyState(torEnabled: true, status: status);
+  }
+
+  @override
+  Future<void> retry() async {
+    retryCalls++;
+    setStatus(NetworkPrivacyConnectionStatus.connecting);
+  }
+}
+
+class _EmptyAddressBookRepository implements AddressBookRepository {
+  @override
+  Future<List<AddressBookContact>> loadContacts() async => [];
+  @override
+  Future<void> saveContacts(List<AddressBookContact> contacts) async {}
+}
+
+SwapPricingSnapshot _pricing(List<SwapAsset> assets) => SwapPricingSnapshot(
+  usdPrices: {SwapAsset.zec: 100, for (final asset in assets) asset: 1},
+);
+
+class _ControlledPricingProvider implements SwapProvider, SwapPricingProvider {
+  _ControlledPricingProvider({this.holdQuotes = false});
+  final bool holdQuotes;
+  final initial = Completer<SwapPricingSnapshot>();
+  final refresh = Completer<SwapPricingSnapshot>();
+  var pricingCalls = 0;
+  final requests = <SwapQuoteRequest>[];
+  final pendingQuotes = <Completer<SwapQuote>>[];
+  int get quoteCalls => requests.length;
+
+  @override
+  String get providerLabel => 'Test pricing';
+
+  @override
+  Future<SwapPricingSnapshot> loadPricingSnapshot({bool forceRefresh = false}) {
+    pricingCalls++;
+    return pricingCalls == 1 ? initial.future : refresh.future;
+  }
+
+  @override
+  Future<List<SwapAsset>> listSupportedExternalAssets() =>
+      throw StateError('Expected the pricing snapshot to supply live assets');
+
+  @override
+  Future<SwapQuote> quote(SwapQuoteRequest request) {
+    requests.add(request);
+    if (!holdQuotes) return Future.value(_quote(request));
+    final completer = Completer<SwapQuote>();
+    pendingQuotes.add(completer);
+    return completer.future;
+  }
+
+  void completeQuote(int index) =>
+      pendingQuotes[index].complete(_quote(requests[index]));
+
+  SwapQuote _quote(SwapQuoteRequest request) => SwapQuote.estimate(
+    direction: request.direction,
+    externalAsset: request.externalAsset,
+    mode: request.mode,
+    amount: request.amount,
+    providerLabel: providerLabel,
+    externalPerZec: 100,
+  );
+
+  @override
+  Future<SwapIntentSnapshot> getStatus(
+    String intentId, {
+    String? depositMemo,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<SwapIntentSnapshot> startSwap(SwapQuote quote) =>
+      throw UnimplementedError();
+
+  @override
+  Future<SwapIntentSnapshot> submitDepositTransaction({
+    required String depositAddress,
+    required String txHash,
+    String? depositMemo,
+    String? nearSenderAccount,
+  }) => throw UnimplementedError();
+}
+
+class _NoOpSwapStore
+    implements
+        SwapActivityStore,
+        SwapComposerPreferencesStore,
+        PaySelectedAssetStore {
+  @override
+  Future<List<SwapIntentRecord>> loadRecords({
+    required String accountUuid,
+  }) async => [];
+  @override
+  Future<void> saveRecords({
+    required String accountUuid,
+    required List<SwapIntentRecord> records,
+  }) async {}
+  @override
+  Future<void> deleteForAccount({required String accountUuid}) async {}
+  @override
+  Future<SwapComposerPreferences?> loadPreferences({
+    required String accountUuid,
+  }) async => null;
+  @override
+  Future<void> savePreferences({
+    required String accountUuid,
+    required SwapComposerPreferences preferences,
+  }) async {}
+  @override
+  Future<SwapAsset?> loadSelectedAsset({required String accountUuid}) async =>
+      null;
+  @override
+  Future<void> saveSelectedAsset({
+    required String accountUuid,
+    required SwapAsset asset,
+  }) async {}
+}

--- a/test/features/pay/mobile_cross_chain_payment_request_host_test.dart
+++ b/test/features/pay/mobile_cross_chain_payment_request_host_test.dart
@@ -1,0 +1,8 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'cross_chain_payment_request_host_test_support.dart';
+
+void main() => runCrossChainPaymentRequestHostTests(isMobile: true);

--- a/test/features/pay/mobile_pay_review_screen_test.dart
+++ b/test/features/pay/mobile_pay_review_screen_test.dart
@@ -15,6 +15,8 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/pay/models/pay_recent_recipients.dart';
+import 'package:zcash_wallet/src/features/pay/screens/mobile/mobile_pay_screen.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_activity_navigation.dart';
 import 'package:zcash_wallet/src/features/pay/screens/mobile/mobile_pay_submitted_screen.dart';
 import 'package:zcash_wallet/src/features/pay/widgets/mobile/mobile_pay_review_content.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
@@ -28,6 +30,73 @@ import '../../fakes/fake_sync_notifier.dart';
 const _recipient = '0x1111111111111111111111111111111111111111';
 
 void main() {
+  testWidgets(
+    'direct payment request review returns to an editable prepared Pay',
+    (tester) async {
+      tester.view.physicalSize = const Size(393, 852);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final router = GoRouter(
+        initialLocation: '/pay/review',
+        routes: [
+          GoRoute(
+            path: '/pay/review',
+            builder: (_, _) => const MobileSwapReviewScreen(
+              payMode: true,
+              paymentRequestId: 'request-review',
+            ),
+          ),
+          GoRoute(
+            path: '/pay',
+            builder: (_, state) {
+              final args = state.extra! as PayComposerNavigationArgs;
+              expect(args.showPreparedReview, isFalse);
+              expect(args.paymentRequestId, 'request-review');
+              return MobilePayScreen(
+                preservePreparedComposer: args.preservePreparedComposer,
+                paymentRequestId: args.paymentRequestId,
+              );
+            },
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        _app(router, quoteLifetime: const Duration(minutes: 5)),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Review Payment'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('mobile_pay_review_confirm_button')),
+        findsOneWidget,
+      );
+      await tester.tap(find.bySemanticsLabel('Back'));
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('mobile_pay_amount_step')),
+        findsOneWidget,
+      );
+      final input = tester.widget<TextField>(
+        find.byKey(const ValueKey('mobile_pay_amount_input')),
+      );
+      expect(input.controller!.text, '10');
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(MobilePayScreen)),
+        listen: false,
+      );
+      expect(container.read(swapStateProvider).destinationText, _recipient);
+      expect(container.read(swapStateProvider).reviewVisible, isFalse);
+      await tester.enterText(
+        find.byKey(const ValueKey('mobile_pay_amount_input')),
+        '12',
+      );
+      await tester.pump();
+      expect(container.read(swapStateProvider).receiveAmountText, '12');
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets(
     'payment review uses the completed spendable snapshot during sync',
     (tester) async {

--- a/test/features/pay/mobile_pay_screen_test.dart
+++ b/test/features/pay/mobile_pay_screen_test.dart
@@ -152,6 +152,7 @@ class _DelayedPayReviewNotifier extends SwapNotifier {
         mode: SwapQuoteMode.exactOutput,
         amount: 10,
         externalPerZec: 400,
+        quoteExpiresAt: DateTime.now().add(const Duration(minutes: 5)),
       ),
       reviewAddressPlan: const SwapAddressPlan(
         direction: SwapDirection.zecToExternal,
@@ -818,6 +819,129 @@ void main() {
     final state = container.read(swapStateProvider);
     expect(state.externalAsset, SwapAsset.sol);
     expect(state.destinationText, isEmpty);
+  });
+
+  testWidgets('editing a payment request keeps its recipient reachable', (
+    tester,
+  ) async {
+    await _setMobileViewport(tester, const Size(393, 852));
+    final notifier = _DelayedPayReviewNotifier();
+    final router = GoRouter(
+      initialLocation: '/pay',
+      routes: [
+        GoRoute(
+          path: '/pay',
+          builder: (_, _) => const MobilePayScreen(
+            preservePreparedComposer: true,
+            paymentRequestId: 'request-edit',
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(_routedPayApp(router, notifier));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_pay_amount_input')),
+      '12',
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
+    );
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('mobile_pay_recipient_step')),
+      findsOneWidget,
+    );
+    expect(notifier.quoteLoading, isFalse);
+    const changedRecipient = '0x52908400098527886E0F7030069857D2E4169EE7';
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_pay_recipient_input')),
+      changedRecipient,
+    );
+    await tester.pump();
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobilePayScreen)),
+      listen: false,
+    );
+    expect(container.read(swapStateProvider).receiveAmountText, '12');
+    expect(container.read(swapStateProvider).destinationText, changedRecipient);
+    expect(container.read(swapStateProvider).reviewVisible, isFalse);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('payment request amount continues directly to Pay review', (
+    tester,
+  ) async {
+    await _setMobileViewport(tester, const Size(393, 852));
+    final notifier = _DelayedPayReviewNotifier();
+    final router = GoRouter(
+      initialLocation: '/pay',
+      routes: [
+        GoRoute(
+          path: '/pay',
+          builder: (_, _) => const MobilePayScreen(
+            preservePreparedComposer: true,
+            paymentRequestId: 'request-entry',
+            reviewAfterAmount: true,
+          ),
+        ),
+        GoRoute(
+          path: '/pay/review',
+          builder: (_, _) => const MobileSwapReviewScreen(payMode: true),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(_routedPayApp(router, notifier));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_pay_amount_input')),
+      '10',
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
+    );
+    await tester.pump();
+    expect(notifier.quoteLoading, isTrue);
+    expect(
+      find.byKey(const ValueKey('mobile_pay_recipient_step')),
+      findsNothing,
+    );
+    expect(router.routerDelegate.currentConfiguration.uri.path, '/pay');
+    notifier.completeQuote();
+    await tester.pumpAndSettle();
+    expect(find.text('Review Payment'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_pay_review_confirm_button')),
+      findsOneWidget,
+    );
+    await tester.tap(find.bySemanticsLabel('Back'));
+    await tester.pumpAndSettle();
+    expect(router.routerDelegate.currentConfiguration.uri.path, '/pay');
+    expect(
+      find.byKey(const ValueKey('mobile_pay_amount_step')),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const ValueKey('mobile_pay_amount_input')),
+          )
+          .controller!
+          .text,
+      '10',
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('mobile_pay_recipient_step')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('leaving recipient while quote loads cannot open review later', (

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -864,6 +864,100 @@ void main() {
     expect(sessionStore.savedPayAsset, SwapAsset.sol);
   });
 
+  for (final hasAmount in [true, false]) {
+    testWidgets(
+      'payment request Pay entry ${hasAmount ? 'opens prepared review' : 'asks only for amount'}',
+      (tester) async {
+        await _setDesktopViewport(tester);
+        const address = '0x52908400098527886e0f7030069857d2e4169ee7';
+        final provider = _FakeSwapProvider();
+        final router = GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _payRoute()],
+        );
+        addTearDown(router.dispose);
+        await tester.pumpWidget(
+          _routerHarness(
+            router,
+            swapProvider: provider,
+            seedSwapActivityFixtures: false,
+          ),
+        );
+        await tester.pumpAndSettle();
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(SwapScreen)),
+          listen: false,
+        );
+        final notifier = container.read(swapStateProvider.notifier);
+        notifier.preparePayFromShieldedZec();
+        notifier.updateDestination(address);
+        if (hasAmount) {
+          notifier.updateReceiveAmount('25');
+          await notifier.showReview();
+        }
+        router.go(
+          '/pay',
+          extra: PayComposerNavigationArgs(
+            preservePreparedComposer: true,
+            paymentRequestId: 'request-entry',
+            showPreparedReview: hasAmount,
+            reviewAfterAmount: !hasAmount,
+          ),
+        );
+        for (
+          var i = 0;
+          i < 5 && find.byType(PayScreen).evaluate().isEmpty;
+          i++
+        ) {
+          await tester.pump();
+        }
+        expect(find.byType(PayScreen), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('pay_review_step')),
+          hasAmount ? findsOneWidget : findsNothing,
+        );
+        expect(
+          find.byKey(const ValueKey('pay_amount_step')),
+          hasAmount ? findsNothing : findsOneWidget,
+        );
+        expect(find.byKey(const ValueKey('pay_recipient_step')), findsNothing);
+        await tester.pumpAndSettle();
+        expect(provider.requests, hasLength(hasAmount ? 1 : 0));
+        if (hasAmount) {
+          await tester.tap(find.text('Amount').first);
+          await tester.pumpAndSettle();
+        }
+        await tester.enterText(
+          find.byKey(const ValueKey('pay_amount_input')),
+          '30',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('pay_amount_continue_button')),
+        );
+        await tester.pumpAndSettle();
+        if (hasAmount) {
+          expect(
+            find.byKey(const ValueKey('pay_recipient_step')),
+            findsOneWidget,
+          );
+          await tester.tap(
+            find.byKey(const ValueKey('pay_select_recipient_button')),
+          );
+          await tester.pumpAndSettle();
+        }
+        expect(find.byKey(const ValueKey('pay_review_step')), findsOneWidget);
+        expect(find.byKey(const ValueKey('pay_recipient_step')), findsNothing);
+        expect(container.read(swapStateProvider).destinationText, address);
+        expect(container.read(swapStateProvider).receiveAmountText, '30');
+        expect(provider.requests.last.mode, SwapQuoteMode.exactOutput);
+        expect(provider.requests.last.amountText, '30');
+        expect(provider.startedQuotes, isEmpty);
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
   testWidgets('Pay review uses the completed spendable snapshot during sync', (
     tester,
   ) async {
@@ -1013,7 +1107,7 @@ void main() {
   testWidgets('Pay retry waits for its original dynamic asset', (tester) async {
     await _setDesktopViewport(tester);
     final savedBaseUsdc = SwapAsset.live(
-      assetId: 'saved-base-usdc',
+      assetId: 'live-base-usdc',
       symbol: 'USDC',
       blockchain: 'base',
       decimals: 6,
@@ -1105,70 +1199,79 @@ void main() {
     expect(container.read(paySelectedAssetProvider), liveBaseUsdc);
   });
 
-  testWidgets('Pay retry does not substitute an unsupported asset', (
-    tester,
-  ) async {
-    await _setDesktopViewport(tester);
-    final savedBaseUsdc = SwapAsset.live(
-      assetId: 'removed-base-usdc',
-      symbol: 'USDC',
-      blockchain: 'base',
-      decimals: 6,
-    );
-    final swapProvider = _DeferredSupportedAssetsSwapProvider();
-    final router = GoRouter(
-      initialLocation: '/activity/swap/removed-pay?from=pay',
-      routes: [_swapRoute(), _payRoute(), _swapActivityRoute()],
-    );
-    final payIntent =
-        _persistedIntent(
-          id: 'removed-pay',
-          txHash: '',
-          status: SwapIntentStatus.expired,
-          nextAction: 'Start a fresh quote',
-        ).copyWith(
-          sellAmount: '1.5000 ZEC',
-          receiveEstimate: '100 USDC',
-          externalAsset: savedBaseUsdc,
-          payMode: true,
-        );
+  testWidgets(
+    'Pay retry does not substitute a same-symbol token with a different ID',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final savedBaseUsdc = SwapAsset.live(
+        assetId: 'removed-base-usdc',
+        symbol: 'USDC',
+        blockchain: 'base',
+        decimals: 6,
+      );
+      final swapProvider = _DeferredSupportedAssetsSwapProvider();
+      final router = GoRouter(
+        initialLocation: '/activity/swap/removed-pay?from=pay',
+        routes: [_swapRoute(), _payRoute(), _swapActivityRoute()],
+      );
+      final payIntent =
+          _persistedIntent(
+            id: 'removed-pay',
+            txHash: '',
+            status: SwapIntentStatus.expired,
+            nextAction: 'Start a fresh quote',
+          ).copyWith(
+            sellAmount: '1.5000 ZEC',
+            receiveEstimate: '100 USDC',
+            externalAsset: savedBaseUsdc,
+            payMode: true,
+          );
 
-    await tester.pumpWidget(
-      _routerHarness(
-        router,
-        swapProvider: swapProvider,
-        sessionStore: _FakeSwapPersistenceStore(initialIntents: [payIntent]),
-        seedSwapActivityFixtures: false,
-      ),
-    );
-    await _pumpUntilPresent(tester, find.text('Restart swap'));
+      await tester.pumpWidget(
+        _routerHarness(
+          router,
+          swapProvider: swapProvider,
+          sessionStore: _FakeSwapPersistenceStore(initialIntents: [payIntent]),
+          seedSwapActivityFixtures: false,
+        ),
+      );
+      await _pumpUntilPresent(tester, find.text('Restart swap'));
 
-    await tester.tap(find.text('Restart swap'));
-    await tester.pump();
-    swapProvider.completeSupportedAssets(const [SwapAsset.usdc]);
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Restart swap'));
+      await tester.pump();
+      swapProvider.completeSupportedAssets([
+        SwapAsset.usdc,
+        SwapAsset.live(
+          assetId: 'different-base-usdc',
+          symbol: 'USDC',
+          blockchain: 'base',
+          decimals: 6,
+        ),
+      ]);
+      await tester.pumpAndSettle();
 
-    final container = ProviderScope.containerOf(
-      tester.element(find.byType(PayScreen)),
-      listen: false,
-    );
-    final state = container.read(swapStateProvider);
-    expect(state.externalAsset, savedBaseUsdc);
-    expect(container.read(paySelectedAssetProvider), savedBaseUsdc);
-    expect(
-      state.externalAssetSupportError,
-      'USDC on Base is not currently supported.',
-    );
-    expect(find.byKey(const ValueKey('pay_amount_error')), findsOneWidget);
-    expect(
-      tester
-          .widget<AppButton>(
-            find.byKey(const ValueKey('pay_amount_continue_button')),
-          )
-          .onPressed,
-      isNull,
-    );
-  });
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(PayScreen)),
+        listen: false,
+      );
+      final state = container.read(swapStateProvider);
+      expect(state.externalAsset, savedBaseUsdc);
+      expect(container.read(paySelectedAssetProvider), savedBaseUsdc);
+      expect(
+        state.externalAssetSupportError,
+        'USDC on Base is not currently supported.',
+      );
+      expect(find.byKey(const ValueKey('pay_amount_error')), findsOneWidget);
+      expect(
+        tester
+            .widget<AppButton>(
+              find.byKey(const ValueKey('pay_amount_continue_button')),
+            )
+            .onPressed,
+        isNull,
+      );
+    },
+  );
 
   testWidgets('swap status summary shows the captured fiat from the mapper', (
     tester,
@@ -9618,8 +9721,18 @@ GoRoute _payRoute() {
     builder: (_, state) {
       final args = state.extra;
       return PayScreen(
+        key: args is PayComposerNavigationArgs && args.paymentRequestId != null
+            ? ValueKey(args.paymentRequestId)
+            : null,
         preservePreparedComposer:
             args is PayComposerNavigationArgs && args.preservePreparedComposer,
+        paymentRequestId: args is PayComposerNavigationArgs
+            ? args.paymentRequestId
+            : null,
+        showPreparedReview:
+            args is PayComposerNavigationArgs && args.showPreparedReview,
+        reviewAfterAmount:
+            args is PayComposerNavigationArgs && args.reviewAfterAmount,
       );
     },
   );

--- a/test/providers/payment_request_flow_provider_test.dart
+++ b/test/providers/payment_request_flow_provider_test.dart
@@ -578,7 +578,7 @@ void main() {
 
     expect(await pending, isA<PaymentRequestReviewOvertaken>());
     expect(
-      container.read(paymentUriPrefillProvider)?.address,
+      (container.read(paymentUriPrefillProvider) as SendPrefillArgs?)?.address,
       'u1a',
       reason:
           'the unlock flow re-presents the parked request; without the park '
@@ -1496,7 +1496,7 @@ void main() {
         .read(paymentUriPrefillProvider.notifier)
         .takeIfFresh();
     expect(
-      claimed.prefill?.address,
+      (claimed.prefill as SendPrefillArgs?)?.address,
       'u1a',
       reason:
           'the unlock claim is what re-presents it, so the request has to be '
@@ -1520,7 +1520,7 @@ void main() {
     await pumpEventQueue();
 
     expect(
-      container.read(paymentUriPrefillProvider)?.address,
+      (container.read(paymentUriPrefillProvider) as SendPrefillArgs?)?.address,
       'u1newer',
       reason: 'latest link wins, the same answer the park gives everywhere',
     );


### PR DESCRIPTION
External cross-chain links now reach the request card and the existing Pay flow. Opening a request leaves the underlying composer intact; `Review payment` prepares one exact-output quote for the requested recipient asset, while `Edit` opens the prepared fields and amountless requests ask for the amount first. Payment still requires confirmation in the existing review screen.

This is **step 4 of 5** in draft integration PR #654, following merged #655, #658, and #659. It targets `rowan/cross-chain-payments-integration` and connects their parser, native URI delivery, and request UI. QR scanning and pasted/manual URI input in Send/Pay/Swap remain in step 5; only the lifecycle/navigation hunks of shared Pay screen and test files are included here.

## Request intake and lifetime

- Extends the Dart incoming-link classifier to Bitcoin, Litecoin, Ethereum, and Solana requests, completing the native-to-Dart handoff introduced in #658. Existing Zcash and Vizor Gift Card classifications retain their separate handling.
- Introduces `PaymentRequestIntake` with one arrival generation. Slow or failed work from an older request cannot replace a newer request or re-park data after wallet reset or provider disposal.
- Generalizes the pending-request contract to `PaymentRequestDraft` and uses one presentation function from incoming links and both unlock screens. Switching between Zcash and cross-chain requests releases the opposite flow, including any Zcash proposal reservation.
- Retains the existing pending-request expiry and drain policy. Locking parks the visible cross-chain request only when no newer request is already parked, then closes the card and cancels its pending review. Account changes close the old request. Wallet reset invalidates parsing and clears pending/visible payment requests.
- Defers Gift Cards while either request card is visible. Registers the cross-chain host within the existing lock, migration, Linux keyring, and keep-awake hierarchy.

## Pay preparation and navigation

- `preparePayPaymentRequest` checks the active account and loaded asset catalog, then applies the exact asset ID/chain, recipient, amount, ZEC funding direction, and exact-output mode together. It clears stale contact/review/error state.
- Pins the request's asset ID against delayed ordinary Pay preference restoration and catalog refresh. Explicit asset IDs cannot fall back to another same-symbol token. Normal Pay/Swap entry and manual asset selection release the request pin.
- Request Review/Edit prepares the in-memory composer without saving the request asset as the ordinary Pay preference. Opening or dismissing a card before those actions preserves the existing draft.
- Quote preparation rechecks request identity, account, lock state, feature availability, and supported-asset availability before navigating. Replacement, cancellation, account switching, or locking prevents a late quote from reopening review.
- Desktop opens the prepared review directly; mobile routes to `/pay/review`. Amountless requests go from amount entry to review once. Edit entry and returning from review keep recipient editing reachable, and mobile Back/expiry retains the prepared request fields.
- Surfaces Tor startup/failure, asset-loading errors, and quote failures on the card with retry actions. A Tor failure keeps the retained route rather than switching to a direct connection.
- Keys the overlay and card by request ID, giving each replacement fresh UI state. Mobile dismissal marks the request as closing before animation completion, so a late quote cannot navigate during dismissal.

## Review focus

1. The complete external-link → pending request → card → Pay review path, including the existing Zcash and Gift Card boundaries.
2. Latest-arrival ordering, reset invalidation, lock/unlock handoff, and account changes during asynchronous work.
3. Exact recipient asset identity through preference restoration, catalog refresh, quote completion, and unsupported-asset handling.
4. No duplicate quote or late navigation after cancellation/replacement; correct amount/Edit/Back behavior in both form factors.

## Validation

Validated the tree committed as `25adeaf71a`:

- **339 desktop test cases passed:** 336 across the incoming-link, intake, prefill/drain/migration/busy-surface, unlock/reset, Zcash request, cross-chain host, and Pay/Swap regression files; three additional lock/account quote-boundary cases also passed. Re-ran the complete affected desktop host suite after adding those cases: **21 passed**. The initial lane skipped one mobile-tagged file, which passed in the mobile lane below.
- **78 mobile test cases passed** with `--tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`: cross-chain host, Pay review/composer, existing Zcash request host, unlock, modal routing, and app request mounting.
- Added boundary coverage for a quote completing after lock, preservation of a newer parked request, re-presentation after unlock, and account switching while a quote is pending. These assert the visible card, route, pending request, and review state.
- `fvm flutter analyze --no-pub` scoped to all 30 changed Dart files — no issues.
- Captured and inspected six widget-rendered images using `VIZOR_CAPTURE_DIR`: ready request, quote preparation, and the actual Pay review after editing, on both desktop and mobile. Both focused capture tests passed in each lane. Capture reruns are not counted as additional cases above.
- `git diff --check` — passed. Checked the split against the preserved implementation: production lifecycle files match, QR/paste hunks remain for step 5, and earlier persistence/Windows ownership corrections remain intact.

Tests use controlled pricing/quote responses and wallet state. No live 1Click quote, signing/broadcast, native app build, or device URI-opening check was performed for this PR. Native handoff evidence is recorded in #658; final integration checks remain tracked in #654.
