### PR TITLE
Add native payment request end-to-end coverage

### DIFF
--- a/integration_test/CROSS_CHAIN_PAYMENT_NATIVE.md
+++ b/integration_test/CROSS_CHAIN_PAYMENT_NATIVE.md
@@ -1,0 +1,39 @@
+# Native payment-request E2E
+
+Run on macOS with Xcode, CocoaPods and the repository's FVM SDK installed:
+
+```sh
+python3 scripts/e2e/flutter-macos-cross-chain-payment-request.py
+```
+
+The runner builds a separate, ad-hoc-signed app with a unique bundle ID. It
+opens the app through macOS Launch Services with a Bitcoin URI, then delivers
+an Ethereum token URI to the running app. It targets the test app explicitly;
+it does not change the user's default URL handler. The app window is hidden.
+
+The native `AppDelegate`, pending-URI buffer, MethodChannel handshake, Dart
+intake, Rust URI parser, production router, password verification, request card,
+SwapNotifier and Pay review screens all run. The test verifies:
+
+1. A cold-launch URL stays behind the lock screen and reaches the card after
+   entering the password.
+2. Tor and token loading keep the action disabled and show placeholders, then
+   resolve the Bitcoin amount and identity. Cancel does not request a quote.
+3. A warm Ethereum URL survives a Tor failure and retry, resolves Base USDC,
+   and reaches review with the exact recipient and amount. Back preserves the
+   Pay composer. Starting or broadcasting a payment fails the test fixture.
+
+Wallet/account data, storage, balances, token/quote responses and Tor connection
+outcomes are controlled fixtures. Password verification still uses the real
+security provider and Rust implementation. This suite does not validate a
+persisted wallet database, Keychain storage, a live Tor bootstrap, the remote
+quote API, signing or broadcasting. Other operating systems need their own
+native URL-delivery runs.
+
+The app reports milestones and test results to a loopback-only driver.
+`build/payment-request-native-e2e/<run-id>/` contains the build log, temporary
+entitlements and `result.json`. A missing result, timeout, failed assertion,
+missing packaged URL registration or non-isolated bundle ID fails the runner.
+The runner restores its temporary flavor override and unregisters only its own
+app from Launch Services. The `_app.dart` entrypoint is deliberately separate
+from ordinary `*_test.dart` discovery.

--- a/integration_test/cross_chain_payment_request_native_app.dart
+++ b/integration_test/cross_chain_payment_request_native_app.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/pay/widgets/cross_chain_payment_request_card.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_state_provider.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_zec_staging_address_service.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
+import 'package:zcash_wallet/src/providers/payment_uri_prefill_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import 'support/cross_chain_payment_native_fixture.dart';
+
+const _driverUrl = String.fromEnvironment('VIZOR_PAYMENT_E2E_DRIVER_URL');
+const _bundleId = String.fromEnvironment('VIZOR_PAYMENT_E2E_BUNDLE_ID');
+const _continue = ValueKey('cross_chain_payment_request_continue');
+const _cancel = ValueKey('cross_chain_payment_request_cancel');
+
+/// Built and cold-launched by the dedicated runner, not a Flutter test driver.
+/// Both initial and later URLs come through Launch Services / AppDelegate.
+void main() {
+  if (!Platform.isMacOS ||
+      !_bundleId.startsWith('com.keplr.vizor.payment-e2e.') ||
+      !Uri.parse(_driverUrl).host.startsWith('127.0.0.1')) {
+    throw StateError(
+      'Run scripts/e2e/flutter-macos-cross-chain-payment-request.py',
+    );
+  }
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  unawaited(
+    binding.allTestsPassed.future.then((passed) async {
+      await _driver('result', {
+        'passed': passed,
+        'results': binding.results.map((key, value) => MapEntry(key, '$value')),
+      });
+      exit(passed ? 0 : 1);
+    }),
+  );
+
+  testWidgets(
+    'native cold and warm payment URLs reach review safely',
+    (tester) async {
+      await _driver('ready', {'pid': pid});
+      FlutterSecureStorage.setMockInitialValues({});
+      await initializeZcashWalletRuntime();
+      // Wallet storage is an in-memory fixture; password verification still
+      // uses AppSecurityNotifier and Rust. Never access a user's Keychain.
+      final store = AppSecureStore.testing(
+        storage: const FlutterSecureStorage(),
+      );
+      await store.configurePassword(nativePaymentPassword);
+      store.clearSessionPassword();
+      final pricing = NativePaymentPricing();
+      final privacy = NativePaymentPrivacy();
+      await tester.pumpWidget(
+        buildZcashWalletApp(
+          bootstrap: nativePaymentBootstrap(),
+          overrides: [
+            accountProvider.overrideWith(NativePaymentAccount.new),
+            syncProvider.overrideWith(NativePaymentSync.new),
+            appSecurityProvider.overrideWith(
+              () => AppSecurityNotifier.testing(store: store),
+            ),
+            networkPrivacyProvider.overrideWith(() => privacy),
+            swapIntentProvider.overrideWithValue(pricing),
+            swapZecStagingAddressServiceProvider.overrideWithValue(
+              SwapZecStagingAddressService(
+                reserveFreshOrchardAddress: ({required accountUuid}) async =>
+                    'u1e2e-refund-address',
+              ),
+            ),
+          ],
+        ),
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ZcashWalletApp)),
+      );
+      await _until(
+        tester,
+        () => container.read(paymentUriPrefillProvider) != null,
+        'cold-launch URL parked by the native bridge and real Rust parser',
+      );
+      expect(
+        find.byKey(const ValueKey('unlock_password_field')),
+        findsOneWidget,
+      );
+      expect(find.byType(CrossChainPaymentRequestCard), findsNothing);
+      await _driver('milestone', {'name': 'cold URL retained behind lock'});
+
+      await tester.enterText(
+        find.byKey(const ValueKey('unlock_password_field')),
+        nativePaymentPassword,
+      );
+      await _tap(tester, const ValueKey('unlock_submit_button'));
+      await _until(
+        tester,
+        () => tester.any(find.text('Connecting to Tor…')),
+        'Tor loading card after unlock',
+      );
+      expect(
+        find.byKey(const ValueKey('payment_request_icon_skeleton')),
+        findsOneWidget,
+      );
+      expect(_button(tester, _continue).onPressed, isNull);
+      privacy.setStatus(NetworkPrivacyConnectionStatus.connected);
+      await _until(
+        tester,
+        () => tester.any(find.text('Checking payment options…')),
+        'token loading after Tor connects',
+      );
+      expect(
+        find.byKey(const ValueKey('payment_request_amount_skeleton')),
+        findsOneWidget,
+      );
+      pricing.releaseTokens();
+      await _until(
+        tester,
+        () => _button(tester, _continue).onPressed != null,
+        'resolved Bitcoin card',
+      );
+      expect(find.text('0.00123456'), findsOneWidget);
+      expect(find.text('BTC'), findsOneWidget);
+      expect(find.text('Bitcoin'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('payment_request_icon_skeleton')),
+        findsNothing,
+      );
+      await _tap(tester, _cancel);
+      await _until(
+        tester,
+        () => !tester.any(find.byType(CrossChainPaymentRequestCard)),
+        'cancelled card',
+      );
+      expect(pricing.quotes, isEmpty);
+      await _driver('milestone', {
+        'name': 'unlock and Tor/token loading resolved; cancel did not quote',
+      });
+
+      privacy.setStatus(NetworkPrivacyConnectionStatus.connecting);
+      await _driver('open', {'uri': nativeEthereumUri});
+      await _until(
+        tester,
+        () => tester.any(find.text('Connecting to Tor…')),
+        'warm Ethereum URL',
+      );
+      privacy.setStatus(NetworkPrivacyConnectionStatus.failed);
+      await _until(
+        tester,
+        () => tester.any(find.text('Try again')),
+        'Tor failure retry action',
+      );
+      await _tap(tester, _continue);
+      expect(privacy.retries, 1);
+      await _until(
+        tester,
+        () => tester.any(find.text('Connecting to Tor…')),
+        'retry loading',
+      );
+      privacy.setStatus(NetworkPrivacyConnectionStatus.connected);
+      await _until(
+        tester,
+        () =>
+            tester.any(find.text('Review payment')) &&
+            _button(tester, _continue).onPressed != null,
+        'resolved Base USDC request',
+      );
+      expect(find.text('25'), findsOneWidget);
+      expect(find.text('USDC'), findsOneWidget);
+      expect(find.text('Base'), findsOneWidget);
+      await _tap(tester, _continue);
+      await _until(
+        tester,
+        () => tester.any(find.byKey(const ValueKey('pay_review_step'))),
+        'real Pay review',
+      );
+      expect(pricing.quotes, hasLength(1));
+      final quote = pricing.quotes.single;
+      expect(quote.destination, nativePaymentRecipient);
+      expect(quote.externalAsset, nativeUsdcAsset);
+      expect(quote.amount, 25);
+      expect(find.byType(CrossChainPaymentRequestCard), findsNothing);
+      await _tap(
+        tester,
+        const ValueKey('pay_wizard_back_link'),
+        appButton: false,
+      );
+      await _until(
+        tester,
+        () => tester.any(find.byKey(const ValueKey('pay_recipient_step'))),
+        'Back to preserved Pay recipient',
+      );
+      expect(
+        container.read(swapStateProvider).destinationText,
+        nativePaymentRecipient,
+      );
+      expect(container.read(swapStateProvider).receiveAmountText, '25');
+      expect(pricing.quotes, hasLength(1));
+      await _driver('milestone', {
+        'name':
+            'warm URL, Tor retry, exact asset/amount/address review and Back passed',
+      });
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    },
+    timeout: const Timeout(Duration(minutes: 4)),
+  );
+}
+
+AppButton _button(WidgetTester tester, Key key) =>
+    tester.widget<AppButton>(find.byKey(key));
+
+Future<void> _tap(WidgetTester tester, Key key, {bool appButton = true}) async {
+  await _until(
+    tester,
+    () =>
+        tester.any(find.byKey(key)) &&
+        (!appButton || _button(tester, key).onPressed != null),
+    'enabled $key',
+  );
+  await tester.ensureVisible(find.byKey(key));
+  await tester.tap(find.byKey(key));
+  await tester.pump();
+}
+
+Future<void> _until(
+  WidgetTester tester,
+  bool Function() ready,
+  String description,
+) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 40));
+  while (!ready()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Timed out waiting for $description');
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+}
+
+Future<void> _driver(String action, Map<String, Object?> data) async {
+  final client = HttpClient();
+  try {
+    final request = await client.postUrl(Uri.parse('$_driverUrl/$action'));
+    request.headers.contentType = ContentType.json;
+    final body = utf8.encode(jsonEncode(data));
+    request.contentLength = body.length;
+    request.add(body);
+    final response = await request.close();
+    await response.drain<void>();
+    if (response.statusCode != 200) {
+      throw StateError('Native driver $action failed: ${response.statusCode}');
+    }
+  } finally {
+    client.close(force: true);
+  }
+}

--- a/integration_test/support/cross_chain_payment_native_fixture.dart
+++ b/integration_test/support/cross_chain_payment_native_fixture.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/network_privacy_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+const nativePaymentAccountId = '550e8400-e29b-41d4-a716-446655440000';
+const nativePaymentPassword = 'PaymentE2E123!';
+const nativePaymentRecipient = '0x52908400098527886E0F7030069857D2E4169EE7';
+const nativePaymentContract = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const nativeBitcoinUri =
+    'bitcoin:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh?amount=0.00123456';
+const nativeEthereumUri =
+    'ethereum:$nativePaymentContract@8453/transfer'
+    '?address=$nativePaymentRecipient&uint256=25000000';
+
+final nativeBitcoinAsset = SwapAsset.live(
+  assetId: 'e2e-bitcoin',
+  symbol: 'BTC',
+  blockchain: 'btc',
+  decimals: 8,
+);
+final nativeUsdcAsset = SwapAsset.live(
+  assetId: 'e2e-base-usdc',
+  symbol: 'USDC',
+  blockchain: 'base',
+  decimals: 6,
+  contractAddress: nativePaymentContract,
+);
+
+const _account = AccountState(
+  accounts: [AccountInfo(uuid: nativePaymentAccountId, name: 'E2E', order: 0)],
+  activeAccountUuid: nativePaymentAccountId,
+  activeAddress: 'u1e2e-refund-address',
+);
+
+/// A funded account snapshot without keys or a live wallet. The actual app
+/// router, unlock/password verification, request intake and Pay screens run.
+AppBootstrapState nativePaymentBootstrap() => AppBootstrapState(
+  initialLocation: '/unlock',
+  initialAccountState: _account,
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.dark,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: false,
+  passwordRotationRecoveryFailed: false,
+);
+
+class NativePaymentAccount extends AccountNotifier {
+  @override
+  Future<AccountState> build() async => _account;
+
+  @override
+  Future<void> restoreAfterUnlock() async {}
+}
+
+class NativePaymentSync extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState(
+    accountUuid: nativePaymentAccountId,
+    hasAccountScopedData: true,
+    spendableBalance: BigInt.from(10000000000),
+    totalBalance: BigInt.from(10000000000),
+    orchardBalance: BigInt.from(10000000000),
+  );
+
+  @override
+  void startSync({int? latestTipHeight}) {}
+
+  @override
+  Future<void> startSyncAnyway() async {}
+
+  @override
+  Future<void> refreshAfterUnlock() async {}
+
+  @override
+  Future<void> refreshAfterSend() async {}
+}
+
+/// Controls connection outcomes, not the Tor transport. Live Tor bootstrap is
+/// deliberately outside this deterministic native UI test.
+class NativePaymentPrivacy extends NetworkPrivacyNotifier {
+  var retries = 0;
+
+  @override
+  NetworkPrivacyState build() => const NetworkPrivacyState(
+    torEnabled: true,
+    status: NetworkPrivacyConnectionStatus.connecting,
+  );
+
+  void setStatus(NetworkPrivacyConnectionStatus status) {
+    state = NetworkPrivacyState(torEnabled: true, status: status);
+  }
+
+  @override
+  Future<void> retry() async {
+    retries++;
+    setStatus(NetworkPrivacyConnectionStatus.connecting);
+  }
+}
+
+/// Deterministic external-service responses. SwapNotifier still performs real
+/// asset resolution, amount conversion, quote preparation and navigation.
+class NativePaymentPricing implements SwapProvider, SwapPricingProvider {
+  final tokens = Completer<SwapPricingSnapshot>();
+  final quotes = <SwapQuoteRequest>[];
+
+  void releaseTokens() => tokens.complete(
+    SwapPricingSnapshot(
+      usdPrices: {
+        SwapAsset.zec: 100,
+        nativeBitcoinAsset: 60000,
+        nativeUsdcAsset: 1,
+      },
+    ),
+  );
+
+  @override
+  String get providerLabel => 'Native payment E2E fixture';
+
+  @override
+  Future<SwapPricingSnapshot> loadPricingSnapshot({
+    bool forceRefresh = false,
+  }) => tokens.future;
+
+  @override
+  Future<List<SwapAsset>> listSupportedExternalAssets() =>
+      throw StateError('Expected the token snapshot');
+
+  @override
+  Future<SwapQuote> quote(SwapQuoteRequest request) async {
+    quotes.add(request);
+    return SwapQuote.estimate(
+      direction: request.direction,
+      externalAsset: request.externalAsset,
+      mode: request.mode,
+      amount: request.amount,
+      externalPerZec: request.externalAsset == nativeUsdcAsset ? 100 : 1 / 600,
+      providerLabel: providerLabel,
+    );
+  }
+
+  @override
+  Future<SwapIntentSnapshot> getStatus(
+    String intentId, {
+    String? depositMemo,
+  }) => throw StateError('This test must stop before creating a payment');
+
+  @override
+  Future<SwapIntentSnapshot> startSwap(SwapQuote quote) =>
+      throw StateError('This test must never start a payment');
+
+  @override
+  Future<SwapIntentSnapshot> submitDepositTransaction({
+    required String depositAddress,
+    required String txHash,
+    String? depositMemo,
+    String? nearSenderAccount,
+  }) => throw StateError('This test must never broadcast a payment');
+}

--- a/scripts/e2e/flutter-macos-cross-chain-payment-request.py
+++ b/scripts/e2e/flutter-macos-cross-chain-payment-request.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Build an isolated app and deliver cold/warm payment URLs through macOS.
+
+Run from any directory: python3 scripts/e2e/flutter-macos-cross-chain-payment-request.py
+No regtest node, funded wallet, default URL-handler changes, or payment is needed.
+"""
+
+import http.server
+import json
+import os
+from pathlib import Path
+import plistlib
+import secrets
+import signal
+import subprocess
+import threading
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COLD_URI = (
+    "bitcoin:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh?amount=0.00123456"
+)
+WARM_URI = (
+    "ethereum:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913@8453/transfer"
+    "?address=0x52908400098527886E0F7030069857D2E4169EE7&uint256=25000000"
+)
+
+
+def main():
+    run_id = secrets.token_hex(6)
+    bundle_id = f"com.keplr.vizor.payment-e2e.r{run_id}"
+    product = f"Vizor Payment E2E {run_id}"
+    artifacts = ROOT / "build" / "payment-request-native-e2e" / run_id
+    artifacts.mkdir(parents=True)
+    app = ROOT / "build/macos/Build/Products/Debug" / f"{product}.app"
+    results = {"bundle_id": bundle_id, "cold_uri": COLD_URI, "milestones": []}
+    done = threading.Event()
+    app_pid = None
+
+    def open_uri(uri, *, cold=False):
+        # Explicit app targeting leaves the user's default handler untouched.
+        args = ["/usr/bin/open", "-g"]
+        if cold:
+            app_log = artifacts / "app.log"
+            app_log.touch()
+            args.extend(["-n", "--stdout", str(app_log), "--stderr", str(app_log)])
+        subprocess.run([*args, "-a", str(app), uri], check=True, timeout=15)
+
+    class Driver(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            nonlocal app_pid
+            if not self.path.startswith(f"/{run_id}/"):
+                self.send_error(404)
+                return
+            action = self.path.rsplit("/", 1)[1]
+            try:
+                data = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+                if action == "ready":
+                    app_pid = int(data["pid"])
+                    results["pid"] = app_pid
+                    print(f"Native test started (PID {app_pid})", flush=True)
+                elif action == "open" and data.get("uri") == WARM_URI:
+                    open_uri(WARM_URI)
+                elif action == "milestone":
+                    results["milestones"].append(data["name"])
+                    print(data["name"], flush=True)
+                elif action == "result":
+                    results.update(data)
+                    (artifacts / "result.json").write_text(json.dumps(results, indent=2) + "\n")
+                    done.set()
+                else:
+                    raise ValueError("Unexpected driver request")
+                self.send_response(200)
+                self.end_headers()
+            except Exception as error:
+                results["driver_error"] = str(error)
+                print(f"Driver failure: {error}", flush=True)
+                self.send_error(500, str(error))
+                done.set()
+
+        def log_message(self, *_args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Driver)
+    server.daemon_threads = True
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    driver_url = f"http://127.0.0.1:{server.server_port}/{run_id}"
+    flavor = ROOT / "macos/Runner/Configs/FlavorOverrides.xcconfig"
+    previous_flavor = flavor.read_bytes() if flavor.exists() else None
+    entitlements = plistlib.loads((ROOT / "macos/Runner/DebugProfile.entitlements").read_bytes())
+    # This isolated test app can report to the loopback driver and is never
+    # shipped. Ad-hoc signing avoids machine-specific provisioning profiles.
+    entitlements["com.apple.security.app-sandbox"] = False
+    entitlements.pop("com.apple.application-identifier", None)
+    entitlements.pop("com.apple.developer.team-identifier", None)
+    entitlements.pop("com.apple.security.temporary-exception.mach-lookup.global-name", None)
+    entitlement_path = artifacts / "PaymentE2E.entitlements"
+    entitlement_path.write_bytes(plistlib.dumps(entitlements))
+    own_flavor = (
+        f"PRODUCT_NAME = {product}\n"
+        f"PRODUCT_BUNDLE_IDENTIFIER = {bundle_id}\n"
+    ).encode()
+
+    try:
+        flavor.write_bytes(own_flavor)
+        print(f"Building {bundle_id}; artifacts: {artifacts}", flush=True)
+        with (artifacts / "build.log").open("w") as log:
+            subprocess.run(
+                [
+                    "fvm", "flutter", "build", "macos", "--debug",
+                    "--target=integration_test/cross_chain_payment_request_native_app.dart",
+                    "--dart-define=VIZOR_E2E_HIDDEN_WINDOW=true",
+                    "--dart-define=INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE=false",
+                    f"--dart-define=VIZOR_PAYMENT_E2E_DRIVER_URL={driver_url}",
+                    f"--dart-define=VIZOR_PAYMENT_E2E_BUNDLE_ID={bundle_id}",
+                ], cwd=ROOT, stdout=log, stderr=subprocess.STDOUT,
+                env={**os.environ, "FLUTTER_XCODE_CODE_SIGNING_ALLOWED": "NO"},
+                check=True, timeout=1200,
+            )
+        subprocess.run([
+            "/usr/bin/codesign", "--force", "--deep", "--sign", "-",
+            "--entitlements", str(entitlement_path), str(app),
+        ], check=True, timeout=60)
+        info = plistlib.loads((app / "Contents/Info.plist").read_bytes())
+        if info["CFBundleIdentifier"] != bundle_id:
+            raise RuntimeError("Refusing to launch a non-isolated app")
+        schemes = {
+            scheme for entry in info.get("CFBundleURLTypes", [])
+            for scheme in entry.get("CFBundleURLSchemes", [])
+        }
+        if not {"bitcoin", "ethereum"} <= schemes:
+            raise RuntimeError("Packaged app is missing payment URL registrations")
+        print("Cold-launching the isolated app with a Bitcoin URL", flush=True)
+        open_uri(COLD_URI, cold=True)
+        if not done.wait(300):
+            raise TimeoutError("Native test did not report completion within five minutes")
+        if not results.get("passed"):
+            raise RuntimeError(f"Native E2E failed; see {artifacts / 'result.json'}")
+        print(f"PASS: {artifacts / 'result.json'}", flush=True)
+    finally:
+        # The test normally exits itself. Terminate only this runner's exact
+        # executable if a failed/timed-out test leaves its process alive.
+        for line in subprocess.check_output(["ps", "-axo", "pid=,command="], text=True).splitlines():
+            process_id, command = line.strip().split(None, 1)
+            if command.startswith(str(app / "Contents/MacOS") + "/"):
+                try:
+                    os.kill(int(process_id), signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+        server.shutdown()
+        server.server_close()
+        if flavor.exists() and flavor.read_bytes() == own_flavor:
+            if previous_flavor is None:
+                flavor.unlink()
+            else:
+                flavor.write_bytes(previous_flavor)
+        if app.exists():
+            subprocess.run([
+                "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
+                "-u", str(app),
+            ], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        if not (artifacts / "result.json").exists():
+            (artifacts / "result.json").write_text(json.dumps(results, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Payment input/widget tests do not exercise an operating-system URL launching the application. This PR adds a dedicated macOS native E2E runner that cold-launches an isolated app with a Bitcoin URI and delivers a Base USDC Ethereum URI to the running app.

It follows merged #661 and targets the draft integration branch in #654. No production code changes are included.

## Coverage

- Real Launch Services delivery, AppDelegate buffering, native/Dart handshake, Rust URI parsing, production router and password verification.
- Cold request retained behind the lock screen, then presented after entering the password.
- Tor/token waiting states, skeleton-to-content transition, disabled continuation and cancellation without a quote.
- Warm Ethereum request, controlled Tor failure/retry, exact Base USDC asset/25-token amount/recipient through Pay review, and Back preserving the composer.

The runner uses a unique app identity and ad-hoc signing, restores the flavor override, unregisters only its test app and checks process ownership before cleanup. It captures native app/build logs and machine-readable results. The dedicated `_app.dart` entrypoint is excluded from ordinary test discovery.

## Validation

- `python3 scripts/e2e/flutter-macos-cross-chain-payment-request.py` — **passed on macOS**, one native test spanning all three recorded milestones. The packaged app declares both URL schemes; cold and warm delivery use `open -a <isolated app>`, not injected MethodChannel messages.
- Scoped `fvm flutter analyze --no-pub` on the two added Dart files — no issues.
- Python syntax and `git diff --check` passed. Temporary flavor restoration and termination of the owned test process were verified.
- Result: `build/payment-request-native-e2e/604da5fe2aa4/result.json` (`passed: true`); adjacent `app.log` and `build.log` preserve evidence.

Wallet/account/storage/balance data, token/quote responses and Tor outcomes are fixtures. Password verification uses the real security provider and Rust. This does not validate persisted wallet bootstrap/Keychain, live Tor or remote quote services, signing/broadcast, default-handler selection, or other operating systems. The test stops at review/Back and cannot execute a payment. See `integration_test/CROSS_CHAIN_PAYMENT_NATIVE.md` for the run command and boundary details.
