### PR TITLE
Accept payment requests from QR scans and pasted input

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1641,12 +1641,14 @@ class _IncomingLinkHostState extends ConsumerState<_IncomingLinkHost> {
 
   Future<void> _handlePaymentRequestLink(String rawUri) async {
     try {
-      final replaced = await ref
+      final result = await ref
           .read(paymentRequestIntakeProvider)
           .receive(rawUri);
       if (!mounted) return;
       _schedulePendingDrain();
-      if (replaced) _showPaymentUriMessage(kPaymentUriReplacedMessage);
+      if (result == PaymentRequestIntakeResult.replaced) {
+        _showPaymentUriMessage(kPaymentUriReplacedMessage);
+      }
     } on Zip321UnsupportedRequestException catch (error) {
       _showPaymentUriMessage(paymentUriRejectionMessage(error));
     } on Zip321ParseException catch (error) {

--- a/lib/src/core/navigation/payment_request_intake.dart
+++ b/lib/src/core/navigation/payment_request_intake.dart
@@ -13,6 +13,8 @@ bool isPaymentRequestUri(String raw) =>
     raw.trim().toLowerCase().startsWith('zcash:') ||
     isCrossChainPaymentUri(raw.trim());
 
+enum PaymentRequestIntakeResult { ignored, accepted, replaced }
+
 /// One arrival order across native links, QR scans and pasted requests.
 /// A slow parser cannot replace a newer request or re-park after a reset.
 /// Input surfaces may also invalidate their own submission before it is parked.
@@ -23,7 +25,10 @@ class PaymentRequestIntake {
 
   void invalidate() => _generation++;
 
-  Future<bool> receive(String raw, {bool Function()? isCurrent}) async {
+  Future<PaymentRequestIntakeResult> receive(
+    String raw, {
+    bool Function()? isCurrent,
+  }) async {
     final generation = ++_generation;
     final uri = raw.trim();
     try {
@@ -41,14 +46,16 @@ class PaymentRequestIntake {
         );
       }
       if (generation != _generation || isCurrent?.call() == false) {
-        return false;
+        return PaymentRequestIntakeResult.ignored;
       }
       final replaced = ref.read(paymentUriPrefillProvider.notifier).set(draft);
       ref.read(paymentRequestArrivalProvider.notifier).arrived();
-      return replaced;
+      return replaced
+          ? PaymentRequestIntakeResult.replaced
+          : PaymentRequestIntakeResult.accepted;
     } catch (_) {
       if (generation != _generation || isCurrent?.call() == false) {
-        return false;
+        return PaymentRequestIntakeResult.ignored;
       }
       rethrow;
     }
@@ -70,11 +77,14 @@ Future<bool> intakePaymentRequest(
   bool Function()? isCurrent,
 }) async {
   if (!isPaymentRequestUri(raw)) return false;
-  final replaced = await ref
+  final result = await ref
       .read(paymentRequestIntakeProvider)
       .receive(raw, isCurrent: isCurrent);
-  if (isCurrent?.call() == false) return false;
-  if (replaced && ref.context.mounted) {
+  if (result == PaymentRequestIntakeResult.ignored ||
+      isCurrent?.call() == false) {
+    return false;
+  }
+  if (result == PaymentRequestIntakeResult.replaced && ref.context.mounted) {
     showAppToast(ref.context, kPaymentUriReplacedMessage);
   }
   return true;

--- a/lib/src/core/navigation/payment_request_intake.dart
+++ b/lib/src/core/navigation/payment_request_intake.dart
@@ -15,6 +15,7 @@ bool isPaymentRequestUri(String raw) =>
 
 /// One arrival order across native links, QR scans and pasted requests.
 /// A slow parser cannot replace a newer request or re-park after a reset.
+/// Input surfaces may also invalidate their own submission before it is parked.
 class PaymentRequestIntake {
   PaymentRequestIntake(this.ref);
   final Ref ref;
@@ -22,7 +23,7 @@ class PaymentRequestIntake {
 
   void invalidate() => _generation++;
 
-  Future<bool> receive(String raw) async {
+  Future<bool> receive(String raw, {bool Function()? isCurrent}) async {
     final generation = ++_generation;
     final uri = raw.trim();
     try {
@@ -39,12 +40,16 @@ class PaymentRequestIntake {
           payment: request.primaryPayment,
         );
       }
-      if (generation != _generation) return false;
+      if (generation != _generation || isCurrent?.call() == false) {
+        return false;
+      }
       final replaced = ref.read(paymentUriPrefillProvider.notifier).set(draft);
       ref.read(paymentRequestArrivalProvider.notifier).arrived();
       return replaced;
     } catch (_) {
-      if (generation != _generation) return false;
+      if (generation != _generation || isCurrent?.call() == false) {
+        return false;
+      }
       rethrow;
     }
   }
@@ -56,11 +61,19 @@ final paymentRequestIntakeProvider = Provider<PaymentRequestIntake>((ref) {
   return intake;
 });
 
-/// Returns false for a plain address. Parsing failures remain explicit so the
+/// Returns false for a plain address or a cancelled input surface. Parsing
+/// failures remain explicit so the
 /// input surface can show them without silently treating a request as an address.
-Future<bool> intakePaymentRequest(WidgetRef ref, String raw) async {
+Future<bool> intakePaymentRequest(
+  WidgetRef ref,
+  String raw, {
+  bool Function()? isCurrent,
+}) async {
   if (!isPaymentRequestUri(raw)) return false;
-  final replaced = await ref.read(paymentRequestIntakeProvider).receive(raw);
+  final replaced = await ref
+      .read(paymentRequestIntakeProvider)
+      .receive(raw, isCurrent: isCurrent);
+  if (isCurrent?.call() == false) return false;
   if (replaced && ref.context.mounted) {
     showAppToast(ref.context, kPaymentUriReplacedMessage);
   }

--- a/lib/src/features/address_scan/widgets/address_qr_scan_modal.dart
+++ b/lib/src/features/address_scan/widgets/address_qr_scan_modal.dart
@@ -7,6 +7,7 @@ import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/layout/app_form_factor.dart';
+import '../../../core/navigation/payment_request_intake.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -14,6 +15,7 @@ import '../../../core/widgets/app_modal_card.dart' show appModalShadow;
 import '../../../services/camera_permission_settings.dart';
 import '../../../services/qr_scanner.dart';
 import '../domain/address_scan_payload.dart';
+import 'payment_request_input.dart';
 
 enum AddressQrCameraStatus { requesting, denied, active, loading, unavailable }
 
@@ -21,11 +23,15 @@ class AddressQrScanModal extends StatefulWidget {
   const AddressQrScanModal({
     required this.onAddressScanned,
     required this.onCancel,
+    this.onPaymentRequestScanned,
+    this.isRefundAddress = false,
     super.key,
   });
 
   final ValueChanged<String> onAddressScanned;
   final VoidCallback onCancel;
+  final ValueChanged<String>? onPaymentRequestScanned;
+  final bool isRefundAddress;
 
   @override
   State<AddressQrScanModal> createState() => _AddressQrScanModalState();
@@ -228,6 +234,21 @@ class _AddressQrScanModalState extends State<AddressQrScanModal>
 
   void _handleScanComplete(String value) {
     if (_completed) return;
+    if (isPaymentRequestUri(value)) {
+      if (widget.isRefundAddress) {
+        setState(() {
+          _error = paymentRequestRefundAddressMessage;
+          _scanResetToken++;
+        });
+        return;
+      }
+      final onPaymentRequestScanned = widget.onPaymentRequestScanned;
+      if (onPaymentRequestScanned != null) {
+        _completed = true;
+        onPaymentRequestScanned(value.trim());
+        return;
+      }
+    }
     final normalized = normalizeAddressScanPayload(value);
     if (normalized == null || normalized.isEmpty) {
       setState(() {

--- a/lib/src/features/address_scan/widgets/payment_request_input.dart
+++ b/lib/src/features/address_scan/widgets/payment_request_input.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/navigation/payment_request_intake.dart';
+import '../../../core/navigation/payment_uri_drain_policy.dart';
+import '../../../core/payments/cross_chain_payment_request.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_toast.dart';
+import '../../../core/zcash/zip321_payment_request.dart';
+
+const paymentRequestRefundAddressMessage =
+    'Enter or scan a plain refund address. A payment request cannot be used here.';
+
+class PaymentRequestInputNotice extends StatelessWidget {
+  const PaymentRequestInputNotice({required this.onReview, super.key});
+
+  final VoidCallback? onReview;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      Text(
+        'Payment request detected. Review the network, token, and amount before continuing.',
+        style: AppTypography.bodyMedium.copyWith(
+          color: context.colors.text.secondary,
+        ),
+      ),
+      const SizedBox(height: AppSpacing.s),
+      AppButton(
+        key: const ValueKey('review_pasted_payment_request'),
+        expand: true,
+        constrainContent: true,
+        onPressed: onReview,
+        child: const Text(
+          'Review payment request',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+    ],
+  );
+}
+
+/// Accepts the whole request into the common card flow. A failed request stays
+/// a request: callers must never fall through to extracting just its address.
+Future<bool> reviewPaymentRequestFromInput(WidgetRef ref, String raw) async {
+  if (!isPaymentRequestUri(raw)) return false;
+  FocusScope.of(ref.context).unfocus();
+  try {
+    return await intakePaymentRequest(ref, raw);
+  } catch (error) {
+    if (!ref.context.mounted) return false;
+    final message = switch (error) {
+      CrossChainPaymentParseException() => error.toString(),
+      Zip321ParseException() ||
+      Zip321UnsupportedRequestException() => paymentUriRejectionMessage(error),
+      _ => 'This payment request could not be read.',
+    };
+    showAppToast(
+      ref.context,
+      message,
+      iconName: AppIcons.warning,
+      tone: AppToastTone.destructive,
+    );
+    return false;
+  }
+}

--- a/lib/src/features/address_scan/widgets/payment_request_input.dart
+++ b/lib/src/features/address_scan/widgets/payment_request_input.dart
@@ -14,6 +14,17 @@ import '../../../core/zcash/zip321_payment_request.dart';
 const paymentRequestRefundAddressMessage =
     'Enter or scan a plain refund address. A payment request cannot be used here.';
 
+/// Keep an empty field or an unfinished payment scheme local while typing.
+/// Once the input diverges from every scheme it can follow address handling.
+bool isPaymentRequestInputDraft(String raw) {
+  final value = raw.trim().toLowerCase();
+  return isPaymentRequestUri(value) ||
+      const {
+        'zcash',
+        ...crossChainPaymentSchemes,
+      }.any((scheme) => scheme.startsWith(value));
+}
+
 class PaymentRequestInputNotice extends StatelessWidget {
   const PaymentRequestInputNotice({required this.onReview, super.key});
 

--- a/lib/src/features/address_scan/widgets/payment_request_input.dart
+++ b/lib/src/features/address_scan/widgets/payment_request_input.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../core/navigation/payment_request_intake.dart';
 import '../../../core/navigation/payment_uri_drain_policy.dart';
@@ -52,11 +53,26 @@ Future<bool> reviewPaymentRequestFromInput(
   bool Function()? isCurrent,
 }) async {
   if (!isPaymentRequestUri(raw)) return false;
-  FocusScope.of(ref.context).unfocus();
+  final context = ref.context;
+  final delegate = GoRouter.maybeOf(context)?.routerDelegate;
+  final location = delegate?.state.uri;
+  final pageKey = delegate?.state.pageKey;
+  var leftSurface = false;
+  void onRouteChanged() {
+    if (delegate?.state.uri != location || delegate?.state.pageKey != pageKey) {
+      leftSurface = true;
+    }
+  }
+
+  bool isActive() =>
+      context.mounted && !leftSurface && (isCurrent?.call() ?? true);
+
+  FocusScope.of(context).unfocus();
+  delegate?.addListener(onRouteChanged);
   try {
-    return await intakePaymentRequest(ref, raw, isCurrent: isCurrent);
+    return await intakePaymentRequest(ref, raw, isCurrent: isActive);
   } catch (error) {
-    if (!ref.context.mounted || isCurrent?.call() == false) return false;
+    if (!isActive()) return false;
     final message = switch (error) {
       CrossChainPaymentParseException() => error.toString(),
       Zip321ParseException() ||
@@ -70,5 +86,7 @@ Future<bool> reviewPaymentRequestFromInput(
       tone: AppToastTone.destructive,
     );
     return false;
+  } finally {
+    delegate?.removeListener(onRouteChanged);
   }
 }

--- a/lib/src/features/address_scan/widgets/payment_request_input.dart
+++ b/lib/src/features/address_scan/widgets/payment_request_input.dart
@@ -46,13 +46,17 @@ class PaymentRequestInputNotice extends StatelessWidget {
 
 /// Accepts the whole request into the common card flow. A failed request stays
 /// a request: callers must never fall through to extracting just its address.
-Future<bool> reviewPaymentRequestFromInput(WidgetRef ref, String raw) async {
+Future<bool> reviewPaymentRequestFromInput(
+  WidgetRef ref,
+  String raw, {
+  bool Function()? isCurrent,
+}) async {
   if (!isPaymentRequestUri(raw)) return false;
   FocusScope.of(ref.context).unfocus();
   try {
-    return await intakePaymentRequest(ref, raw);
+    return await intakePaymentRequest(ref, raw, isCurrent: isCurrent);
   } catch (error) {
-    if (!ref.context.mounted) return false;
+    if (!ref.context.mounted || isCurrent?.call() == false) return false;
     final message = switch (error) {
       CrossChainPaymentParseException() => error.toString(),
       Zip321ParseException() ||

--- a/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
+++ b/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
@@ -8,10 +8,12 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_bottom_safe_area.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
+import '../../../../core/navigation/payment_request_intake.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../address_book/models/address_book_contact.dart';
 import '../../../address_scan/domain/address_scan_payload.dart';
 import '../../../address_scan/widgets/mobile_address_scan_card.dart';
+import '../../../address_scan/widgets/payment_request_input.dart';
 import '../../../address_scan/widgets/mobile_address_scan_view.dart'
     show MobileScanOutcome;
 import '../../../../providers/account_provider.dart';
@@ -61,6 +63,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
   int _reviewRequestGeneration = 0;
   bool _reviewAfterAmount = false;
   var _step = _MobilePayStep.amount;
+  String? _paymentRequestText;
 
   @override
   void initState() {
@@ -139,12 +142,29 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
   }
 
   void _handleAddressScanned(String value) {
+    if (isPaymentRequestUri(value)) {
+      unawaited(_reviewInputPaymentRequest(value));
+      return;
+    }
     _handleAddressChanged(value);
     _closePayModal();
   }
 
   void _handleAddressChanged(String value) {
+    if (isPaymentRequestUri(value)) {
+      setState(() => _paymentRequestText = value);
+      return;
+    }
+    if (_paymentRequestText != null) setState(() => _paymentRequestText = null);
     ref.read(swapStateProvider.notifier).updateDestination(value);
+  }
+
+  Future<void> _reviewInputPaymentRequest(String raw) async {
+    _closePayModal();
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    final accepted = await reviewPaymentRequestFromInput(ref, raw);
+    if (accepted && mounted) setState(() => _paymentRequestText = null);
   }
 
   void _chooseRecipient(PayRecipientSelection selection) {
@@ -203,10 +223,13 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
                 onClose: _closePayModal,
               ),
               _PayModalSurface.addressScanner => MobileAddressScanCard(
-                caption: 'Scan the recipient address QR code',
+                caption: 'Scan an address or payment request QR code',
                 permissionTitle: 'Scan the recipient address',
                 steadyHint: 'Keep the QR code steady and fully visible.',
                 resolve: (raw) async {
+                  if (isPaymentRequestUri(raw)) {
+                    return MobileScanOutcome.accepted(raw.trim());
+                  }
                   final address = normalizeAddressScanPayload(raw)?.trim();
                   if (address == null || address.isEmpty) {
                     return const MobileScanOutcome.rejected(
@@ -294,7 +317,10 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
           ? swapState.receiveFiatText
           : swapState.receiveAmountText,
     );
-    _syncController(_recipientController, swapState.destinationText);
+    _syncController(
+      _recipientController,
+      _paymentRequestText ?? swapState.destinationText,
+    );
 
     final network = AddressBookNetwork.tryFromChainTicker(
       swapState.externalAsset.chainTicker,
@@ -387,7 +413,8 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
                   ),
                   _MobilePayStep.recipient => MobilePayRecipientStep(
                     controller: _recipientController,
-                    typedAddress: swapState.destinationText,
+                    typedAddress:
+                        _paymentRequestText ?? swapState.destinationText,
                     addressError: swapState.destinationAddressFormatError,
                     quoteError:
                         swapState.externalAssetSupportError ??
@@ -401,6 +428,9 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
                     selectedContactId: swapState.userExternalContactId,
                     externalAsset: swapState.externalAsset,
                     onAddressChanged: _handleAddressChanged,
+                    onReviewPaymentRequest: () => unawaited(
+                      _reviewInputPaymentRequest(_recipientController.text),
+                    ),
                     onOpenScanner: () =>
                         _openModal(_PayModalSurface.addressScanner),
                     onChooseRecipient: _chooseRecipient,

--- a/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
+++ b/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
@@ -64,6 +64,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
   bool _reviewAfterAmount = false;
   var _step = _MobilePayStep.amount;
   String? _paymentRequestText;
+  var _paymentRequestGeneration = 0;
 
   @override
   void initState() {
@@ -151,6 +152,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
   }
 
   void _handleAddressChanged(String value) {
+    _paymentRequestGeneration++;
     if (isPaymentRequestUri(value)) {
       setState(() => _paymentRequestText = value);
       return;
@@ -160,14 +162,30 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
   }
 
   Future<void> _reviewInputPaymentRequest(String raw) async {
+    final generation = ++_paymentRequestGeneration;
+    final reviewGeneration = _reviewRequestGeneration;
+    final step = _step;
+    final input = _recipientController.text;
+    bool isCurrent() =>
+        mounted &&
+        generation == _paymentRequestGeneration &&
+        reviewGeneration == _reviewRequestGeneration &&
+        step == _step &&
+        input == _recipientController.text &&
+        _payModal.value == null;
     _closePayModal();
     await WidgetsBinding.instance.endOfFrame;
-    if (!mounted) return;
-    final accepted = await reviewPaymentRequestFromInput(ref, raw);
-    if (accepted && mounted) setState(() => _paymentRequestText = null);
+    if (!isCurrent()) return;
+    final accepted = await reviewPaymentRequestFromInput(
+      ref,
+      raw,
+      isCurrent: isCurrent,
+    );
+    if (accepted && isCurrent()) setState(() => _paymentRequestText = null);
   }
 
   void _chooseRecipient(PayRecipientSelection selection) {
+    _paymentRequestGeneration++;
     final notifier = ref.read(swapStateProvider.notifier);
     final contactId = selection.contactId;
     if (contactId == null) {

--- a/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
+++ b/lib/src/features/pay/screens/mobile/mobile_pay_screen.dart
@@ -153,7 +153,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
 
   void _handleAddressChanged(String value) {
     _paymentRequestGeneration++;
-    if (isPaymentRequestUri(value)) {
+    if (isPaymentRequestInputDraft(value)) {
       setState(() => _paymentRequestText = value);
       return;
     }
@@ -186,6 +186,7 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
 
   void _chooseRecipient(PayRecipientSelection selection) {
     _paymentRequestGeneration++;
+    setState(() => _paymentRequestText = null);
     final notifier = ref.read(swapStateProvider.notifier);
     final contactId = selection.contactId;
     if (contactId == null) {
@@ -433,7 +434,9 @@ class _MobilePayScreenState extends ConsumerState<MobilePayScreen> {
                     controller: _recipientController,
                     typedAddress:
                         _paymentRequestText ?? swapState.destinationText,
-                    addressError: swapState.destinationAddressFormatError,
+                    addressError: swapState
+                        .copyWith(destinationText: _paymentRequestText)
+                        .destinationAddressFormatError,
                     quoteError:
                         swapState.externalAssetSupportError ??
                         swapState.quoteError,

--- a/lib/src/features/pay/screens/pay_screen.dart
+++ b/lib/src/features/pay/screens/pay_screen.dart
@@ -73,6 +73,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   late final TextEditingController _recipientController;
   _PayModalSurface? _payModal;
   String? _paymentRequestText;
+  var _paymentRequestGeneration = 0;
   var _wizardStep = _PayWizardStep.amount;
   var _startingIntent = false;
   var _reviewRequestGeneration = 0;
@@ -153,6 +154,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   }
 
   void _handleAddressChanged(String value) {
+    _paymentRequestGeneration++;
     if (isPaymentRequestUri(value)) {
       setState(() => _paymentRequestText = value);
       return;
@@ -162,14 +164,30 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   }
 
   Future<void> _reviewInputPaymentRequest(String raw) async {
+    final generation = ++_paymentRequestGeneration;
+    final reviewGeneration = _reviewRequestGeneration;
+    final step = _wizardStep;
+    final input = _recipientController.text;
+    bool isCurrent() =>
+        mounted &&
+        generation == _paymentRequestGeneration &&
+        reviewGeneration == _reviewRequestGeneration &&
+        step == _wizardStep &&
+        input == _recipientController.text &&
+        _payModal == null;
     _closePayModal();
     await WidgetsBinding.instance.endOfFrame;
-    if (!mounted) return;
-    final accepted = await reviewPaymentRequestFromInput(ref, raw);
-    if (accepted && mounted) setState(() => _paymentRequestText = null);
+    if (!isCurrent()) return;
+    final accepted = await reviewPaymentRequestFromInput(
+      ref,
+      raw,
+      isCurrent: isCurrent,
+    );
+    if (accepted && isCurrent()) setState(() => _paymentRequestText = null);
   }
 
   void _chooseRecipient(PayRecipientSelection selection) {
+    _paymentRequestGeneration++;
     final notifier = ref.read(swapStateProvider.notifier);
     final contactId = selection.contactId;
     if (contactId == null) {

--- a/lib/src/features/pay/screens/pay_screen.dart
+++ b/lib/src/features/pay/screens/pay_screen.dart
@@ -155,7 +155,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
 
   void _handleAddressChanged(String value) {
     _paymentRequestGeneration++;
-    if (isPaymentRequestUri(value)) {
+    if (isPaymentRequestInputDraft(value)) {
       _cancelReviewForPaymentRequest();
       setState(() => _paymentRequestText = value);
       return;
@@ -195,6 +195,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
 
   void _chooseRecipient(PayRecipientSelection selection) {
     _paymentRequestGeneration++;
+    setState(() => _paymentRequestText = null);
     final notifier = ref.read(swapStateProvider.notifier);
     final contactId = selection.contactId;
     if (contactId == null) {
@@ -413,7 +414,9 @@ class _PayScreenState extends ConsumerState<PayScreen> {
     };
     final recipientActions = PayRecipientActions(
       typedAddress: swapState.destinationText,
-      addressError: swapState.destinationAddressFormatError,
+      addressError: swapState
+          .copyWith(destinationText: _paymentRequestText)
+          .destinationAddressFormatError,
       contacts: contacts,
       busy: swapState.quoteLoading,
       enabled: swapState.externalAssetIsAvailable && !addressBookInitialLoading,
@@ -507,7 +510,9 @@ class _PayScreenState extends ConsumerState<PayScreen> {
                   controller: _recipientController,
                   typedAddress:
                       _paymentRequestText ?? swapState.destinationText,
-                  addressError: swapState.destinationAddressFormatError,
+                  addressError: swapState
+                      .copyWith(destinationText: _paymentRequestText)
+                      .destinationAddressFormatError,
                   contacts: contacts,
                   recents: recents,
                   busy: swapState.quoteLoading,

--- a/lib/src/features/pay/screens/pay_screen.dart
+++ b/lib/src/features/pay/screens/pay_screen.dart
@@ -7,12 +7,14 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/navigation/payment_request_intake.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_scan/widgets/address_qr_scan_modal.dart';
+import '../../address_scan/widgets/payment_request_input.dart';
 import '../../send/widgets/verify_address_modal.dart';
 import '../../../providers/account_provider.dart';
 import '../../address_book/providers/address_book_provider.dart';
@@ -70,6 +72,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   late final FocusNode _amountFocusNode;
   late final TextEditingController _recipientController;
   _PayModalSurface? _payModal;
+  String? _paymentRequestText;
   var _wizardStep = _PayWizardStep.amount;
   var _startingIntent = false;
   var _reviewRequestGeneration = 0;
@@ -141,12 +144,29 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   }
 
   void _handleAddressScanned(String value) {
+    if (isPaymentRequestUri(value)) {
+      unawaited(_reviewInputPaymentRequest(value));
+      return;
+    }
     _handleAddressChanged(value);
     _closePayModal();
   }
 
   void _handleAddressChanged(String value) {
+    if (isPaymentRequestUri(value)) {
+      setState(() => _paymentRequestText = value);
+      return;
+    }
+    if (_paymentRequestText != null) setState(() => _paymentRequestText = null);
     ref.read(swapStateProvider.notifier).updateDestination(value);
+  }
+
+  Future<void> _reviewInputPaymentRequest(String raw) async {
+    _closePayModal();
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    final accepted = await reviewPaymentRequestFromInput(ref, raw);
+    if (accepted && mounted) setState(() => _paymentRequestText = null);
   }
 
   void _chooseRecipient(PayRecipientSelection selection) {
@@ -287,7 +307,10 @@ class _PayScreenState extends ConsumerState<PayScreen> {
           ? swapState.receiveFiatText
           : swapState.receiveAmountText,
     );
-    _syncController(_recipientController, swapState.destinationText);
+    _syncController(
+      _recipientController,
+      _paymentRequestText ?? swapState.destinationText,
+    );
 
     final network = AddressBookNetwork.tryFromChainTicker(
       swapState.externalAsset.chainTicker,
@@ -388,7 +411,9 @@ class _PayScreenState extends ConsumerState<PayScreen> {
         },
       ),
       _PayWizardStep.recipient =>
-        recipientActions.visible ? recipientActions : null,
+        _paymentRequestText == null && recipientActions.visible
+            ? recipientActions
+            : null,
       _PayWizardStep.review =>
         quote == null
             ? swapState.quoteLoading
@@ -455,7 +480,8 @@ class _PayScreenState extends ConsumerState<PayScreen> {
                 ),
                 _PayWizardStep.recipient => PayRecipientStep(
                   controller: _recipientController,
-                  typedAddress: swapState.destinationText,
+                  typedAddress:
+                      _paymentRequestText ?? swapState.destinationText,
                   addressError: swapState.destinationAddressFormatError,
                   contacts: contacts,
                   recents: recents,
@@ -465,6 +491,9 @@ class _PayScreenState extends ConsumerState<PayScreen> {
                       !addressBookInitialLoading,
                   selectedContactId: swapState.userExternalContactId,
                   onAddressChanged: _handleAddressChanged,
+                  onReviewPaymentRequest: () => unawaited(
+                    _reviewInputPaymentRequest(_recipientController.text),
+                  ),
                   onOpenScanner: () => setState(
                     () => _payModal = _PayModalSurface.addressScanner,
                   ),
@@ -524,6 +553,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
                     ),
                     _PayModalSurface.addressScanner => AddressQrScanModal(
                       onAddressScanned: _handleAddressScanned,
+                      onPaymentRequestScanned: _handleAddressScanned,
                       onCancel: _closePayModal,
                     ),
                     // The contact picker surface is mobile-only; the desktop

--- a/lib/src/features/pay/screens/pay_screen.dart
+++ b/lib/src/features/pay/screens/pay_screen.dart
@@ -156,6 +156,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   void _handleAddressChanged(String value) {
     _paymentRequestGeneration++;
     if (isPaymentRequestUri(value)) {
+      _cancelReviewForPaymentRequest();
       setState(() => _paymentRequestText = value);
       return;
     }
@@ -163,7 +164,13 @@ class _PayScreenState extends ConsumerState<PayScreen> {
     ref.read(swapStateProvider.notifier).updateDestination(value);
   }
 
+  void _cancelReviewForPaymentRequest() {
+    _reviewRequestGeneration++;
+    ref.read(swapStateProvider.notifier).cancelReviewQuote();
+  }
+
   Future<void> _reviewInputPaymentRequest(String raw) async {
+    _cancelReviewForPaymentRequest();
     final generation = ++_paymentRequestGeneration;
     final reviewGeneration = _reviewRequestGeneration;
     final step = _wizardStep;

--- a/lib/src/features/pay/widgets/cross_chain_payment_request_card.dart
+++ b/lib/src/features/pay/widgets/cross_chain_payment_request_card.dart
@@ -390,6 +390,10 @@ class _CrossChainPaymentRequestCardState
     final request = widget.request;
     final resolution = widget.resolution;
     final asset = resolution.asset;
+    final loadingAsset =
+        widget.isLoading && asset == null && request.unsupportedReason == null;
+    final loadingAmount =
+        loadingAsset && request.amount != null && !resolution.needsNetwork;
     final hasNetworkPicker =
         request.needsNetwork && request.unsupportedReason == null;
     final value = hasAmount
@@ -406,16 +410,28 @@ class _CrossChainPaymentRequestCardState
                 ? AppTypography.headlineLarge
                 : AppTypography.bodyMediumStrong)
             .copyWith(color: context.colors.text.accent);
-    final amount = Text(
-      value,
-      key: const ValueKey('cross_chain_payment_request_amount'),
-      softWrap: true,
-      style: amountStyle,
-    );
+    final amount = loadingAmount
+        ? const _RequestSkeleton(
+            key: ValueKey('payment_request_amount_skeleton'),
+            width: 112,
+            height: 28,
+          )
+        : Text(
+            value,
+            key: const ValueKey('cross_chain_payment_request_amount'),
+            softWrap: true,
+            style: amountStyle,
+          );
     final identity = Wrap(
       spacing: AppSpacing.xs,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
+        if (loadingAsset)
+          const _RequestSkeleton(
+            key: ValueKey('payment_request_token_skeleton'),
+            width: 48,
+            height: 14,
+          ),
         if (asset != null)
           Text(
             asset.symbol,
@@ -444,14 +460,21 @@ class _CrossChainPaymentRequestCardState
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         amount,
-        if (asset != null || !hasNetworkPicker) ...[
+        if (asset != null || loadingAsset || !hasNetworkPicker) ...[
           const SizedBox(height: AppSpacing.xxs),
           identity,
         ],
       ],
     );
     const iconSize = 48.0;
-    final icon = asset == null
+    final icon = loadingAsset
+        ? const _RequestSkeleton(
+            key: ValueKey('payment_request_icon_skeleton'),
+            width: iconSize,
+            height: iconSize,
+            circular: true,
+          )
+        : asset == null
         ? null
         : ExcludeSemantics(
             child: SwapAssetIcon(
@@ -717,5 +740,38 @@ class _Detail extends StatelessWidget {
       const SizedBox(height: AppSpacing.xxs),
       child,
     ],
+  );
+}
+
+/// Static placeholders keep the unresolved layout visible without adding motion.
+class _RequestSkeleton extends StatelessWidget {
+  const _RequestSkeleton({
+    required this.width,
+    required this.height,
+    this.circular = false,
+    super.key,
+  });
+
+  final double width;
+  final double height;
+  final bool circular;
+
+  @override
+  Widget build(BuildContext context) => ExcludeSemantics(
+    child: Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            context.colors.background.neutralSubtleOpacity,
+            context.colors.background.overlay,
+          ],
+        ),
+        borderRadius: BorderRadius.circular(
+          circular ? AppRadii.full : AppRadii.small,
+        ),
+      ),
+    ),
   );
 }

--- a/lib/src/features/pay/widgets/mobile/mobile_pay_recipient_step.dart
+++ b/lib/src/features/pay/widgets/mobile/mobile_pay_recipient_step.dart
@@ -2,11 +2,13 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart' show TextInputAction;
 
 import '../../../../core/theme/app_theme.dart';
+import '../../../../core/navigation/payment_request_intake.dart';
 import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_profile_picture.dart';
 import '../../../../core/widgets/mobile_text_field.dart';
 import '../../../address_book/models/address_book_contact.dart';
+import '../../../address_scan/widgets/payment_request_input.dart';
 import '../../../address_book/models/address_book_label_lookup.dart';
 import '../../../swap/models/swap_address_formatting.dart';
 import '../../../swap/models/swap_models.dart';
@@ -37,6 +39,7 @@ class MobilePayRecipientStep extends StatefulWidget {
     required this.onChooseRecipient,
     required this.onSelectRecipient,
     required this.onAddToContacts,
+    this.onReviewPaymentRequest,
     super.key,
   });
 
@@ -55,6 +58,7 @@ class MobilePayRecipientStep extends StatefulWidget {
   final ValueChanged<PayRecipientSelection> onChooseRecipient;
   final VoidCallback onSelectRecipient;
   final VoidCallback onAddToContacts;
+  final VoidCallback? onReviewPaymentRequest;
 
   @override
   State<MobilePayRecipientStep> createState() => _MobilePayRecipientStepState();
@@ -78,8 +82,9 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
   @override
   Widget build(BuildContext context) {
     final typed = widget.typedAddress.trim();
+    final isRequest = isPaymentRequestUri(typed);
     final hasInput = typed.isNotEmpty;
-    final valid = hasInput && widget.addressError == null;
+    final valid = hasInput && widget.addressError == null && !isRequest;
     final contactMatches = valid
         ? payContactsForAddress(widget.contacts, typed)
         : const <AddressBookContact>[];
@@ -140,6 +145,14 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
                     children: [
                       _buildRecipientField(context),
                       const SizedBox(height: AppSpacing.md),
+                      if (isRequest) ...[
+                        PaymentRequestInputNotice(
+                          onReview: widget.busy
+                              ? null
+                              : widget.onReviewPaymentRequest,
+                        ),
+                        const SizedBox(height: AppSpacing.md),
+                      ],
                       _buildQrRow(context),
                       if (visibleRecents.isNotEmpty) ...[
                         const SizedBox(height: AppSpacing.md),
@@ -309,7 +322,8 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
 
   Widget _buildRecipientField(BuildContext context) {
     final colors = context.colors;
-    final hasError = widget.addressError != null;
+    final isRequest = isPaymentRequestUri(widget.typedAddress);
+    final hasError = widget.addressError != null && !isRequest;
     return SizedBox(
       key: const ValueKey('mobile_pay_recipient_field_group'),
       height: _recipientFieldGroupHeight,
@@ -352,6 +366,9 @@ class _MobilePayRecipientStepState extends State<MobilePayRecipientStep> {
               ),
             ),
             onChanged: widget.onAddressChanged,
+            onSubmitted: isRequest
+                ? (_) => widget.onReviewPaymentRequest?.call()
+                : null,
           ),
           SizedBox(
             height: _recipientErrorGap + _recipientErrorHeight,

--- a/lib/src/features/pay/widgets/pay_recipient_step.dart
+++ b/lib/src/features/pay/widgets/pay_recipient_step.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
+import '../../../core/navigation/payment_request_intake.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_icon_hover_button.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../core/widgets/app_text_field.dart';
 import '../../address_book/models/address_book_contact.dart';
+import '../../address_scan/widgets/payment_request_input.dart';
 import '../../swap/models/swap_address_formatting.dart';
 import '../models/pay_recent_recipients.dart';
 import 'pay_wizard_page.dart';
@@ -26,6 +28,7 @@ class PayRecipientStep extends StatelessWidget {
     required this.onAddressChanged,
     required this.onOpenScanner,
     required this.onChooseRecipient,
+    this.onReviewPaymentRequest,
     super.key,
   });
 
@@ -47,6 +50,7 @@ class PayRecipientStep extends StatelessWidget {
 
   final ValueChanged<String> onAddressChanged;
   final VoidCallback onOpenScanner;
+  final VoidCallback? onReviewPaymentRequest;
 
   /// Row tap: select this exact recipient. The screen owns quote/review
   /// orchestration so the same selection contract works on desktop and mobile.
@@ -56,8 +60,9 @@ class PayRecipientStep extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final typed = typedAddress.trim();
+    final isRequest = isPaymentRequestUri(typed);
     final hasInput = typed.isNotEmpty;
-    final validDestination = hasInput && addressError == null;
+    final validDestination = hasInput && addressError == null && !isRequest;
     final matchedContacts = !hasInput
         ? contacts
         : [
@@ -74,7 +79,8 @@ class PayRecipientStep extends StatelessWidget {
         : const <PayRecentRecipient>[];
     final hasMatches = matchedRecents.isNotEmpty || matchedContacts.isNotEmpty;
     final unknownAddress = validDestination && !hasMatches;
-    final showAddressError = hasInput && addressError != null && !hasMatches;
+    final showAddressError =
+        hasInput && addressError != null && !hasMatches && !isRequest;
 
     Widget buildRecentRow(PayRecentRecipient recent) {
       final selection = payRecipientSelectionForRecent(contacts, recent);
@@ -105,7 +111,7 @@ class PayRecipientStep extends StatelessWidget {
           label: 'Recipient address',
           showLabel: false,
           controller: controller,
-          hintText: 'Paste an address or scan QR code',
+          hintText: 'Paste an address or payment request',
           leading: AppIcon(AppIcons.user, size: 20, color: colors.icon.regular),
           leadingSlotWidth: 32,
           trailing: AppIconHoverButton(
@@ -119,6 +125,7 @@ class PayRecipientStep extends StatelessWidget {
           trailingSlotWidth: 40,
           trailingFitsSlot: true,
           onChanged: onAddressChanged,
+          onSubmitted: isRequest ? (_) => onReviewPaymentRequest?.call() : null,
           textStyle: AppTypography.codeMedium.copyWith(
             color: colors.text.accent,
           ),
@@ -128,7 +135,11 @@ class PayRecipientStep extends StatelessWidget {
           messageText: showAddressError ? addressError : null,
         ),
         const SizedBox(height: AppSpacing.s),
-        if (unknownAddress)
+        if (isRequest)
+          PaymentRequestInputNotice(
+            onReview: busy ? null : onReviewPaymentRequest,
+          )
+        else if (unknownAddress)
           SizedBox(
             height: 310,
             child: Center(

--- a/lib/src/features/send/models/send_scan_result.dart
+++ b/lib/src/features/send/models/send_scan_result.dart
@@ -8,8 +8,8 @@
 /// to give it. So the send scanners classify first and let the caller route:
 /// an address goes in the field, a request goes to the card.
 ///
-/// Only the send-context scanners do this. Address book, swap and pay scan for
-/// a destination, not for a payment to answer, so they stay address-only.
+/// Pay and Swap also preserve payment requests before address normalization.
+/// Address-only surfaces, such as the address book, keep their own semantics.
 library;
 
 import '../../../core/formatting/zec_amount.dart';
@@ -20,6 +20,13 @@ import 'send_prefill_args.dart';
 /// A scan the send flow accepted.
 sealed class SendScanResult {
   const SendScanResult();
+}
+
+/// A cross-chain request whose complete terms must reach the common intake.
+class SendScanPaymentUri extends SendScanResult {
+  const SendScanPaymentUri(this.rawUri);
+
+  final String rawUri;
 }
 
 /// Why a scanned ZIP-321 request came back as a bare recipient instead of a

--- a/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_scan_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../../core/payments/cross_chain_payment_request.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_scan/domain/address_scan_payload.dart';
 import '../../../address_scan/widgets/mobile_address_scan_card.dart';
@@ -36,6 +37,7 @@ Future<SendScanResult?> showMobileSendScanSheet(
   return showAppMobileSheet<SendScanResult>(
     context: context,
     builder: (sheetContext) => MobileAddressScanCard(
+      caption: 'Scan an address or payment request QR code',
       controller: controller,
       resolve: (raw) async {
         final outcome = await resolver(raw);
@@ -43,6 +45,11 @@ Future<SendScanResult?> showMobileSendScanSheet(
         return outcome;
       },
       onScanned: (address) {
+        final raw = acceptedRaw ?? address;
+        if (isCrossChainPaymentUri(raw.trim())) {
+          Navigator.of(sheetContext).pop(SendScanPaymentUri(raw.trim()));
+          return;
+        }
         final result =
             resolveSendScanPayload(
               acceptedRaw ?? address,
@@ -66,6 +73,9 @@ Future<MobileScanOutcome> resolveScannedZcashAddress(
   String raw, {
   required String networkName,
 }) async {
+  if (isCrossChainPaymentUri(raw.trim())) {
+    return MobileScanOutcome.accepted(raw.trim());
+  }
   final address = normalizeAddressScanPayload(raw);
   if (address == null || address.isEmpty) {
     return const MobileScanOutcome.rejected(

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/formatting/zec_amount.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/navigation/payment_uri_busy_surface_provider.dart';
+import '../../../../core/navigation/payment_request_intake.dart';
 import '../../../../core/storage/wallet_paths.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_button.dart';
@@ -36,6 +37,7 @@ import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_book/models/address_book_contact.dart';
 import '../../../address_book/providers/address_book_provider.dart';
 import '../../../address_book/widgets/contact_name_inline.dart';
+import '../../../address_scan/widgets/payment_request_input.dart';
 import '../../../../providers/payment_request_flow_provider.dart';
 import '../../../migration/providers/ironwood_migration_announcement_provider.dart';
 import '../../models/send_scan_result.dart';
@@ -795,6 +797,14 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   }
 
   void _handleAddressChanged({bool clearContact = true}) {
+    if (isPaymentRequestUri(_addressController.text)) {
+      _addressSeq++;
+      setState(() {
+        _addressType = '';
+        _addressWrongNetwork = false;
+      });
+      return;
+    }
     setState(() {
       if (widget.isPaymentRequest &&
           !_paymentRequestDetached &&
@@ -838,6 +848,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     );
     if (scanned == null || !mounted) return;
     switch (scanned) {
+      case SendScanPaymentUri(:final rawUri):
+        await WidgetsBinding.instance.endOfFrame;
+        if (!mounted) return;
+        await reviewPaymentRequestFromInput(ref, rawUri);
       case SendScanPaymentRequest(:final prefill):
         // A QR that already names an amount is the same object a `zcash:`
         // link is, so it gets the same answer: the card, over whatever is on
@@ -872,6 +886,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     final data = await Clipboard.getData(Clipboard.kTextPlain);
     final pasted = data?.text?.trim() ?? '';
     if (pasted.isEmpty || !mounted) return;
+    if (isPaymentRequestUri(pasted)) {
+      await reviewPaymentRequestFromInput(ref, pasted);
+      return;
+    }
     _addressController.value = TextEditingValue(
       text: pasted,
       selection: TextSelection.collapsed(offset: pasted.length),
@@ -2452,6 +2470,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   Widget _buildAddressField(BuildContext context) {
     final colors = context.colors;
+    final isRequest = isPaymentRequestUri(_addressController.text);
     final showAction = _addressFocus.hasFocus;
     final hasAddressError =
         _addressType == 'invalid' || _addressType == 'error';
@@ -2498,10 +2517,19 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
               height: AppInputSizing.height,
               child: Center(
                 child: _AddressFieldActionButton(
-                  label: _addressController.text.trim().isEmpty
+                  label: isRequest
+                      ? 'Review'
+                      : _addressController.text.trim().isEmpty
                       ? 'Paste'
                       : 'Clear',
-                  onTap: _addressController.text.trim().isEmpty
+                  onTap: isRequest
+                      ? () => unawaited(
+                          reviewPaymentRequestFromInput(
+                            ref,
+                            _addressController.text,
+                          ),
+                        )
+                      : _addressController.text.trim().isEmpty
                       ? () => unawaited(_pasteAddress())
                       : _clearAddress,
                 ),
@@ -2509,6 +2537,9 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
             )
           : null,
       onChanged: (_) => _handleAddressChanged(),
+      onSubmitted: isRequest
+          ? (raw) => unawaited(reviewPaymentRequestFromInput(ref, raw))
+          : null,
       keyboardType: TextInputType.text,
     );
   }

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -904,15 +904,14 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     final data = await Clipboard.getData(Clipboard.kTextPlain);
     final pasted = data?.text?.trim() ?? '';
     if (pasted.isEmpty || !mounted || sequence != _addressSeq) return;
-    if (isPaymentRequestUri(pasted)) {
-      await _reviewInputPaymentRequest(pasted);
-      return;
-    }
     _addressController.value = TextEditingValue(
       text: pasted,
       selection: TextSelection.collapsed(offset: pasted.length),
     );
     _handleAddressChanged();
+    if (isPaymentRequestUri(pasted)) {
+      await _reviewInputPaymentRequest(pasted);
+    }
   }
 
   void _clearAddress() {

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -796,6 +796,23 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     }
   }
 
+  Future<void> _reviewInputPaymentRequest(String raw) async {
+    final sequence = _addressSeq;
+    final input = _addressController.text;
+    final step = _step;
+    final phase = _phase;
+    await reviewPaymentRequestFromInput(
+      ref,
+      raw,
+      isCurrent: () =>
+          mounted &&
+          sequence == _addressSeq &&
+          input == _addressController.text &&
+          step == _step &&
+          phase == _phase,
+    );
+  }
+
   void _handleAddressChanged({bool clearContact = true}) {
     if (isPaymentRequestUri(_addressController.text)) {
       _addressSeq++;
@@ -851,7 +868,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       case SendScanPaymentUri(:final rawUri):
         await WidgetsBinding.instance.endOfFrame;
         if (!mounted) return;
-        await reviewPaymentRequestFromInput(ref, rawUri);
+        await _reviewInputPaymentRequest(rawUri);
       case SendScanPaymentRequest(:final prefill):
         // A QR that already names an amount is the same object a `zcash:`
         // link is, so it gets the same answer: the card, over whatever is on
@@ -883,11 +900,12 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   }
 
   Future<void> _pasteAddress() async {
+    final sequence = _addressSeq;
     final data = await Clipboard.getData(Clipboard.kTextPlain);
     final pasted = data?.text?.trim() ?? '';
-    if (pasted.isEmpty || !mounted) return;
+    if (pasted.isEmpty || !mounted || sequence != _addressSeq) return;
     if (isPaymentRequestUri(pasted)) {
-      await reviewPaymentRequestFromInput(ref, pasted);
+      await _reviewInputPaymentRequest(pasted);
       return;
     }
     _addressController.value = TextEditingValue(
@@ -2524,10 +2542,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                       : 'Clear',
                   onTap: isRequest
                       ? () => unawaited(
-                          reviewPaymentRequestFromInput(
-                            ref,
-                            _addressController.text,
-                          ),
+                          _reviewInputPaymentRequest(_addressController.text),
                         )
                       : _addressController.text.trim().isEmpty
                       ? () => unawaited(_pasteAddress())
@@ -2538,7 +2553,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
           : null,
       onChanged: (_) => _handleAddressChanged(),
       onSubmitted: isRequest
-          ? (raw) => unawaited(reviewPaymentRequestFromInput(ref, raw))
+          ? (raw) => unawaited(_reviewInputPaymentRequest(raw))
           : null,
       keyboardType: TextInputType.text,
     );

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -12,6 +12,7 @@ import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/navigation/payment_request_intake.dart';
 import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
@@ -35,6 +36,7 @@ import '../../../rust/api/sync.dart' as rust_sync;
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/providers/address_book_provider.dart';
 import '../../address_book/widgets/address_book_contact_picker_modal.dart';
+import '../../address_scan/widgets/payment_request_input.dart';
 import '../../migration/providers/ironwood_migration_announcement_provider.dart';
 import '../models/send_prefill_args.dart';
 import '../services/send_amount_conversion.dart';
@@ -448,6 +450,17 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   void _handleAddressChanged() {
     _addressSeq++;
     _maxDebounceTimer?.cancel();
+    if (isPaymentRequestUri(_addressController.text)) {
+      _validateSeq++;
+      _maxSeq++;
+      setState(() {
+        _addressType = '';
+        _addressWrongNetwork = false;
+        _isResolvingMax = false;
+        _maxQuote = null;
+      });
+      return;
+    }
     setState(() {
       _addressType = '';
       _addressWrongNetwork = false;
@@ -1133,14 +1146,19 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         matchedRecipientName = recipient.name;
       }
     }
-    final addressMessage = switch (_addressType) {
-      // A wrong-network address is well-formed, so "Invalid address" would
-      // send the user hunting for a typo that is not there.
-      'invalid' =>
-        _addressWrongNetwork ? kWrongNetworkAddressMessage : 'Invalid address',
-      'error' => 'Address validation failed',
-      _ => matchedRecipientName,
-    };
+    final isRequest = isPaymentRequestUri(_addressController.text);
+    final addressMessage = isRequest
+        ? 'Payment request detected.'
+        : switch (_addressType) {
+            // A wrong-network address is well-formed, so "Invalid address" would
+            // send the user hunting for a typo that is not there.
+            'invalid' =>
+              _addressWrongNetwork
+                  ? kWrongNetworkAddressMessage
+                  : 'Invalid address',
+            'error' => 'Address validation failed',
+            _ => matchedRecipientName,
+          };
     final addressMessageIcon = switch (_addressType) {
       'invalid' || 'error' => AppIcon(
         AppIcons.warning,
@@ -1278,7 +1296,16 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                             event.logicalKey ==
                                                 LogicalKeyboardKey
                                                     .numpadEnter)) {
-                                      onFieldSubmitted();
+                                      if (isRequest) {
+                                        unawaited(
+                                          reviewPaymentRequestFromInput(
+                                            ref,
+                                            controller.text,
+                                          ),
+                                        );
+                                      } else {
+                                        onFieldSubmitted();
+                                      }
                                       return KeyEventResult.handled;
                                     }
                                     return KeyEventResult.ignored;
@@ -1288,8 +1315,17 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                     label: 'Send to',
                                     labelStyle: sendFieldLabelStyle,
                                     rightSlot: _SendContactsLabelButton(
-                                      label: 'Contacts',
-                                      onTap: _openContactPicker,
+                                      label: isRequest
+                                          ? 'Review request'
+                                          : 'Contacts',
+                                      onTap: isRequest
+                                          ? () => unawaited(
+                                              reviewPaymentRequestFromInput(
+                                                ref,
+                                                controller.text,
+                                              ),
+                                            )
+                                          : _openContactPicker,
                                     ),
                                     tone: addressTone,
                                     borderColor:
@@ -1308,7 +1344,18 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                     messageText: addressMessage,
                                     messageIcon: addressMessageIcon,
                                     onChanged: (_) => _handleAddressChanged(),
-                                    onSubmitted: (_) => onFieldSubmitted(),
+                                    onSubmitted: (raw) {
+                                      if (isRequest) {
+                                        unawaited(
+                                          reviewPaymentRequestFromInput(
+                                            ref,
+                                            raw,
+                                          ),
+                                        );
+                                      } else {
+                                        onFieldSubmitted();
+                                      }
+                                    },
                                     keyboardType: TextInputType.text,
                                     showClearButton: true,
                                     onClear: () {

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -447,6 +447,19 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     }
   }
 
+  Future<void> _reviewInputPaymentRequest(String raw) async {
+    final sequence = _addressSeq;
+    final input = _addressController.text;
+    await reviewPaymentRequestFromInput(
+      ref,
+      raw,
+      isCurrent: () =>
+          mounted &&
+          sequence == _addressSeq &&
+          input == _addressController.text,
+    );
+  }
+
   void _handleAddressChanged() {
     _addressSeq++;
     _maxDebounceTimer?.cancel();
@@ -1298,8 +1311,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                     .numpadEnter)) {
                                       if (isRequest) {
                                         unawaited(
-                                          reviewPaymentRequestFromInput(
-                                            ref,
+                                          _reviewInputPaymentRequest(
                                             controller.text,
                                           ),
                                         );
@@ -1320,8 +1332,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                           : 'Contacts',
                                       onTap: isRequest
                                           ? () => unawaited(
-                                              reviewPaymentRequestFromInput(
-                                                ref,
+                                              _reviewInputPaymentRequest(
                                                 controller.text,
                                               ),
                                             )
@@ -1347,10 +1358,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                     onSubmitted: (raw) {
                                       if (isRequest) {
                                         unawaited(
-                                          reviewPaymentRequestFromInput(
-                                            ref,
-                                            raw,
-                                          ),
+                                          _reviewInputPaymentRequest(raw),
                                         );
                                       } else {
                                         onFieldSubmitted();

--- a/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
@@ -65,6 +65,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
   bool _modalRouteOpen = false;
   String? _addressEditorDraftText;
   bool _addressEditorDraftRemember = false;
+  var _addressEditorGeneration = 0;
 
   @override
   void initState() {
@@ -101,6 +102,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
         transitionDuration: Duration.zero,
         pageBuilder: (_, _, _) => _buildSwapModal(),
       ).whenComplete(() {
+        _addressEditorGeneration++;
         _modalRouteOpen = false;
         if (mounted) {
           setState(() {
@@ -113,6 +115,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
   }
 
   void _openAddressEditor({String? draftText, bool? draftRemember}) {
+    _addressEditorGeneration++;
     _addressEditorDraftText = draftText ?? _addressEditorDraftText;
     _addressEditorDraftRemember = draftRemember ?? _addressEditorDraftRemember;
     _openModal(_SwapModalSurface.addressEditor);
@@ -129,6 +132,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
   }
 
   void _closeSwapModal() {
+    _addressEditorGeneration++;
     if (_modalRouteOpen) {
       // State resets in the route's whenComplete.
       _clearAddressEditorDraft();
@@ -150,6 +154,21 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
           address: contact.address,
           contactId: contact.id,
         );
+    _closeSwapModal();
+  }
+
+  Future<void> _reviewPastedPaymentRequest(String raw) async {
+    if (!ref.read(swapStateProvider).direction.sendsZec) return;
+    final generation = _addressEditorGeneration;
+    // Keep the editor and its raw text until parsing succeeds. Intake presents
+    // the card after the frame, so closing here still removes the editor first.
+    final accepted = await reviewPaymentRequestFromInput(ref, raw);
+    if (!mounted ||
+        !accepted ||
+        generation != _addressEditorGeneration ||
+        _swapModal.value != _SwapModalSurface.addressEditor) {
+      return;
+    }
     _closeSwapModal();
   }
 
@@ -192,7 +211,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                 initialRememberAddress: _addressEditorDraftRemember,
                 onSubmitted: (value, remember) {
                   if (isPaymentRequestUri(value)) {
-                    unawaited(_reviewScannedPaymentRequest(value));
+                    unawaited(_reviewPastedPaymentRequest(value));
                     return;
                   }
                   if (remember) {

--- a/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
@@ -208,6 +208,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
               ),
               _SwapModalSurface.addressEditor => MobileSwapAddressEditModal(
                 state: swapState,
+                onChanged: () => _addressEditorGeneration++,
                 contacts:
                     ref.watch(addressBookProvider).value?.contacts ?? const [],
                 initialAddress: _addressEditorDraftText,

--- a/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
@@ -8,6 +8,7 @@ import '../../../../core/formatting/zec_amount.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/navigation/mobile_tab_history.dart';
+import '../../../../core/navigation/payment_request_intake.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
@@ -20,6 +21,7 @@ import '../../../address_book/widgets/address_book_contact_picker_modal.dart';
 import '../../../migration/providers/ironwood_migration_announcement_provider.dart';
 import '../../../address_scan/domain/address_scan_payload.dart';
 import '../../../address_scan/widgets/mobile_address_scan_card.dart';
+import '../../../address_scan/widgets/payment_request_input.dart';
 import '../../../address_scan/widgets/mobile_address_scan_view.dart'
     show MobileScanOutcome;
 import '../../models/swap_address_book_helpers.dart';
@@ -151,6 +153,14 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
     _closeSwapModal();
   }
 
+  Future<void> _reviewScannedPaymentRequest(String raw) async {
+    if (!ref.read(swapStateProvider).direction.sendsZec) return;
+    _closeSwapModal();
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    await reviewPaymentRequestFromInput(ref, raw);
+  }
+
   /// Content of the root modal route: re-renders on surface switches
   /// via [_swapModal] and on swap state changes via its own Consumer
   /// (the route doesn't rebuild with the screen). Empty space around
@@ -181,6 +191,10 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                 initialAddress: _addressEditorDraftText,
                 initialRememberAddress: _addressEditorDraftRemember,
                 onSubmitted: (value, remember) {
+                  if (isPaymentRequestUri(value)) {
+                    unawaited(_reviewScannedPaymentRequest(value));
+                    return;
+                  }
                   if (remember) {
                     unawaited(_rememberSwapAddress(value, swapState));
                   }
@@ -201,7 +215,17 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
               // `Address QR` 4697:106096); it shares the same MobileModalCard
               // surface as the other swap modals.
               _SwapModalSurface.addressScanner => MobileAddressScanCard(
+                caption: swapState.direction.sendsZec
+                    ? 'Scan an address or payment request QR code'
+                    : 'Scan a plain refund address QR code',
                 resolve: (raw) async {
+                  if (isPaymentRequestUri(raw)) {
+                    return swapState.direction.sendsZec
+                        ? MobileScanOutcome.accepted(raw.trim())
+                        : const MobileScanOutcome.rejected(
+                            paymentRequestRefundAddressMessage,
+                          );
+                  }
                   final address = normalizeAddressScanPayload(raw);
                   if (address == null || address.isEmpty) {
                     return const MobileScanOutcome.rejected(
@@ -211,6 +235,10 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                   return MobileScanOutcome.accepted(address);
                 },
                 onScanned: (value) {
+                  if (isPaymentRequestUri(value)) {
+                    unawaited(_reviewScannedPaymentRequest(value));
+                    return;
+                  }
                   _openAddressEditor(draftText: value);
                 },
                 onClose: _openAddressEditor,

--- a/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
@@ -160,15 +160,18 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
   Future<void> _reviewPastedPaymentRequest(String raw) async {
     if (!ref.read(swapStateProvider).direction.sendsZec) return;
     final generation = _addressEditorGeneration;
-    // Keep the editor and its raw text until parsing succeeds. Intake presents
-    // the card after the frame, so closing here still removes the editor first.
-    final accepted = await reviewPaymentRequestFromInput(ref, raw);
-    if (!mounted ||
-        !accepted ||
-        generation != _addressEditorGeneration ||
-        _swapModal.value != _SwapModalSurface.addressEditor) {
-      return;
-    }
+    bool isCurrent() =>
+        mounted &&
+        generation == _addressEditorGeneration &&
+        _swapModal.value == _SwapModalSurface.addressEditor;
+    // Keep rejected input editable, and discard cancelled submissions before
+    // intake can publish them. Accepted cards are presented after the frame.
+    final accepted = await reviewPaymentRequestFromInput(
+      ref,
+      raw,
+      isCurrent: isCurrent,
+    );
+    if (!accepted || !isCurrent()) return;
     _closeSwapModal();
   }
 

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -58,6 +58,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     debugLabel: 'swap_toast_overlay_context',
   );
   _SwapModalSurface? _swapModal;
+  var _addressEditorGeneration = 0;
 
   @override
   void initState() {
@@ -83,6 +84,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
   }
 
   void _openAddressEditor() {
+    _addressEditorGeneration++;
     setState(() => _swapModal = _SwapModalSurface.addressEditor);
   }
 
@@ -99,12 +101,28 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
   }
 
   void _closeSwapModal() {
+    _addressEditorGeneration++;
     if (_swapModal == null) return;
     setState(() => _swapModal = null);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _shortcutFocusNode.requestFocus();
     });
+  }
+
+  Future<void> _reviewPastedPaymentRequest(String raw) async {
+    if (!ref.read(swapStateProvider).direction.sendsZec) return;
+    final generation = _addressEditorGeneration;
+    // Keep the editor and its raw text until parsing succeeds. Intake presents
+    // the card after the frame, so closing here still removes the editor first.
+    final accepted = await reviewPaymentRequestFromInput(ref, raw);
+    if (!mounted ||
+        !accepted ||
+        generation != _addressEditorGeneration ||
+        _swapModal != _SwapModalSurface.addressEditor) {
+      return;
+    }
+    _closeSwapModal();
   }
 
   Future<void> _reviewScannedPaymentRequest(String raw) async {
@@ -350,7 +368,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                             const [],
                         onSubmitted: (value, remember) {
                           if (isPaymentRequestUri(value)) {
-                            unawaited(_reviewScannedPaymentRequest(value));
+                            unawaited(_reviewPastedPaymentRequest(value));
                             return;
                           }
                           if (remember) {

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -10,6 +10,7 @@ import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_pane_scroll_scaffold.dart';
+import '../../../core/navigation/payment_request_intake.dart';
 import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
@@ -28,6 +29,7 @@ import '../models/swap_models.dart';
 import '../models/swap_address_book_helpers.dart';
 import '../providers/swap_state_provider.dart';
 import '../../address_scan/widgets/address_qr_scan_modal.dart';
+import '../../address_scan/widgets/payment_request_input.dart';
 import '../widgets/swap_address_edit_modal.dart';
 import '../widgets/swap_asset_selector_modal.dart';
 import '../widgets/swap_composer_panel.dart';
@@ -103,6 +105,16 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
       if (!mounted) return;
       _shortcutFocusNode.requestFocus();
     });
+  }
+
+  Future<void> _reviewScannedPaymentRequest(String raw) async {
+    if (!ref.read(swapStateProvider).direction.sendsZec) return;
+    _closeSwapModal();
+    // Let the scanner/editor release its modal and busy hold before the card
+    // intake can drain. Keep the existing composer unchanged behind the card.
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    await reviewPaymentRequestFromInput(ref, raw);
   }
 
   void _selectAddressBookContact(AddressBookContact contact) {
@@ -337,6 +349,10 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                             ref.watch(addressBookProvider).value?.contacts ??
                             const [],
                         onSubmitted: (value, remember) {
+                          if (isPaymentRequestUri(value)) {
+                            unawaited(_reviewScannedPaymentRequest(value));
+                            return;
+                          }
                           if (remember) {
                             unawaited(_rememberSwapAddress(value, swapState));
                           }
@@ -348,6 +364,9 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                         onCancel: _closeSwapModal,
                       ),
                       _SwapModalSurface.addressScanner => AddressQrScanModal(
+                        isRefundAddress: !swapState.direction.sendsZec,
+                        onPaymentRequestScanned: (value) =>
+                            unawaited(_reviewScannedPaymentRequest(value)),
                         onAddressScanned: (value) {
                           swapNotifier.updateDestination(value);
                           _closeSwapModal();

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -113,15 +113,18 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
   Future<void> _reviewPastedPaymentRequest(String raw) async {
     if (!ref.read(swapStateProvider).direction.sendsZec) return;
     final generation = _addressEditorGeneration;
-    // Keep the editor and its raw text until parsing succeeds. Intake presents
-    // the card after the frame, so closing here still removes the editor first.
-    final accepted = await reviewPaymentRequestFromInput(ref, raw);
-    if (!mounted ||
-        !accepted ||
-        generation != _addressEditorGeneration ||
-        _swapModal != _SwapModalSurface.addressEditor) {
-      return;
-    }
+    bool isCurrent() =>
+        mounted &&
+        generation == _addressEditorGeneration &&
+        _swapModal == _SwapModalSurface.addressEditor;
+    // Keep rejected input editable, and discard cancelled submissions before
+    // intake can publish them. Accepted cards are presented after the frame.
+    final accepted = await reviewPaymentRequestFromInput(
+      ref,
+      raw,
+      isCurrent: isCurrent,
+    );
+    if (!accepted || !isCurrent()) return;
     _closeSwapModal();
   }
 

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -366,6 +366,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                       ),
                       _SwapModalSurface.addressEditor => SwapAddressEditModal(
                         state: swapState,
+                        onChanged: () => _addressEditorGeneration++,
                         contacts:
                             ref.watch(addressBookProvider).value?.contacts ??
                             const [],

--- a/lib/src/features/swap/widgets/mobile/mobile_swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/mobile/mobile_swap_address_edit_modal.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/theme/app_theme.dart';
+import '../../../../core/navigation/payment_request_intake.dart';
 import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/mobile_text_field.dart';
@@ -10,6 +11,7 @@ import '../../../address_book/models/address_book_contact.dart';
 import '../../../address_book/models/address_book_label_lookup.dart';
 import '../../../address_book/models/address_format_validator.dart';
 import '../../../address_book/widgets/contact_name_inline.dart';
+import '../../../address_scan/widgets/payment_request_input.dart';
 import '../../models/swap_models.dart';
 import '../swap_modal_controls.dart';
 
@@ -111,10 +113,16 @@ class _MobileSwapAddressEditModalState
   }
 
   bool get _canSubmit => _formatError == null;
+  bool get _isPaymentRequest => isPaymentRequestUri(_controller.text);
 
   String? get _formatError {
     final trimmed = _controller.text.trim();
     if (trimmed.isEmpty) return null;
+    if (_isPaymentRequest) {
+      return widget.state.direction.sendsZec
+          ? null
+          : paymentRequestRefundAddressMessage;
+    }
     final network = AddressBookNetwork.tryFromChainTicker(
       widget.state.externalAsset.chainTicker,
     );
@@ -243,17 +251,23 @@ class _MobileSwapAddressEditModalState
             style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
           ),
           const SizedBox(height: 16),
-          _AddressRememberToggle(
-            selected: _rememberAddress,
-            label: rememberLabel,
-            onTap: _toggleRemember,
-          ),
+          if (!_isPaymentRequest)
+            _AddressRememberToggle(
+              selected: _rememberAddress,
+              label: rememberLabel,
+              onTap: _toggleRemember,
+            ),
           const SizedBox(height: AppSpacing.md),
           AppButton(
             key: const ValueKey('swap_address_update_button'),
             expand: true,
+            constrainContent: true,
             onPressed: _canSubmit ? _submit : null,
-            child: const Text('Update'),
+            child: Text(
+              _isPaymentRequest ? 'Review payment request' : 'Update',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
           const SizedBox(height: 12),
           AppButton(

--- a/lib/src/features/swap/widgets/mobile/mobile_swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/mobile/mobile_swap_address_edit_modal.dart
@@ -33,6 +33,7 @@ class MobileSwapAddressEditModal extends StatefulWidget {
     required this.onScan,
     required this.onOpenContacts,
     required this.onCancel,
+    this.onChanged,
     this.contacts = const <AddressBookContact>[],
     this.initialAddress,
     this.initialRememberAddress = false,
@@ -44,6 +45,7 @@ class MobileSwapAddressEditModal extends StatefulWidget {
   final void Function(String value, bool remember) onScan;
   final void Function(String value, bool remember) onOpenContacts;
   final VoidCallback onCancel;
+  final VoidCallback? onChanged;
   final String? initialAddress;
   final bool initialRememberAddress;
 
@@ -187,7 +189,10 @@ class _MobileSwapAddressEditModalState
             hintText: hint,
             textInputAction: TextInputAction.done,
             onSubmitted: (_) => _submit(),
-            onChanged: (_) => setState(() {}),
+            onChanged: (_) {
+              widget.onChanged?.call();
+              setState(() {});
+            },
             trailing: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10),
               child: Row(

--- a/lib/src/features/swap/widgets/swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/swap_address_edit_modal.dart
@@ -23,6 +23,7 @@ class SwapAddressEditModal extends StatefulWidget {
     required this.onScan,
     required this.onOpenContacts,
     required this.onCancel,
+    this.onChanged,
     this.contacts = const <AddressBookContact>[],
     super.key,
   });
@@ -32,6 +33,7 @@ class SwapAddressEditModal extends StatefulWidget {
   final VoidCallback onScan;
   final VoidCallback onOpenContacts;
   final VoidCallback onCancel;
+  final VoidCallback? onChanged;
 
   /// Saved contacts; when the entered address matches one, its name is shown
   /// under the field so the user knows the address is correct.
@@ -195,7 +197,10 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
                   focusNode: _focusNode,
                   hint: hint,
                   onSubmitted: (_) => _submit(),
-                  onChanged: (_) => setState(() {}),
+                  onChanged: (_) {
+                    widget.onChanged?.call();
+                    setState(() {});
+                  },
                   onScan: widget.onScan,
                   onOpenContacts: widget.onOpenContacts,
                 ),

--- a/lib/src/features/swap/widgets/swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/swap_address_edit_modal.dart
@@ -3,12 +3,14 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
+import '../../../core/navigation/payment_request_intake.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_modal_card.dart';
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/models/address_book_label_lookup.dart';
 import '../../address_book/models/address_format_validator.dart';
 import '../../address_book/widgets/contact_name_inline.dart';
+import '../../address_scan/widgets/payment_request_input.dart';
 import '../models/swap_models.dart';
 import 'swap_modal_controls.dart';
 
@@ -91,10 +93,18 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
   }
 
   bool get _canSubmit => _formatError == null;
+  bool get _isPaymentRequest => isPaymentRequestUri(_controller.text);
 
   AddressFormatFinding? get _formatFinding {
     final trimmed = _controller.text.trim();
     if (trimmed.isEmpty) return null;
+    if (_isPaymentRequest) {
+      return widget.state.direction.sendsZec
+          ? null
+          : const AddressFormatFinding.error(
+              paymentRequestRefundAddressMessage,
+            );
+    }
     final network = AddressBookNetwork.tryFromChainTicker(
       widget.state.externalAsset.chainTicker,
     );
@@ -240,11 +250,12 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
                 const SizedBox(height: AppSpacing.sm),
                 // Remembered addresses are auto-named (and auto-avatared)
                 // on save, so opting in needs no extra fields here.
-                _AddressRememberToggle(
-                  selected: _rememberAddress,
-                  label: rememberLabel,
-                  onTap: _toggleRemember,
-                ),
+                if (!_isPaymentRequest)
+                  _AddressRememberToggle(
+                    selected: _rememberAddress,
+                    label: rememberLabel,
+                    onTap: _toggleRemember,
+                  ),
               ],
             ),
           ),
@@ -252,7 +263,9 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
           AppModalActions(
             actionKey: const ValueKey('swap_address_update_button'),
             cancelKey: const ValueKey('swap_address_cancel_button'),
-            actionLabel: 'Update',
+            actionLabel: _isPaymentRequest
+                ? 'Review payment request'
+                : 'Update',
             onAction: _canSubmit ? _submit : null,
             onCancel: widget.onCancel,
           ),

--- a/test/core/navigation/payment_request_intake_test.dart
+++ b/test/core/navigation/payment_request_intake_test.dart
@@ -43,7 +43,7 @@ void main() {
           parser.complete(cancelled);
         }
 
-        expect(await pending, isFalse);
+        expect(await pending, PaymentRequestIntakeResult.ignored);
         expect(container.read(paymentUriPrefillProvider), same(parked));
         expect(container.read(paymentRequestArrivalProvider), 1);
       },
@@ -66,12 +66,12 @@ void main() {
     final pendingNewer = intake.receive(newer.rawUri);
     newerParse.complete(newer);
 
-    expect(await pendingNewer, isFalse);
+    expect(await pendingNewer, PaymentRequestIntakeResult.accepted);
     expect(container.read(paymentUriPrefillProvider), same(newer));
     expect(container.read(paymentRequestArrivalProvider), 1);
 
     olderParse.complete(older);
-    expect(await pendingOlder, isFalse);
+    expect(await pendingOlder, PaymentRequestIntakeResult.ignored);
     expect(container.read(paymentUriPrefillProvider), same(newer));
     expect(container.read(paymentRequestArrivalProvider), 1);
     expect(received, [older.rawUri, newer.rawUri]);
@@ -102,7 +102,7 @@ void main() {
       // Even a late error from the superseded parse must not become a new error
       // on the input surface after the latest request was already rejected.
       olderParse.completeError(const CrossChainPaymentParseException());
-      expect(await pendingOlder, isFalse);
+      expect(await pendingOlder, PaymentRequestIntakeResult.ignored);
       expect(container.read(paymentUriPrefillProvider), same(parked));
       expect(container.read(paymentRequestArrivalProvider), 1);
     },
@@ -126,11 +126,14 @@ void main() {
       container.read(paymentUriPrefillProvider.notifier).clear();
       pendingParse.complete(beforeReset);
 
-      expect(await pending, isFalse);
+      expect(await pending, PaymentRequestIntakeResult.ignored);
       expect(container.read(paymentUriPrefillProvider), isNull);
       expect(container.read(paymentRequestArrivalProvider), 0);
 
-      expect(await intake.receive(afterReset.rawUri), isFalse);
+      expect(
+        await intake.receive(afterReset.rawUri),
+        PaymentRequestIntakeResult.accepted,
+      );
       expect(container.read(paymentUriPrefillProvider), same(afterReset));
       expect(container.read(paymentRequestArrivalProvider), 1);
     },
@@ -155,7 +158,7 @@ void main() {
       container.dispose();
       parser.complete(request);
 
-      expect(await pending, isFalse);
+      expect(await pending, PaymentRequestIntakeResult.ignored);
     },
   );
 
@@ -170,14 +173,23 @@ void main() {
       final intake = container.read(paymentRequestIntakeProvider);
       final park = container.read(paymentUriPrefillProvider.notifier);
 
-      expect(await intake.receive(first.rawUri), isFalse);
-      expect(await intake.receive(second.rawUri), isTrue);
+      expect(
+        await intake.receive(first.rawUri),
+        PaymentRequestIntakeResult.accepted,
+      );
+      expect(
+        await intake.receive(second.rawUri),
+        PaymentRequestIntakeResult.replaced,
+      );
       final fresh = park.takeIfFresh();
       expect(fresh.prefill, same(second));
       expect(fresh.expired, isFalse);
       expect(container.read(paymentUriPrefillProvider), isNull);
 
-      expect(await intake.receive(first.rawUri), isFalse);
+      expect(
+        await intake.receive(first.rawUri),
+        PaymentRequestIntakeResult.accepted,
+      );
       park.debugAgePark(
         PaymentUriPrefillNotifier.parkTtl + const Duration(seconds: 1),
       );
@@ -219,7 +231,10 @@ void main() {
         return Future.error(StateError('Zcash must use its existing parser'));
       });
       final intake = container.read(paymentRequestIntakeProvider);
-      expect(await intake.receive(' ZCASH:u1recipient?amount=0.25 '), isFalse);
+      expect(
+        await intake.receive(' ZCASH:u1recipient?amount=0.25 '),
+        PaymentRequestIntakeResult.accepted,
+      );
       final parked = container.read(paymentUriPrefillProvider);
       expect(parked, isA<SendPrefillArgs>());
       final zcashPrefill = parked! as SendPrefillArgs;

--- a/test/core/navigation/payment_request_intake_test.dart
+++ b/test/core/navigation/payment_request_intake_test.dart
@@ -18,6 +18,38 @@ void main() {
     return container;
   }
 
+  for (final parseFails in [false, true]) {
+    test(
+      'cancelled input preserves the park and arrival (parseFails: $parseFails)',
+      () async {
+        final parked = _request('parked');
+        final cancelled = _request('cancelled');
+        final parser = Completer<CrossChainPaymentRequest>();
+        final container = containerFor(
+          (raw) => raw == parked.rawUri ? Future.value(parked) : parser.future,
+        );
+        final intake = container.read(paymentRequestIntakeProvider);
+        await intake.receive(parked.rawUri);
+        var current = true;
+        final pending = intake.receive(
+          cancelled.rawUri,
+          isCurrent: () => current,
+        );
+
+        current = false;
+        if (parseFails) {
+          parser.completeError(const CrossChainPaymentParseException());
+        } else {
+          parser.complete(cancelled);
+        }
+
+        expect(await pending, isFalse);
+        expect(container.read(paymentUriPrefillProvider), same(parked));
+        expect(container.read(paymentRequestArrivalProvider), 1);
+      },
+    );
+  }
+
   test('a slow older parse cannot replace a newer accepted request', () async {
     final older = _request('older');
     final newer = _request('newer', solana: true);

--- a/test/features/pay/cross_chain_payment_request_card_test_support.dart
+++ b/test/features/pay/cross_chain_payment_request_card_test_support.dart
@@ -362,6 +362,52 @@ void runCrossChainPaymentRequestCardTests({required bool isMobile}) {
     await _capture(tester, isMobile: isMobile, state: 'unsupported');
   });
 
+  testWidgets(
+    'unresolved token skeletons become payment details after loading',
+    (tester) async {
+      await pump(
+        tester,
+        isLoading: true,
+        resolution: const PaymentRequestResolution(),
+      );
+      expect(
+        find.byKey(const ValueKey('payment_request_icon_skeleton')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('payment_request_token_skeleton')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('payment_request_amount_skeleton')),
+        findsOneWidget,
+      );
+      expect(find.text('Base'), findsOneWidget);
+      expect(find.text(truncatedAddress(_recipient)), findsOneWidget);
+      expect(find.text('Amount unavailable'), findsNothing);
+      expect(_primary(tester).onPressed, isNull);
+      await _capture(tester, isMobile: isMobile, state: 'loading-skeleton');
+      await pump(tester);
+      expect(
+        find.byKey(const ValueKey('payment_request_icon_skeleton')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('payment_request_token_skeleton')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('payment_request_amount_skeleton')),
+        findsNothing,
+      );
+      expect(find.text('25'), findsOneWidget);
+      expect(find.text('USDC'), findsOneWidget);
+      expect(_primary(tester).onPressed, isNotNull);
+      expect(tester.takeException(), isNull);
+      await _capture(tester, isMobile: isMobile, state: 'loaded-skeleton');
+    },
+  );
+
   testWidgets('loading preserves request details and blocks continuing', (
     tester,
   ) async {

--- a/test/features/pay/mobile_pay_screen_test.dart
+++ b/test/features/pay/mobile_pay_screen_test.dart
@@ -404,82 +404,113 @@ void main() {
     );
   }
 
-  testWidgets(
-    'mobile Pay pasted request preserves composer until explicit review',
-    (tester) async {
-      await _setMobileViewport(tester, const Size(393, 852));
-      final parsed = <String>[];
-      await tester.pumpWidget(
-        _app(
-          paymentParser: (raw) async {
-            parsed.add(raw);
-            return CrossChainPaymentRequest(
-              id: 'mobile-input',
-              rawUri: raw,
-              address: 'Payee',
-              isEvm: false,
-              chain: 'sol',
+  for (final typing in [false, true]) {
+    testWidgets(
+      'mobile Pay pasted request preserves composer until explicit review (typing: $typing)',
+      (tester) async {
+        await _setMobileViewport(tester, const Size(393, 852));
+        final parsed = <String>[];
+        await tester.pumpWidget(
+          _app(
+            paymentParser: (raw) async {
+              parsed.add(raw);
+              return CrossChainPaymentRequest(
+                id: 'mobile-input',
+                rawUri: raw,
+                address: 'Payee',
+                isEvm: false,
+                chain: 'sol',
+              );
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('mobile_pay_amount_input')),
+          '10',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
+        );
+        await tester.pumpAndSettle();
+        const address = '0x1111111111111111111111111111111111111111';
+        await tester.enterText(
+          find.byKey(const ValueKey('mobile_pay_recipient_input')),
+          address,
+        );
+        await tester.pumpAndSettle();
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MobilePayScreen)),
+        );
+        final previous = container.read(swapStateProvider);
+        const raw = 'solana:Payee?amount=25&spl-token=Mint&reference=Order';
+        if (typing) {
+          final field = find.byKey(
+            const ValueKey('mobile_pay_recipient_input'),
+          );
+          await tester.enterText(field, '');
+          await tester.pump();
+          for (var length = 1; length <= raw.length; length++) {
+            await tester.enterText(field, raw.substring(0, length));
+            await tester.pump();
+            expect(
+              container.read(swapStateProvider).destinationText,
+              previous.destinationText,
             );
-          },
-        ),
-      );
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        find.byKey(const ValueKey('mobile_pay_amount_input')),
-        '10',
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(
-        find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
-      );
-      await tester.pumpAndSettle();
-      const address = '0x1111111111111111111111111111111111111111';
-      await tester.enterText(
-        find.byKey(const ValueKey('mobile_pay_recipient_input')),
-        address,
-      );
-      await tester.pumpAndSettle();
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(MobilePayScreen)),
-      );
-      final previous = container.read(swapStateProvider);
-      const raw = 'solana:Payee?amount=25&spl-token=Mint&reference=Order';
-      await tester.enterText(
-        find.byKey(const ValueKey('mobile_pay_recipient_input')),
-        raw,
-      );
-      await tester.pumpAndSettle();
-      expect(parsed, isEmpty);
-      expect(container.read(swapStateProvider).destinationText, address);
-      expect(
-        find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
-        findsNothing,
-      );
-      expect(
-        find.byKey(const ValueKey('mobile_pay_add_to_contacts_button')),
-        findsNothing,
-      );
-      expect(
-        find.byKey(const ValueKey('mobile_pay_recipient_error')),
-        findsNothing,
-      );
-      await tester.tap(
-        find.byKey(const ValueKey('review_pasted_payment_request')),
-      );
-      await tester.pumpAndSettle();
-      expect(parsed, [raw]);
-      expect(
-        (container.read(paymentUriPrefillProvider) as CrossChainPaymentRequest)
-            .rawUri,
-        raw,
-      );
-      final after = container.read(swapStateProvider);
-      expect(after.destinationText, previous.destinationText);
-      expect(after.externalAsset, previous.externalAsset);
-      expect(after.receiveAmountText, previous.receiveAmountText);
-      expect(tester.takeException(), isNull);
-    },
-  );
+          }
+        } else {
+          await tester.enterText(
+            find.byKey(const ValueKey('mobile_pay_recipient_input')),
+            raw,
+          );
+        }
+        await tester.pumpAndSettle();
+        expect(parsed, isEmpty);
+        expect(container.read(swapStateProvider).destinationText, address);
+        expect(
+          find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(const ValueKey('mobile_pay_add_to_contacts_button')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(const ValueKey('mobile_pay_recipient_error')),
+          findsNothing,
+        );
+        await tester.tap(
+          find.byKey(const ValueKey('review_pasted_payment_request')),
+        );
+        await tester.pumpAndSettle();
+        expect(parsed, [raw]);
+        expect(
+          (container.read(paymentUriPrefillProvider)
+                  as CrossChainPaymentRequest)
+              .rawUri,
+          raw,
+        );
+        final after = container.read(swapStateProvider);
+        expect(after.destinationText, previous.destinationText);
+        expect(after.externalAsset, previous.externalAsset);
+        expect(after.receiveAmountText, previous.receiveAmountText);
+        if (typing) {
+          final field = find.byKey(
+            const ValueKey('mobile_pay_recipient_input'),
+          );
+          await tester.enterText(field, 's');
+          await tester.pump();
+          const plain = '0x2222222222222222222222222222222222222222';
+          await tester.enterText(field, plain);
+          await tester.pumpAndSettle();
+          expect(container.read(swapStateProvider).destinationText, plain);
+          expect(find.text(plain), findsOneWidget);
+        }
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
 
   testWidgets(
     'mobile pay amount uses the completed spendable snapshot during sync',
@@ -707,6 +738,17 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    // Abandon a possible URI prefix and select an existing contact.
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_pay_recipient_input')),
+      's',
+    );
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_pay_recipient_input')),
+      '',
+    );
+    await tester.pumpAndSettle();
     expect(find.text('2 contacts'), findsOneWidget);
     await tester.tap(find.text('Second'));
     await tester.pumpAndSettle();

--- a/test/features/pay/mobile_pay_screen_test.dart
+++ b/test/features/pay/mobile_pay_screen_test.dart
@@ -8,6 +8,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
@@ -57,9 +60,12 @@ Widget _app({
   bool preservePreparedComposer = false,
   bool usePreparedComposer = false,
   SyncState? syncState,
+  CrossChainPaymentParser? paymentParser,
 }) {
   return ProviderScope(
     overrides: [
+      if (paymentParser != null)
+        crossChainPaymentParserProvider.overrideWithValue(paymentParser),
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       if (usePreparedComposer)
         swapStateProvider.overrideWith(_PreparedPayNotifier.new),
@@ -333,6 +339,83 @@ Future<void> _setMobileViewport(WidgetTester tester, Size size) async {
 }
 
 void main() {
+  testWidgets(
+    'mobile Pay pasted request preserves composer until explicit review',
+    (tester) async {
+      await _setMobileViewport(tester, const Size(393, 852));
+      final parsed = <String>[];
+      await tester.pumpWidget(
+        _app(
+          paymentParser: (raw) async {
+            parsed.add(raw);
+            return CrossChainPaymentRequest(
+              id: 'mobile-input',
+              rawUri: raw,
+              address: 'Payee',
+              isEvm: false,
+              chain: 'sol',
+            );
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('mobile_pay_amount_input')),
+        '10',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
+      );
+      await tester.pumpAndSettle();
+      const address = '0x1111111111111111111111111111111111111111';
+      await tester.enterText(
+        find.byKey(const ValueKey('mobile_pay_recipient_input')),
+        address,
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(MobilePayScreen)),
+      );
+      final previous = container.read(swapStateProvider);
+      const raw = 'solana:Payee?amount=25&spl-token=Mint&reference=Order';
+      await tester.enterText(
+        find.byKey(const ValueKey('mobile_pay_recipient_input')),
+        raw,
+      );
+      await tester.pumpAndSettle();
+      expect(parsed, isEmpty);
+      expect(container.read(swapStateProvider).destinationText, address);
+      expect(
+        find.byKey(const ValueKey('mobile_pay_recipient_continue_button')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('mobile_pay_add_to_contacts_button')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('mobile_pay_recipient_error')),
+        findsNothing,
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('review_pasted_payment_request')),
+      );
+      await tester.pumpAndSettle();
+      expect(parsed, [raw]);
+      expect(
+        (container.read(paymentUriPrefillProvider) as CrossChainPaymentRequest)
+            .rawUri,
+        raw,
+      );
+      final after = container.read(swapStateProvider);
+      expect(after.destinationText, previous.destinationText);
+      expect(after.externalAsset, previous.externalAsset);
+      expect(after.receiveAmountText, previous.receiveAmountText);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets(
     'mobile pay amount uses the completed spendable snapshot during sync',
     (tester) async {

--- a/test/features/pay/mobile_pay_screen_test.dart
+++ b/test/features/pay/mobile_pay_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_request_intake.dart';
 import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
 import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
@@ -339,6 +340,70 @@ Future<void> _setMobileViewport(WidgetTester tester, Size size) async {
 }
 
 void main() {
+  for (final leaveStep in [false, true]) {
+    testWidgets(
+      'Pay discards a pending request after input or step changes (leaveStep: $leaveStep)',
+      (tester) async {
+        final parsed = Completer<CrossChainPaymentRequest>();
+        await _setMobileViewport(tester, const Size(393, 852));
+        await tester.pumpWidget(_app(paymentParser: (_) => parsed.future));
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('mobile_pay_amount_input')),
+          '10',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('mobile_pay_amount_continue_button')),
+        );
+        await tester.pumpAndSettle();
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MobilePayScreen)),
+        );
+        const raw = 'bitcoin:bc1qinvoice?amount=0.1';
+        await tester.enterText(
+          find.byKey(const ValueKey('mobile_pay_recipient_input')),
+          raw,
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('review_pasted_payment_request')),
+        );
+        await tester.pumpAndSettle();
+        if (leaveStep) {
+          await tester.tap(find.bySemanticsLabel('Back'));
+        } else {
+          await tester.enterText(
+            find.byKey(const ValueKey('mobile_pay_recipient_input')),
+            'bitcoin:new-draft',
+          );
+        }
+        await tester.pumpAndSettle();
+        parsed.complete(
+          const CrossChainPaymentRequest(
+            id: 'obsolete',
+            rawUri: raw,
+            address: 'bc1qinvoice',
+            isEvm: false,
+            chain: 'btc',
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(container.read(paymentUriPrefillProvider), isNull);
+        expect(container.read(paymentRequestArrivalProvider), 0);
+        if (leaveStep) {
+          expect(
+            find.byKey(const ValueKey('mobile_pay_amount_input')),
+            findsOneWidget,
+          );
+        } else {
+          expect(find.text('bitcoin:new-draft'), findsOneWidget);
+        }
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
   testWidgets(
     'mobile Pay pasted request preserves composer until explicit review',
     (tester) async {

--- a/test/features/send/mobile_send_scan_sheet_test.dart
+++ b/test/features/send/mobile_send_scan_sheet_test.dart
@@ -113,6 +113,27 @@ void main() {
     });
     tearDownAll(RustLib.dispose);
 
+    test(
+      'preserves cross-chain payment terms for the common request intake',
+      () async {
+        rustApi.lastNetwork = null;
+        for (final raw in [
+          'bitcoin:bc1qinvoice?amount=0.01&label=Coffee%20shop',
+          'litecoin:ltc1qinvoice?amount=1.5',
+          'ethereum:0xToken@8453/transfer?address=0xPayee&uint256=25000000',
+          'solana:Payee?amount=25&spl-token=Mint&reference=Order',
+        ]) {
+          final outcome = await resolveScannedZcashAddress(
+            raw,
+            networkName: kZcashDefaultNetworkName,
+          );
+          expect(outcome.isAccepted, isTrue);
+          expect(outcome.address, raw);
+        }
+        expect(rustApi.lastNetwork, isNull);
+      },
+    );
+
     test('accepts an address this wallet can pay', () async {
       final outcome = await resolveScannedZcashAddress(
         _mainnetAddress,

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -835,6 +835,70 @@ void main() {
       ..devicePixelRatio = 1.0;
   });
 
+  testWidgets('rejected clipboard request remains editable and retries', (
+    tester,
+  ) async {
+    const raw = 'bitcoin:malformed?amount=oops';
+    final parsed = <String>[];
+    await tester.pumpWidget(
+      _app(
+        paymentParser: (value) async {
+          parsed.add(value);
+          if (value == raw) throw const CrossChainPaymentParseException();
+          return CrossChainPaymentRequest(
+            id: 'corrected',
+            rawUri: value,
+            address: 'bc1qinvoice',
+            isEvm: false,
+            chain: 'btc',
+          );
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async => call.method == 'Clipboard.getData'
+          ? <String, dynamic>{'text': raw}
+          : null,
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+    final field = find.byKey(const ValueKey('mobile_send_address_field'));
+    await tester.tap(field);
+    await tester.pumpAndSettle();
+    final actions = find.byKey(
+      const ValueKey('mobile_send_address_action_slot'),
+    );
+    await tester.tap(
+      find.descendant(of: actions, matching: find.text('Paste')),
+    );
+    await tester.pumpAndSettle();
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobileSendScreen)),
+    );
+    expect(find.text(raw), findsOneWidget);
+    expect(parsed, [raw]);
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    const corrected = 'bitcoin:bc1qinvoice?amount=0.1';
+    await tester.enterText(
+      find.descendant(of: field, matching: find.byType(EditableText)),
+      corrected,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.descendant(of: actions, matching: find.text('Review')),
+    );
+    await tester.pumpAndSettle();
+    expect(parsed, [raw, corrected]);
+    expect(container.read(paymentUriPrefillProvider)!.id, 'corrected');
+    expect(tester.takeException(), isNull);
+  });
+
   for (final change in ['none', 'edit', 'leave', 'paste-edit']) {
     testWidgets(
       'Send request intake respects input lifetime (change: $change)',

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -2,10 +2,15 @@
 library;
 
 import 'dart:async';
+import 'package:zcash_wallet/src/core/navigation/payment_request_intake.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
 
 import '../../figma_compare/figma_compare_font_loader.dart';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/rendering.dart' show RenderParagraph;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
@@ -397,6 +402,7 @@ class _FakeAddressBookRepository implements AddressBookRepository {
 }
 
 Widget _app({
+  CrossChainPaymentParser? paymentParser,
   List<AddressBookContact> contacts = const [],
   AccountState? accountState,
   Map<String, AccountInfo> ownAccounts = const {},
@@ -445,6 +451,8 @@ Widget _app({
   );
   return ProviderScope(
     overrides: [
+      if (paymentParser != null)
+        crossChainPaymentParserProvider.overrideWithValue(paymentParser),
       appBootstrapProvider.overrideWithValue(
         _bootstrap(accountState: accountState),
       ),
@@ -826,6 +834,98 @@ void main() {
       ..physicalSize = const Size(520, 1100)
       ..devicePixelRatio = 1.0;
   });
+
+  for (final change in ['none', 'edit', 'leave', 'paste-edit']) {
+    testWidgets(
+      'Send request intake respects input lifetime (change: $change)',
+      (tester) async {
+        final parsed = Completer<CrossChainPaymentRequest>();
+        await tester.pumpWidget(_app(paymentParser: (_) => parsed.future));
+        await tester.pumpAndSettle();
+        final element = tester.element(find.byType(MobileSendScreen));
+        final container = ProviderScope.containerOf(element);
+        final router = GoRouter.of(element);
+        const raw = 'bitcoin:bc1qinvoice?amount=0.1';
+        if (change == 'paste-edit') {
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            SystemChannels.platform,
+            (call) async => call.method == 'Clipboard.getData'
+                ? <String, dynamic>{'text': raw}
+                : null,
+          );
+          addTearDown(
+            () => tester.binding.defaultBinaryMessenger
+                .setMockMethodCallHandler(SystemChannels.platform, null),
+          );
+          await tester.tap(
+            find.byKey(const ValueKey('mobile_send_address_field')),
+          );
+          await tester.pumpAndSettle();
+          await tester.tap(
+            find.descendant(
+              of: find.byKey(const ValueKey('mobile_send_address_action_slot')),
+              matching: find.text('Paste'),
+            ),
+          );
+          await tester.pumpAndSettle();
+        } else {
+          await tester.enterText(
+            find.descendant(
+              of: find.byKey(const ValueKey('mobile_send_address_field')),
+              matching: find.byType(EditableText),
+            ),
+            raw,
+          );
+          await tester.pumpAndSettle();
+          await tester.tap(
+            find.descendant(
+              of: find.byKey(const ValueKey('mobile_send_address_action_slot')),
+              matching: find.text('Review'),
+            ),
+          );
+          await tester.pumpAndSettle();
+        }
+        if (change == 'edit' || change == 'paste-edit') {
+          await tester.enterText(
+            find.descendant(
+              of: find.byKey(const ValueKey('mobile_send_address_field')),
+              matching: find.byType(EditableText),
+            ),
+            'bitcoin:new-draft',
+          );
+        } else if (change == 'leave') {
+          unawaited(router.push('/home'));
+        }
+        await tester.pumpAndSettle();
+        parsed.complete(
+          const CrossChainPaymentRequest(
+            id: 'send-input',
+            rawUri: raw,
+            address: 'bc1qinvoice',
+            isEvm: false,
+            chain: 'btc',
+          ),
+        );
+        await tester.pumpAndSettle();
+        if (change == 'none') {
+          expect(container.read(paymentUriPrefillProvider)!.id, 'send-input');
+          expect(container.read(paymentRequestArrivalProvider), 1);
+        } else {
+          expect(container.read(paymentUriPrefillProvider), isNull);
+          expect(container.read(paymentRequestArrivalProvider), 0);
+        }
+        if (change == 'edit' || change == 'paste-edit') {
+          expect(find.text('bitcoin:new-draft'), findsOneWidget);
+        }
+        if (change == 'leave') {
+          expect(find.text('home'), findsOneWidget);
+        }
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+      },
+    );
+  }
 
   testWidgets('starts Orchard proving-key warmup when mobile send loads', (
     tester,

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -1,4 +1,8 @@
 import 'dart:async';
+import 'package:zcash_wallet/src/core/navigation/payment_request_intake.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -45,6 +49,63 @@ void main() {
   });
 
   tearDownAll(RustLib.dispose);
+
+  for (final change in ['none', 'edit', 'leave']) {
+    testWidgets(
+      'Send request intake respects input lifetime (change: $change)',
+      (tester) async {
+        final parsed = Completer<CrossChainPaymentRequest>();
+        await _setDesktopViewport(tester);
+        await tester.pumpWidget(
+          _sendHarness(paymentParser: (_) => parsed.future),
+        );
+        await tester.pumpAndSettle();
+        final element = tester.element(find.byType(SendScreen));
+        final container = ProviderScope.containerOf(element);
+        final router = GoRouter.of(element);
+        const raw = 'bitcoin:bc1qinvoice?amount=0.1';
+        await tester.enterText(_editableIn('send_address_field'), raw);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Review request'));
+        await tester.pumpAndSettle();
+        if (change == 'edit') {
+          await tester.enterText(
+            _editableIn('send_address_field'),
+            'bitcoin:new-draft',
+          );
+        } else if (change == 'leave') {
+          unawaited(router.push('/home'));
+        }
+        await tester.pumpAndSettle();
+        parsed.complete(
+          const CrossChainPaymentRequest(
+            id: 'send-input',
+            rawUri: raw,
+            address: 'bc1qinvoice',
+            isEvm: false,
+            chain: 'btc',
+          ),
+        );
+        await tester.pumpAndSettle();
+        if (change == 'none') {
+          expect(container.read(paymentUriPrefillProvider)!.id, 'send-input');
+          expect(container.read(paymentRequestArrivalProvider), 1);
+        } else {
+          expect(container.read(paymentUriPrefillProvider), isNull);
+          expect(container.read(paymentRequestArrivalProvider), 0);
+        }
+        if (change == 'edit') {
+          expect(find.text('bitcoin:new-draft'), findsOneWidget);
+        }
+        if (change == 'leave') {
+          expect(find.text('home'), findsOneWidget);
+        }
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+      },
+    );
+  }
 
   testWidgets('starts Orchard proving-key warmup when send loads', (
     tester,
@@ -1577,6 +1638,7 @@ MigrationStatus _migrationStatus(String phase) {
 }
 
 Widget _sendHarness({
+  CrossChainPaymentParser? paymentParser,
   SendPrefillArgs? prefill,
   AddressBookRepository? addressBookRepository,
   AppBootstrapState? bootstrap,
@@ -1599,6 +1661,7 @@ Widget _sendHarness({
   final router = GoRouter(
     initialLocation: '/send',
     routes: [
+      GoRoute(path: '/home', builder: (_, _) => const Text('home')),
       GoRoute(
         path: '/send',
         builder: (_, _) => SendScreen(prefill: prefill),
@@ -1618,6 +1681,8 @@ Widget _sendHarness({
 
   return ProviderScope(
     overrides: [
+      if (paymentParser != null)
+        crossChainPaymentParserProvider.overrideWithValue(paymentParser),
       appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap),
       if (realReview)
         ownAccountAddressesProvider.overrideWith((ref) async => {}),

--- a/test/features/swap/mobile_swap_modal_route_test.dart
+++ b/test/features/swap/mobile_swap_modal_route_test.dart
@@ -545,6 +545,81 @@ void main() {
     );
   });
 
+  testWidgets('newer review survives an older completion in the same editor', (
+    tester,
+  ) async {
+    final parses = [
+      Completer<CrossChainPaymentRequest>(),
+      Completer<CrossChainPaymentRequest>(),
+    ];
+    var calls = 0;
+    Future<CrossChainPaymentRequest> parser(String raw) =>
+        parses[calls++].future;
+    await _setNarrowMobileViewport(tester);
+    await tester.pumpWidget(
+      _app(
+        swapProvider: _MobileDelayedQuoteSwapProvider(),
+        paymentParser: parser,
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.bySemanticsLabel('Swap').last);
+    await tester.pumpAndSettle();
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobileSwapScreen)),
+    );
+    container
+        .read(swapStateProvider.notifier)
+        .selectDirection(SwapDirection.zecToExternal);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add recipient address'));
+    await tester.pumpAndSettle();
+    const raw = 'bitcoin:bc1qinvoice?amount=0.1';
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      raw,
+    );
+    await tester.pumpAndSettle();
+    for (var i = 0; i < 2; i++) {
+      await tester.tap(
+        find.byKey(const ValueKey('swap_address_update_button')),
+      );
+      await tester.pumpAndSettle();
+    }
+    expect(calls, 2);
+    parses[0].complete(
+      const CrossChainPaymentRequest(
+        id: 'older',
+        rawUri: raw,
+        address: 'bc1qinvoice',
+        isEvm: false,
+        chain: 'btc',
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('swap_destination_field')),
+      findsOneWidget,
+    );
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    parses[1].complete(
+      const CrossChainPaymentRequest(
+        id: 'newer',
+        rawUri: raw,
+        address: 'bc1qinvoice',
+        isEvm: false,
+        chain: 'btc',
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('swap_destination_field')), findsNothing);
+    expect(container.read(paymentUriPrefillProvider)!.id, 'newer');
+    expect(container.read(paymentRequestArrivalProvider), 1);
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('rejected pasted request stays editable and can be retried', (
     tester,
   ) async {
@@ -644,81 +719,85 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets(
-    'late pasted request result leaves a reopened address editor alone',
-    (tester) async {
-      final parseGate = Completer<void>();
-      Future<CrossChainPaymentRequest> parser(String raw) async {
-        await parseGate.future;
-        return CrossChainPaymentRequest(
-          id: 'retry-input',
-          rawUri: raw,
-          address: 'bc1qinvoice',
-          isEvm: false,
-          chain: 'btc',
-        );
-      }
+  for (final reopen in [false, true]) {
+    testWidgets(
+      'late pasted request result respects editor changes (reopen: $reopen)',
+      (tester) async {
+        final parseGate = Completer<void>();
+        Future<CrossChainPaymentRequest> parser(String raw) async {
+          await parseGate.future;
+          return CrossChainPaymentRequest(
+            id: 'retry-input',
+            rawUri: raw,
+            address: 'bc1qinvoice',
+            isEvm: false,
+            chain: 'btc',
+          );
+        }
 
-      await _setNarrowMobileViewport(tester);
-      await tester.pumpWidget(
-        _app(
-          swapProvider: _MobileDelayedQuoteSwapProvider(),
-          paymentParser: parser,
-        ),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.bySemanticsLabel('Swap').last);
-      await tester.pumpAndSettle();
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(MobileSwapScreen)),
-      );
-      container
-          .read(swapStateProvider.notifier)
-          .selectDirection(SwapDirection.zecToExternal);
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Add recipient address'));
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        find.byKey(const ValueKey('swap_destination_field')),
-        'bitcoin:bc1qinvoice?amount=0.1',
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(
-        find.byKey(const ValueKey('swap_address_update_button')),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Cancel'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Add recipient address'));
-      await tester.pumpAndSettle();
-      const nextDraft = 'bitcoin:another-request';
-      await tester.enterText(
-        find.byKey(const ValueKey('swap_destination_field')),
-        nextDraft,
-      );
-      await tester.pumpAndSettle();
-      parseGate.complete();
-      await tester.pumpAndSettle();
-      expect(
-        find.byKey(const ValueKey('swap_destination_field')),
-        findsOneWidget,
-      );
-      expect(
-        tester
-            .widget<TextField>(
-              find.byKey(const ValueKey('swap_destination_field')),
-            )
-            .controller!
-            .text,
-        nextDraft,
-      );
-      expect(container.read(paymentUriPrefillProvider), isNull);
-      expect(container.read(paymentRequestArrivalProvider), 0);
-      expect(tester.takeException(), isNull);
-      await tester.pumpWidget(const SizedBox.shrink());
-      await tester.pumpAndSettle();
-    },
-  );
+        await _setNarrowMobileViewport(tester);
+        await tester.pumpWidget(
+          _app(
+            swapProvider: _MobileDelayedQuoteSwapProvider(),
+            paymentParser: parser,
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.bySemanticsLabel('Swap').last);
+        await tester.pumpAndSettle();
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MobileSwapScreen)),
+        );
+        container
+            .read(swapStateProvider.notifier)
+            .selectDirection(SwapDirection.zecToExternal);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Add recipient address'));
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('swap_destination_field')),
+          'bitcoin:bc1qinvoice?amount=0.1',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('swap_address_update_button')),
+        );
+        await tester.pumpAndSettle();
+        if (reopen) {
+          await tester.tap(find.text('Cancel'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Add recipient address'));
+          await tester.pumpAndSettle();
+        }
+        const nextDraft = 'bitcoin:another-request';
+        await tester.enterText(
+          find.byKey(const ValueKey('swap_destination_field')),
+          nextDraft,
+        );
+        await tester.pumpAndSettle();
+        parseGate.complete();
+        await tester.pumpAndSettle();
+        expect(
+          find.byKey(const ValueKey('swap_destination_field')),
+          findsOneWidget,
+        );
+        expect(
+          tester
+              .widget<TextField>(
+                find.byKey(const ValueKey('swap_destination_field')),
+              )
+              .controller!
+              .text,
+          nextDraft,
+        );
+        expect(container.read(paymentUriPrefillProvider), isNull);
+        expect(container.read(paymentRequestArrivalProvider), 0);
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+      },
+    );
+  }
 
   testWidgets('QR scan returns to address editor before committing address', (
     tester,

--- a/test/features/swap/mobile_swap_modal_route_test.dart
+++ b/test/features/swap/mobile_swap_modal_route_test.dart
@@ -11,6 +11,7 @@ import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/layout/mobile/mobile_top_nav.dart';
 import 'package:zcash_wallet/src/core/navigation/mobile_routes.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_request_intake.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
 import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
@@ -711,6 +712,8 @@ void main() {
             .text,
         nextDraft,
       );
+      expect(container.read(paymentUriPrefillProvider), isNull);
+      expect(container.read(paymentRequestArrivalProvider), 0);
       expect(tester.takeException(), isNull);
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pumpAndSettle();

--- a/test/features/swap/mobile_swap_modal_route_test.dart
+++ b/test/features/swap/mobile_swap_modal_route_test.dart
@@ -12,6 +12,9 @@ import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/layout/mobile/mobile_top_nav.dart';
 import 'package:zcash_wallet/src/core/navigation/mobile_routes.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
@@ -59,10 +62,13 @@ AppBootstrapState _bootstrap() => AppBootstrapState(
 
 Widget _app({
   _MobileDelayedQuoteSwapProvider? swapProvider,
+  CrossChainPaymentParser? paymentParser,
   SwapComposerPreferencesStore? composerPreferencesStore,
   List<AddressBookContact> addressBookContacts = const [],
 }) => ProviderScope(
   overrides: [
+    if (paymentParser != null)
+      crossChainPaymentParserProvider.overrideWithValue(paymentParser),
     appBootstrapProvider.overrideWithValue(_bootstrap()),
     addressBookRepositoryProvider.overrideWithValue(
       _FakeAddressBookRepository(addressBookContacts),
@@ -537,6 +543,179 @@ void main() {
       findsNothing,
     );
   });
+
+  testWidgets('rejected pasted request stays editable and can be retried', (
+    tester,
+  ) async {
+    const rejected = 'bitcoin:malformed?amount=oops';
+    const corrected = 'bitcoin:bc1qinvoice?amount=0.1';
+    final parsed = <String>[];
+    final parseGate = Completer<void>();
+    Future<CrossChainPaymentRequest> parser(String raw) async {
+      parsed.add(raw);
+      if (raw == rejected) {
+        await parseGate.future;
+        throw const CrossChainPaymentParseException();
+      }
+      return CrossChainPaymentRequest(
+        id: 'retry-input',
+        rawUri: raw,
+        address: 'bc1qinvoice',
+        isEvm: false,
+        chain: 'btc',
+      );
+    }
+
+    await _setNarrowMobileViewport(tester);
+    await tester.pumpWidget(
+      _app(
+        swapProvider: _MobileDelayedQuoteSwapProvider(),
+        paymentParser: parser,
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.bySemanticsLabel('Swap').last);
+    await tester.pumpAndSettle();
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobileSwapScreen)),
+    );
+    container
+        .read(swapStateProvider.notifier)
+        .selectDirection(SwapDirection.zecToExternal);
+    await tester.pumpAndSettle();
+    final before = container.read(swapStateProvider);
+    await tester.tap(find.text('Add recipient address'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      rejected,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
+    await tester.pumpAndSettle();
+    parseGate.complete();
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('swap_destination_field')),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const ValueKey('swap_destination_field')),
+          )
+          .controller!
+          .text,
+      rejected,
+    );
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(
+      container.read(swapStateProvider).destinationText,
+      before.destinationText,
+    );
+    expect(container.read(swapStateProvider).amountText, before.amountText);
+    expect(
+      find.text(const CrossChainPaymentParseException().toString()),
+      findsOneWidget,
+    );
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      corrected,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
+    await tester.pumpAndSettle();
+    expect(parsed, [rejected, corrected]);
+    expect(find.byKey(const ValueKey('swap_destination_field')), findsNothing);
+    expect(
+      (container.read(paymentUriPrefillProvider) as CrossChainPaymentRequest)
+          .rawUri,
+      corrected,
+    );
+    expect(
+      container.read(swapStateProvider).destinationText,
+      before.destinationText,
+    );
+    expect(container.read(swapStateProvider).amountText, before.amountText);
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+    'late pasted request result leaves a reopened address editor alone',
+    (tester) async {
+      final parseGate = Completer<void>();
+      Future<CrossChainPaymentRequest> parser(String raw) async {
+        await parseGate.future;
+        return CrossChainPaymentRequest(
+          id: 'retry-input',
+          rawUri: raw,
+          address: 'bc1qinvoice',
+          isEvm: false,
+          chain: 'btc',
+        );
+      }
+
+      await _setNarrowMobileViewport(tester);
+      await tester.pumpWidget(
+        _app(
+          swapProvider: _MobileDelayedQuoteSwapProvider(),
+          paymentParser: parser,
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.bySemanticsLabel('Swap').last);
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(MobileSwapScreen)),
+      );
+      container
+          .read(swapStateProvider.notifier)
+          .selectDirection(SwapDirection.zecToExternal);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Add recipient address'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_destination_field')),
+        'bitcoin:bc1qinvoice?amount=0.1',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('swap_address_update_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Add recipient address'));
+      await tester.pumpAndSettle();
+      const nextDraft = 'bitcoin:another-request';
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_destination_field')),
+        nextDraft,
+      );
+      await tester.pumpAndSettle();
+      parseGate.complete();
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('swap_destination_field')),
+        findsOneWidget,
+      );
+      expect(
+        tester
+            .widget<TextField>(
+              find.byKey(const ValueKey('swap_destination_field')),
+            )
+            .controller!
+            .text,
+        nextDraft,
+      );
+      expect(tester.takeException(), isNull);
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+    },
+  );
 
   testWidgets('QR scan returns to address editor before committing address', (
     tester,

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -76,6 +76,76 @@ import 'support/swap_activity_fixture_intents.dart';
 part 'support/swap_screen_test_fakes.dart';
 
 void main() {
+  for (final leaveStep in [false, true]) {
+    testWidgets(
+      'Pay discards a pending request after input or step changes (leaveStep: $leaveStep)',
+      (tester) async {
+        final parsed = Completer<CrossChainPaymentRequest>();
+        await _setDesktopViewport(tester);
+        await tester.pumpWidget(
+          _routerHarness(
+            GoRouter(initialLocation: '/pay', routes: [_payRoute()]),
+            seedSwapActivityFixtures: false,
+            paymentParser: (_) => parsed.future,
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('pay_amount_input')),
+          '10',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('pay_amount_continue_button')),
+        );
+        await tester.pumpAndSettle();
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(PayScreen)),
+        );
+        const raw = 'bitcoin:bc1qinvoice?amount=0.1';
+        await tester.enterText(
+          find.byKey(const ValueKey('pay_recipient_search_field')),
+          raw,
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('review_pasted_payment_request')),
+        );
+        await tester.pumpAndSettle();
+        if (leaveStep) {
+          await tester.tap(find.byKey(const ValueKey('pay_wizard_back_link')));
+        } else {
+          await tester.enterText(
+            find.byKey(const ValueKey('pay_recipient_search_field')),
+            'bitcoin:new-draft',
+          );
+        }
+        await tester.pumpAndSettle();
+        parsed.complete(
+          const CrossChainPaymentRequest(
+            id: 'obsolete',
+            rawUri: raw,
+            address: 'bc1qinvoice',
+            isEvm: false,
+            chain: 'btc',
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(container.read(paymentUriPrefillProvider), isNull);
+        expect(container.read(paymentRequestArrivalProvider), 0);
+        if (leaveStep) {
+          expect(
+            find.byKey(const ValueKey('pay_amount_input')),
+            findsOneWidget,
+          );
+        } else {
+          expect(find.text('bitcoin:new-draft'), findsOneWidget);
+        }
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
   test('swapIntentProvider uses the Vizor proxy and referral', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);
@@ -2761,6 +2831,83 @@ void main() {
     },
   );
 
+  testWidgets('newer review survives an older completion in the same editor', (
+    tester,
+  ) async {
+    final parses = [
+      Completer<CrossChainPaymentRequest>(),
+      Completer<CrossChainPaymentRequest>(),
+    ];
+    var calls = 0;
+    Future<CrossChainPaymentRequest> parser(String raw) =>
+        parses[calls++].future;
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+        paymentParser: parser,
+      ),
+    );
+    await tester.pumpAndSettle();
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SwapScreen)),
+    );
+    container
+        .read(swapStateProvider.notifier)
+        .selectDirection(SwapDirection.zecToExternal);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+    const raw = 'bitcoin:bc1qinvoice?amount=0.1';
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      raw,
+    );
+    await tester.pumpAndSettle();
+    for (var i = 0; i < 2; i++) {
+      await tester.tap(
+        find.byKey(const ValueKey('swap_address_update_button')),
+      );
+      await tester.pumpAndSettle();
+    }
+    expect(calls, 2);
+    parses[0].complete(
+      const CrossChainPaymentRequest(
+        id: 'older',
+        rawUri: raw,
+        address: 'bc1qinvoice',
+        isEvm: false,
+        chain: 'btc',
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('swap_destination_field')),
+      findsOneWidget,
+    );
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    parses[1].complete(
+      const CrossChainPaymentRequest(
+        id: 'newer',
+        rawUri: raw,
+        address: 'bc1qinvoice',
+        isEvm: false,
+        chain: 'btc',
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('swap_destination_field')), findsNothing);
+    expect(container.read(paymentUriPrefillProvider)!.id, 'newer');
+    expect(container.read(paymentRequestArrivalProvider), 1);
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('rejected pasted request stays editable and can be retried', (
     tester,
   ) async {
@@ -2862,83 +3009,87 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets(
-    'late pasted request result leaves a reopened address editor alone',
-    (tester) async {
-      final parseGate = Completer<void>();
-      Future<CrossChainPaymentRequest> parser(String raw) async {
-        await parseGate.future;
-        return CrossChainPaymentRequest(
-          id: 'retry-input',
-          rawUri: raw,
-          address: 'bc1qinvoice',
-          isEvm: false,
-          chain: 'btc',
-        );
-      }
+  for (final reopen in [false, true]) {
+    testWidgets(
+      'late pasted request result respects editor changes (reopen: $reopen)',
+      (tester) async {
+        final parseGate = Completer<void>();
+        Future<CrossChainPaymentRequest> parser(String raw) async {
+          await parseGate.future;
+          return CrossChainPaymentRequest(
+            id: 'retry-input',
+            rawUri: raw,
+            address: 'bc1qinvoice',
+            isEvm: false,
+            chain: 'btc',
+          );
+        }
 
-      await _setDesktopViewport(tester);
-      await tester.pumpWidget(
-        _routerHarness(
-          GoRouter(
-            initialLocation: '/swap',
-            routes: [_swapRoute(), _swapActivityRoute()],
+        await _setDesktopViewport(tester);
+        await tester.pumpWidget(
+          _routerHarness(
+            GoRouter(
+              initialLocation: '/swap',
+              routes: [_swapRoute(), _swapActivityRoute()],
+            ),
+            seedSwapActivityFixtures: false,
+            paymentParser: parser,
           ),
-          seedSwapActivityFixtures: false,
-          paymentParser: parser,
-        ),
-      );
-      await tester.pumpAndSettle();
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(SwapScreen)),
-      );
-      container
-          .read(swapStateProvider.notifier)
-          .selectDirection(SwapDirection.zecToExternal);
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        find.byKey(const ValueKey('swap_destination_field')),
-        'bitcoin:bc1qinvoice?amount=0.1',
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(
-        find.byKey(const ValueKey('swap_address_update_button')),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Cancel'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
-      await tester.pumpAndSettle();
-      const nextDraft = 'bitcoin:another-request';
-      await tester.enterText(
-        find.byKey(const ValueKey('swap_destination_field')),
-        nextDraft,
-      );
-      await tester.pumpAndSettle();
-      parseGate.complete();
-      await tester.pumpAndSettle();
-      expect(
-        find.byKey(const ValueKey('swap_destination_field')),
-        findsOneWidget,
-      );
-      expect(
-        tester
-            .widget<TextField>(
-              find.byKey(const ValueKey('swap_destination_field')),
-            )
-            .controller!
-            .text,
-        nextDraft,
-      );
-      expect(container.read(paymentUriPrefillProvider), isNull);
-      expect(container.read(paymentRequestArrivalProvider), 0);
-      expect(tester.takeException(), isNull);
-      await tester.pumpWidget(const SizedBox.shrink());
-      await tester.pumpAndSettle();
-    },
-  );
+        );
+        await tester.pumpAndSettle();
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(SwapScreen)),
+        );
+        container
+            .read(swapStateProvider.notifier)
+            .selectDirection(SwapDirection.zecToExternal);
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('swap_destination_field')),
+          'bitcoin:bc1qinvoice?amount=0.1',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('swap_address_update_button')),
+        );
+        await tester.pumpAndSettle();
+        if (reopen) {
+          await tester.tap(find.text('Cancel'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+          await tester.pumpAndSettle();
+        }
+        const nextDraft = 'bitcoin:another-request';
+        await tester.enterText(
+          find.byKey(const ValueKey('swap_destination_field')),
+          nextDraft,
+        );
+        await tester.pumpAndSettle();
+        parseGate.complete();
+        await tester.pumpAndSettle();
+        expect(
+          find.byKey(const ValueKey('swap_destination_field')),
+          findsOneWidget,
+        );
+        expect(
+          tester
+              .widget<TextField>(
+                find.byKey(const ValueKey('swap_destination_field')),
+              )
+              .controller!
+              .text,
+          nextDraft,
+        );
+        expect(container.read(paymentUriPrefillProvider), isNull);
+        expect(container.read(paymentRequestArrivalProvider), 0);
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+      },
+    );
+  }
 
   testWidgets('Swap payment QR reaches intake after scanner closes', (
     tester,

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -26,6 +26,11 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_toast.dart';
 import 'package:zcash_wallet/src/core/widgets/review_list_row.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
+import 'package:zcash_wallet/src/core/payments/cross_chain_payment_request.dart';
+import 'package:zcash_wallet/src/features/pay/providers/cross_chain_payment_request_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/features/address_scan/widgets/payment_request_input.dart';
+import 'package:zcash_wallet/src/services/qr_scanner.dart';
 import 'package:zcash_wallet/src/features/address_book/contact_label_generator.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
@@ -2687,6 +2692,191 @@ void main() {
 
     expect(_destinationSummaryText(tester), '0x529084...169ee7');
   });
+
+  testWidgets(
+    'Pay pasted payment request waits for review and preserves composer',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final parsed = <String>[];
+      final router = GoRouter(initialLocation: '/pay', routes: [_payRoute()]);
+      await tester.pumpWidget(
+        _routerHarness(
+          router,
+          seedSwapActivityFixtures: false,
+          paymentParser: (raw) async {
+            parsed.add(raw);
+            return _crossChainInputFixture(raw);
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_amount_input')),
+        '25',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('pay_amount_continue_button')),
+      );
+      await tester.pumpAndSettle();
+      const destination = '0x52908400098527886e0f7030069857d2e4169ee7';
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_recipient_search_field')),
+        destination,
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(PayScreen)),
+      );
+      final previous = container.read(swapStateProvider);
+      const raw = 'bitcoin:bc1qinvoice?amount=0.01&label=Coffee%20shop';
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_recipient_search_field')),
+        raw,
+      );
+      await tester.pumpAndSettle();
+      expect(parsed, isEmpty);
+      expect(container.read(swapStateProvider).destinationText, destination);
+      expect(
+        find.byKey(const ValueKey('pay_select_recipient_button')),
+        findsNothing,
+      );
+      expect(find.text('Invalid EVM address'), findsNothing);
+      await tester.tap(
+        find.byKey(const ValueKey('review_pasted_payment_request')),
+      );
+      await tester.pumpAndSettle();
+      expect(parsed, [raw]);
+      expect(
+        (container.read(paymentUriPrefillProvider) as CrossChainPaymentRequest)
+            .rawUri,
+        raw,
+      );
+      final after = container.read(swapStateProvider);
+      expect(after.destinationText, previous.destinationText);
+      expect(after.externalAsset, previous.externalAsset);
+      expect(after.receiveAmountText, previous.receiveAmountText);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('Swap payment QR reaches intake after scanner closes', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final parsed = <String>[];
+    int? scannerCountAtParse;
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+        paymentParser: (raw) async {
+          parsed.add(raw);
+          scannerCountAtParse = find
+              .byType(AddressQrScanModal)
+              .evaluate()
+              .length;
+          return _crossChainInputFixture(raw);
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SwapScreen)),
+    );
+    container
+        .read(swapStateProvider.notifier)
+        .selectDirection(SwapDirection.zecToExternal);
+    await tester.pumpAndSettle();
+    final previous = container.read(swapStateProvider);
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_scan_button')));
+    await tester.pumpAndSettle();
+    final scanner = tester.widget<AddressQrScanModalContent>(
+      find.byType(AddressQrScanModalContent),
+    );
+    const raw =
+        'ethereum:0xToken@8453/transfer?address=0xPayee&uint256=25000000';
+    expect(
+      tester
+          .widget<AddressQrScanModal>(find.byType(AddressQrScanModal))
+          .isRefundAddress,
+      isFalse,
+    );
+    (scanner.cameraView! as PlainQrScannerView).onComplete(raw);
+    await tester.pumpAndSettle();
+    expect(parsed, [raw]);
+    expect(scannerCountAtParse, 0);
+    expect(
+      (container.read(paymentUriPrefillProvider) as CrossChainPaymentRequest)
+          .rawUri,
+      raw,
+    );
+    expect(
+      container.read(swapStateProvider).destinationText,
+      previous.destinationText,
+    );
+    expect(container.read(swapStateProvider).amountText, previous.amountText);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'Swap refund input refuses payment requests and never parks one',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(
+        _routerHarness(
+          GoRouter(
+            initialLocation: '/swap',
+            routes: [_swapRoute(), _swapActivityRoute()],
+          ),
+          seedSwapActivityFixtures: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SwapScreen)),
+      );
+      container
+          .read(swapStateProvider.notifier)
+          .selectDirection(SwapDirection.externalToZec);
+      await tester.pumpAndSettle();
+      final previous = container.read(swapStateProvider).destinationText;
+      await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+      await tester.pumpAndSettle();
+      const raw = 'solana:Payee?amount=25&reference=Order';
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_destination_field')),
+        raw,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text(paymentRequestRefundAddressMessage), findsOneWidget);
+      expect(
+        tester
+            .widget<AppButton>(
+              find.byKey(const ValueKey('swap_address_update_button')),
+            )
+            .onPressed,
+        isNull,
+      );
+      await tester.tap(find.byKey(const ValueKey('swap_address_scan_button')));
+      await tester.pumpAndSettle();
+      final scanner = tester.widget<AddressQrScanModalContent>(
+        find.byType(AddressQrScanModalContent),
+      );
+      (scanner.cameraView! as PlainQrScannerView).onComplete(raw);
+      await tester.pumpAndSettle();
+      expect(find.byType(AddressQrScanModal), findsOneWidget);
+      expect(find.text(paymentRequestRefundAddressMessage), findsOneWidget);
+      expect(container.read(paymentUriPrefillProvider), isNull);
+      expect(container.read(swapStateProvider).destinationText, previous);
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('typed contact address shows the match line and names the chip', (
     tester,
@@ -9609,6 +9799,7 @@ Widget _routerHarness(
   List<rust_sync.TransactionInfo> recentTransactions = const [],
   PayDepositTransactionLoader? payDepositTransactionLoader,
   NetworkPrivacyState networkPrivacyState = const NetworkPrivacyState.off(),
+  CrossChainPaymentParser? paymentParser,
 }) {
   final fixtureIntents = seedSwapActivityFixtures
       ? _accountScopedSwapActivityFixtureIntents()
@@ -9617,6 +9808,8 @@ Widget _routerHarness(
       sessionStore ?? _FakeSwapPersistenceStore(initialIntents: fixtureIntents);
   return ProviderScope(
     overrides: [
+      if (paymentParser != null)
+        crossChainPaymentParserProvider.overrideWithValue(paymentParser),
       appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap),
       networkPrivacyProvider.overrideWith(
         () => _FakeNetworkPrivacyNotifier(networkPrivacyState),
@@ -10484,3 +10677,12 @@ String _fieldText(WidgetTester tester, String keyValue) {
   );
   return editable.controller.text;
 }
+
+CrossChainPaymentRequest _crossChainInputFixture(String raw) =>
+    CrossChainPaymentRequest(
+      id: 'input-fixture',
+      rawUri: raw,
+      address: 'bc1qinvoice',
+      isEvm: false,
+      chain: 'btc',
+    );

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -76,6 +76,55 @@ import 'support/swap_activity_fixture_intents.dart';
 part 'support/swap_screen_test_fakes.dart';
 
 void main() {
+  testWidgets('Pay request paste cancels the previous recipient quote', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final provider = _DelayedQuoteSwapProvider();
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(initialLocation: '/pay', routes: [_payRoute()]),
+        swapProvider: provider,
+        seedSwapActivityFixtures: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('pay_amount_input')),
+      '25',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pay_amount_continue_button')));
+    await tester.pumpAndSettle();
+    final field = find.byKey(const ValueKey('pay_recipient_search_field'));
+    const destination = '0x52908400098527886e0f7030069857d2e4169ee7';
+    await tester.enterText(field, destination);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pay_select_recipient_button')));
+    await tester.pump();
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(PayScreen)),
+    );
+    expect(container.read(swapStateProvider).quoteLoading, isTrue);
+    const raw = 'bitcoin:bc1qinvoice?amount=0.1';
+    await tester.enterText(field, raw);
+    await tester.pump();
+    provider.completeQuote();
+    await tester.pumpAndSettle();
+    expect(find.text(raw), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('review_pasted_payment_request')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('pay_review_step')), findsNothing);
+    final state = container.read(swapStateProvider);
+    expect(state.quoteLoading, isFalse);
+    expect(state.reviewVisible, isFalse);
+    expect(state.destinationText, destination);
+    expect(state.receiveAmountText, '25');
+    expect(tester.takeException(), isNull);
+  });
+
   for (final leaveStep in [false, true]) {
     testWidgets(
       'Pay discards a pending request after input or step changes (leaveStep: $leaveStep)',

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/navigation/payment_request_intake.dart';
 import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/layout/app_pane_scroll_scaffold.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
@@ -2931,6 +2932,8 @@ void main() {
             .text,
         nextDraft,
       );
+      expect(container.read(paymentUriPrefillProvider), isNull);
+      expect(container.read(paymentRequestArrivalProvider), 0);
       expect(tester.takeException(), isNull);
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pumpAndSettle();

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -2760,6 +2760,183 @@ void main() {
     },
   );
 
+  testWidgets('rejected pasted request stays editable and can be retried', (
+    tester,
+  ) async {
+    const rejected = 'bitcoin:malformed?amount=oops';
+    const corrected = 'bitcoin:bc1qinvoice?amount=0.1';
+    final parsed = <String>[];
+    final parseGate = Completer<void>();
+    Future<CrossChainPaymentRequest> parser(String raw) async {
+      parsed.add(raw);
+      if (raw == rejected) {
+        await parseGate.future;
+        throw const CrossChainPaymentParseException();
+      }
+      return CrossChainPaymentRequest(
+        id: 'retry-input',
+        rawUri: raw,
+        address: 'bc1qinvoice',
+        isEvm: false,
+        chain: 'btc',
+      );
+    }
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+        paymentParser: parser,
+      ),
+    );
+    await tester.pumpAndSettle();
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SwapScreen)),
+    );
+    container
+        .read(swapStateProvider.notifier)
+        .selectDirection(SwapDirection.zecToExternal);
+    await tester.pumpAndSettle();
+    final before = container.read(swapStateProvider);
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      rejected,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
+    await tester.pumpAndSettle();
+    parseGate.complete();
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('swap_destination_field')),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const ValueKey('swap_destination_field')),
+          )
+          .controller!
+          .text,
+      rejected,
+    );
+    expect(container.read(paymentUriPrefillProvider), isNull);
+    expect(
+      container.read(swapStateProvider).destinationText,
+      before.destinationText,
+    );
+    expect(container.read(swapStateProvider).amountText, before.amountText);
+    expect(
+      find.text(const CrossChainPaymentParseException().toString()),
+      findsOneWidget,
+    );
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      corrected,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
+    await tester.pumpAndSettle();
+    expect(parsed, [rejected, corrected]);
+    expect(find.byKey(const ValueKey('swap_destination_field')), findsNothing);
+    expect(
+      (container.read(paymentUriPrefillProvider) as CrossChainPaymentRequest)
+          .rawUri,
+      corrected,
+    );
+    expect(
+      container.read(swapStateProvider).destinationText,
+      before.destinationText,
+    );
+    expect(container.read(swapStateProvider).amountText, before.amountText);
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+    'late pasted request result leaves a reopened address editor alone',
+    (tester) async {
+      final parseGate = Completer<void>();
+      Future<CrossChainPaymentRequest> parser(String raw) async {
+        await parseGate.future;
+        return CrossChainPaymentRequest(
+          id: 'retry-input',
+          rawUri: raw,
+          address: 'bc1qinvoice',
+          isEvm: false,
+          chain: 'btc',
+        );
+      }
+
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(
+        _routerHarness(
+          GoRouter(
+            initialLocation: '/swap',
+            routes: [_swapRoute(), _swapActivityRoute()],
+          ),
+          seedSwapActivityFixtures: false,
+          paymentParser: parser,
+        ),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SwapScreen)),
+      );
+      container
+          .read(swapStateProvider.notifier)
+          .selectDirection(SwapDirection.zecToExternal);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_destination_field')),
+        'bitcoin:bc1qinvoice?amount=0.1',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('swap_address_update_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+      await tester.pumpAndSettle();
+      const nextDraft = 'bitcoin:another-request';
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_destination_field')),
+        nextDraft,
+      );
+      await tester.pumpAndSettle();
+      parseGate.complete();
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('swap_destination_field')),
+        findsOneWidget,
+      );
+      expect(
+        tester
+            .widget<TextField>(
+              find.byKey(const ValueKey('swap_destination_field')),
+            )
+            .controller!
+            .text,
+        nextDraft,
+      );
+      expect(tester.takeException(), isNull);
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+    },
+  );
+
   testWidgets('Swap payment QR reaches intake after scanner closes', (
     tester,
   ) async {

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -1172,6 +1172,17 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('pay_amount_continue_button')));
     await tester.pumpAndSettle();
 
+    // Abandon a possible URI prefix and select an existing contact.
+    await tester.enterText(
+      find.byKey(const ValueKey('pay_recipient_search_field')),
+      's',
+    );
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('pay_recipient_search_field')),
+      '',
+    );
+    await tester.pumpAndSettle();
     expect(find.text('First'), findsOneWidget);
     expect(find.text('Second'), findsOneWidget);
     await tester.tap(find.text('Second'));
@@ -2813,72 +2824,103 @@ void main() {
     expect(_destinationSummaryText(tester), '0x529084...169ee7');
   });
 
-  testWidgets(
-    'Pay pasted payment request waits for review and preserves composer',
-    (tester) async {
-      await _setDesktopViewport(tester);
-      final parsed = <String>[];
-      final router = GoRouter(initialLocation: '/pay', routes: [_payRoute()]);
-      await tester.pumpWidget(
-        _routerHarness(
-          router,
-          seedSwapActivityFixtures: false,
-          paymentParser: (raw) async {
-            parsed.add(raw);
-            return _crossChainInputFixture(raw);
-          },
-        ),
-      );
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        find.byKey(const ValueKey('pay_amount_input')),
-        '25',
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(
-        find.byKey(const ValueKey('pay_amount_continue_button')),
-      );
-      await tester.pumpAndSettle();
-      const destination = '0x52908400098527886e0f7030069857d2e4169ee7';
-      await tester.enterText(
-        find.byKey(const ValueKey('pay_recipient_search_field')),
-        destination,
-      );
-      await tester.pumpAndSettle();
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(PayScreen)),
-      );
-      final previous = container.read(swapStateProvider);
-      const raw = 'bitcoin:bc1qinvoice?amount=0.01&label=Coffee%20shop';
-      await tester.enterText(
-        find.byKey(const ValueKey('pay_recipient_search_field')),
-        raw,
-      );
-      await tester.pumpAndSettle();
-      expect(parsed, isEmpty);
-      expect(container.read(swapStateProvider).destinationText, destination);
-      expect(
-        find.byKey(const ValueKey('pay_select_recipient_button')),
-        findsNothing,
-      );
-      expect(find.text('Invalid EVM address'), findsNothing);
-      await tester.tap(
-        find.byKey(const ValueKey('review_pasted_payment_request')),
-      );
-      await tester.pumpAndSettle();
-      expect(parsed, [raw]);
-      expect(
-        (container.read(paymentUriPrefillProvider) as CrossChainPaymentRequest)
-            .rawUri,
-        raw,
-      );
-      final after = container.read(swapStateProvider);
-      expect(after.destinationText, previous.destinationText);
-      expect(after.externalAsset, previous.externalAsset);
-      expect(after.receiveAmountText, previous.receiveAmountText);
-      expect(tester.takeException(), isNull);
-    },
-  );
+  for (final typing in [false, true]) {
+    testWidgets(
+      'Pay pasted payment request waits for review and preserves composer (typing: $typing)',
+      (tester) async {
+        await _setDesktopViewport(tester);
+        final parsed = <String>[];
+        final router = GoRouter(initialLocation: '/pay', routes: [_payRoute()]);
+        await tester.pumpWidget(
+          _routerHarness(
+            router,
+            seedSwapActivityFixtures: false,
+            paymentParser: (raw) async {
+              parsed.add(raw);
+              return _crossChainInputFixture(raw);
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const ValueKey('pay_amount_input')),
+          '25',
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.byKey(const ValueKey('pay_amount_continue_button')),
+        );
+        await tester.pumpAndSettle();
+        const destination = '0x52908400098527886e0f7030069857d2e4169ee7';
+        await tester.enterText(
+          find.byKey(const ValueKey('pay_recipient_search_field')),
+          destination,
+        );
+        await tester.pumpAndSettle();
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(PayScreen)),
+        );
+        final previous = container.read(swapStateProvider);
+        const raw = 'bitcoin:bc1qinvoice?amount=0.01&label=Coffee%20shop';
+        if (typing) {
+          final field = find.byKey(
+            const ValueKey('pay_recipient_search_field'),
+          );
+          await tester.enterText(field, '');
+          await tester.pump();
+          for (var length = 1; length <= raw.length; length++) {
+            await tester.enterText(field, raw.substring(0, length));
+            await tester.pump();
+            expect(
+              container.read(swapStateProvider).destinationText,
+              previous.destinationText,
+            );
+          }
+        } else {
+          await tester.enterText(
+            find.byKey(const ValueKey('pay_recipient_search_field')),
+            raw,
+          );
+        }
+        await tester.pumpAndSettle();
+        expect(parsed, isEmpty);
+        expect(container.read(swapStateProvider).destinationText, destination);
+        expect(
+          find.byKey(const ValueKey('pay_select_recipient_button')),
+          findsNothing,
+        );
+        expect(find.text('Invalid EVM address'), findsNothing);
+        await tester.tap(
+          find.byKey(const ValueKey('review_pasted_payment_request')),
+        );
+        await tester.pumpAndSettle();
+        expect(parsed, [raw]);
+        expect(
+          (container.read(paymentUriPrefillProvider)
+                  as CrossChainPaymentRequest)
+              .rawUri,
+          raw,
+        );
+        final after = container.read(swapStateProvider);
+        expect(after.destinationText, previous.destinationText);
+        expect(after.externalAsset, previous.externalAsset);
+        expect(after.receiveAmountText, previous.receiveAmountText);
+        if (typing) {
+          final field = find.byKey(
+            const ValueKey('pay_recipient_search_field'),
+          );
+          await tester.enterText(field, 's');
+          await tester.pump();
+          const plain = '0x2222222222222222222222222222222222222222';
+          await tester.enterText(field, plain);
+          await tester.pumpAndSettle();
+          expect(container.read(swapStateProvider).destinationText, plain);
+          expect(find.text(plain), findsOneWidget);
+        }
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
 
   testWidgets('newer review survives an older completion in the same editor', (
     tester,


### PR DESCRIPTION
Payment URIs scanned or entered inside the app must retain their network, asset, recipient, and amount instead of being reduced to an address. This PR connects Send, Pay, and Swap input surfaces to the shared request intake and card flow, while keeping refund fields address-only.

This is **step 5 of 5** in draft integration PR #654, following merged #655, #658, #659, and #660. It targets `rowan/cross-chain-payments-integration`. The parser, native external-link handoff, request UI, and Pay lifecycle are already integrated; this PR completes the in-app input paths.

## Input behavior

- Adds a shared payment-request notice and explicit `Review payment request` action. Parsing errors remain request errors and cannot fall through to address extraction. Intake distinguishes ignored, accepted, and replacement results, so an obsolete parse cannot be mistaken for a successful submission.
- Pay recognizes a request before address validation, contact matching, or committing a new destination. Typed/pasted request text, including an empty field and incomplete payment-scheme prefixes, is held separately from the existing composer recipient. Ordinary addresses and explicit contact selections replace the recipient normally. Request input does not offer the ordinary select-recipient or add-to-contacts action. Editing the recipient, changing the wizard step, or leaving the source page cancels pending input review.
- Pay scanners preserve the complete request URI. The scanner closes before shared intake can present the request card. Plain address scans retain their existing behavior.
- The mobile Send scanner returns a dedicated `SendScanPaymentUri` for cross-chain requests, preserving all URI parameters. Send's explicit paste/review actions pass requests to shared intake; ordinary Zcash scan results retain their existing classification. Send button, keyboard, paste, and cross-chain scan submissions check the current recipient/surface before publication.
- Desktop Send recognizes typed requests and exposes `Review request`/Enter instead of treating them as recipient addresses. It cancels obsolete address/Max validation work when the input becomes a request.
- Swap accepts request URIs in the ZEC-to-external direction from its address editor and scanner while preserving the composer. Typed/pasted requests keep the editor and raw text until parsing succeeds, allowing correction and retry after rejection. An accepted request closes the editor before the deferred card presentation; QR scans still close the scanner before intake. Editing the raw text, cancelling, or reopening the editor invalidates its pending submission before shared-state writes or card-arrival notifications; late errors are also discarded. Request text is not saved as a remembered address.
- The external-to-ZEC refund field rejects payment URIs in both typed input and QR scans, explains that a plain refund address is required, and prevents submission. Address-book scanning keeps its existing address-only meaning.

## Request loading

Unresolved token icons, symbols, and supplied amounts use static skeleton placeholders while payment options load. Known chain names, recipient addresses, and already resolved token details remain visible. Placeholders become the resolved values when loading finishes; the existing Tor/loading status, disabled primary action, and failure/retry behavior remain in place.

## Review focus

1. Preserve the whole URI before normalization, including token/mint, chain, amount, and request parameters.
2. Keep request review explicit and avoid silently changing the Pay/Swap composer or saving a URI as an address.
3. Close scanner/editor surfaces before card presentation; retain ordinary address and existing Zcash scan behavior.
4. Reject payment requests consistently in refund fields and keep parse failures from falling back to an address.

## Review corrections

- [Rejected input](https://github.com/chainapsis/vizor-wallet/pull/661#discussion_r3986954183): malformed requests keep their raw text in the address editor for correction and retry.
- [Cancelled input](https://github.com/chainapsis/vizor-wallet/pull/661#discussion_r3987052164): shared intake checks the originating input before storing a request or notifying the card host, without globally invalidating unrelated request sources.
- [Ignored versus accepted results](https://github.com/chainapsis/vizor-wallet/pull/661#discussion_r3987122480): explicit intake results keep an older completion from closing the same editor and thereby cancelling the newer submission.
- [Input and page lifetime](https://github.com/chainapsis/vizor-wallet/pull/661#discussion_r3987122487): Pay and Send reject obsolete parser results after recipient edits, step changes, or navigation. Swap raw edits invalidate submissions too. The shared helper observes the active router state, including pushed pages whose source widget remains mounted, and removes its navigation listener when parsing completes.

- [Previous recipient quote](https://github.com/chainapsis/vizor-wallet/pull/661#discussion_r3987305755): entering or reviewing a request in desktop Pay cancels the outstanding quote and its wizard continuation while preserving composer values.
- [Rejected clipboard input](https://github.com/chainapsis/vizor-wallet/pull/661#discussion_r3987305763): Mobile Send writes pasted requests into the editable field before parsing, so rejection retains the original text for correction and retry.

- [Character-by-character URI input](https://github.com/chainapsis/vizor-wallet/pull/661#discussion_r3987400803): desktop and mobile Pay stage incomplete payment schemes locally so typing `bitcoin:` or `solana:` cannot overwrite the prior recipient before the colon. Validation uses the visible draft; choosing a contact clears it.

## Validation

Latest change at `9af013030e6` — **11 focused cases passed**:

- Desktop Pay: **6 passed**, covering atomic paste, character-by-character input, falling back to a plain address, recipient/step lifetime, cancellation of an older quote, and choosing a contact after clearing a partial scheme.
- Mobile Pay: **5 passed**, covering the same typed/pasted preservation, plain-address fallback, recipient/step lifetime, and contact-selection boundary.
- Scoped analysis of all **5 changed Dart files** and `git diff --check` passed. UI assertions check the input, preserved composer, and contact/review behavior. No additional image captures or broad suites were run.

Previous update at `2aaa19a3644` — **13 focused cases passed** (not rerun for this update):

- Desktop Pay quote cancellation and existing request input, plus card skeleton-to-content, loading, and retry states: **5 passed**.
- Mobile Send rejected clipboard correction/retry and four existing input-lifetime cases, plus the same three card states: **8 passed**.
- Changed Dart files passed scoped analysis; `git diff --check` passed.
- Visually inspected four widget captures: desktop and mobile cards before and after token resolution. No new native app/device checks or broad suite runs.
- The prior complete candidate comparison below is from `61154d5aaa2`; this commit adds the two review fixes and requested loading UI. The final combined-tree check remains an integration completion step.

Previous focused validation at `61154d5aaa2` — **35 cases passed** (not rerun for this update):

- Shared intake: `fvm flutter test --no-pub test/core/navigation/payment_request_intake_test.dart` — **8 passed**.
- Desktop Pay/Swap inputs and the changed native-link caller: `fvm flutter test --no-pub test/features/swap/swap_screen_test.dart test/app_incoming_link_host_test.dart --name 'newer review survives|Pay discards a pending request|Pay pasted payment request|rejected pasted request|late pasted request|Swap payment QR reaches intake|Swap refund input refuses|external request uses|replacing Zcash|one host routes'` — **12 passed** (9 input cases and 3 link-host cases).
- Desktop Send: `fvm flutter test --no-pub test/features/send/send_screen_test.dart --plain-name 'Send request intake respects input lifetime'` — **3 passed**.
- Mobile: `fvm flutter test --no-pub --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/pay/mobile_pay_screen_test.dart test/features/swap/mobile_swap_modal_route_test.dart test/features/send/mobile_send_screen_test.dart --name 'newer review survives|Pay discards a pending request|mobile Pay pasted request|rejected pasted request|late pasted request|QR scan returns to address editor|Send request intake respects input lifetime'` — **12 passed**.
- These cases cover successful acceptance, two reviews from the same editor, raw edits, cancel/reopen, Pay Back, pushed-page navigation, clipboard input, ordinary address scanning, refund rejection, and existing Zcash/external-link handoff. UI assertions verify the retained/new input and resulting navigation alongside pending-state and arrival checks.
- `fvm flutter analyze --no-pub` scoped to the **17 files changed by this correction** — no issues.
- `git diff --check` passed. The complete candidate tree matches the preserved implementation plus all recorded main, review, and test adjustments: `023c37b47a0fa6110cdf679eb05878d76590be11`.

Earlier evidence: 15 focused cases and two actual-host cancellation captures at `815f4e2f96a`; 283 desktop and 161 mobile cases, analysis of the then-18 PR files, and four rejection/retry captures at `458f886d2b1`; three original Pay/refund input captures at `f0e621e1a2`. The broader suites and older input-flow captures were not rerun for this update.

Validation uses widget tests, controlled request-parser/quote responses, and simulated scanner callbacks. No physical camera scan, native device/app build, live 1Click quote, signing, or broadcast was performed for this PR. The integration PR remains a draft pending this review and final integration checks.
