### PR TITLE
Update zcash_voting and support 50 proposals

### DIFF
--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -8,7 +8,7 @@ import '../../providers/voting/voting_state.dart';
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 
 const int _minProposalId = 1;
-const int _maxProposalId = 15;
+const int _maxProposalId = 50;
 const List<String> _forumUrlKeys = [
   'discussion_url',
   'discussionUrl',

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1392,7 +1392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.5.0",
+ "heck 0.4.1",
 ]
 
 [[package]]
@@ -1401,9 +1401,9 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1548,7 +1548,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2754,9 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "imt-tree"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2c80d291f1fbd82527aa29a194f09b76a2df8f2e92d90a2709355d682a9e26"
+checksum = "f92c99eb90cebfcd9697072e01c55eb7313297405dd59890556ba808ecea03c8"
 dependencies = [
  "anyhow",
  "hex",
@@ -2979,7 +2979,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3335,7 +3335,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3775,9 +3775,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1965648d9ea094809794710b0a654c9376d034b38405fba610905d91150bbd"
+checksum = "e828f60bc83396d8e5791d41a423fa3406d26344e6dc31a48afbca52829308d6"
 dependencies = [
  "anyhow",
  "futures",
@@ -3793,9 +3793,9 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334dfc8e3e5b5f06b82bf6f1373b36a35a53d7f3cd44e7c71fab579fef99727a"
+checksum = "555365eac794205a9d4b28f5515f5e3e93c6e1e1f61cac4976a8a48ffba3227f"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -4064,8 +4064,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4110,7 +4110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4608,7 +4608,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5332,7 +5332,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7070,8 +7070,8 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.6.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?tag=v3.1.0-rc.16#46ef27bd637ad8ef3f8f25f87cab5a4b42be0b34"
+version = "0.6.1"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=806fb8fa5d24b75a797a0560e4f1455f836fba8d#806fb8fa5d24b75a797a0560e4f1455f836fba8d"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -7084,8 +7084,8 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.8.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?tag=v3.1.0-rc.16#46ef27bd637ad8ef3f8f25f87cab5a4b42be0b34"
+version = "0.8.1"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=806fb8fa5d24b75a797a0560e4f1455f836fba8d#806fb8fa5d24b75a797a0560e4f1455f836fba8d"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -7098,9 +7098,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.11.2"
+version = "0.12.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc41d4731d5ec65e6b78b38e7db7c8c3c823dd241447be8d4128ba2b91784a78"
+checksum = "c90a84e2c6f13abd29427b131290faf9f2bb66dacc0441952866f8aef91943fe"
 dependencies = [
  "blake2b_simd",
  "incrementalmerkletree",
@@ -7111,9 +7111,9 @@ dependencies = [
 
 [[package]]
 name = "voting-crypto-deps"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d510090b7c0948010682561d4bea6c1aa4c28f6f6bdb38f24fd12098156287"
+checksum = "7093c43ce71cde30f4d9c1154fa6f0b69c6866a4efb9cb582055a81dcf438a6e"
 dependencies = [
  "rand 0.10.2",
  "zakura-halo2-gadgets",
@@ -7291,7 +7291,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7695,9 +7695,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-bellman"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57a0ef43d09d41602ee6f313f371b7a4b779eae067aa6d2fcb9218be2eede37"
+checksum = "6668703cc9a72754c4081991cc81180fed31e25b8069c1ff5c3c4fdb41e1850f"
 dependencies = [
  "bitvec",
  "blake2s_simd",
@@ -7712,9 +7712,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-bls12-381"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70821a2d2c88a38585d239651d620e78092e404cdfcc9c75a13118239481da"
+checksum = "2edea13b7bba94ccb7aa473b30e4c390549ffe7c25d83919d6ba4e9b65626497"
 dependencies = [
  "ff 0.14.0",
  "group 0.14.0",
@@ -7725,9 +7725,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-client-backend"
-version = "0.1.0-rc4"
+version = "0.1.0-rc5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70f61bb142b29dfd260561cccb21a657acdf86c2e901189817acdf3e25d5d6"
+checksum = "ad892817774c836ab37239af03840b17368a4c5ed364f9ee868273bb0ddf0ada"
 dependencies = [
  "arti-client",
  "async-trait",
@@ -7794,9 +7794,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-client-sqlite"
-version = "0.1.0-rc4"
+version = "0.1.0-rc5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1a4276239587ef4090c28320246c76fb25a6a76b788020d0082e128153c53b"
+checksum = "4757a07d2fcc344aa2bbec9ba4d68d95d09ed9968b1d3032f0ca348487f251af"
 dependencies = [
  "bip32",
  "bitflags 2.13.1",
@@ -7842,9 +7842,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-gadgets"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2743e20797b1d79d353371cebc78a06573186af0f0eb17c20211fa3e97c122d"
+checksum = "f5d24d27771c16598da80f900efcf8051282221b035931e0b61dd465e70c7e3f"
 dependencies = [
  "arrayvec",
  "ff 0.14.0",
@@ -7858,15 +7858,15 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-legacy-pdqsort"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3324d3eaae64e48717cf18df2f84461385025ad0e05bc77ecf12d9150d07571d"
+checksum = "3ab38fc11181f44ad3158e16e9a247c8a76a1bcf73adfa08b9ea29d3d9f68be6"
 
 [[package]]
 name = "zakura-halo2-poseidon"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f196e3c9b62f963d8bc39901f711f3b76230404613c2fba9d051897d62a9e3"
+checksum = "7f7ea83759fbaa8a599b7e37b71d1b57e3ac9dcb40e42e572a9fc7a8d927e08b"
 dependencies = [
  "bitvec",
  "ff 0.14.0",
@@ -7876,9 +7876,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-proofs"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1386cce49a4d9e4a1b1e32fbbb3ba34d23e53dcefd700ee976d736d72f302a"
+checksum = "dfa509d1ddcec871a2508ae4d90c89c57a55bd49dc0ddb6456adfaad08069222"
 dependencies = [
  "blake2b_simd",
  "ff 0.14.0",
@@ -7893,9 +7893,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-jubjub"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494ad340524224ea1e4b8e9f242825cf2a4e1e4421e6ef39af65a562347c2e15"
+checksum = "e7cc2178b04ba26be2676cd74018add8768fcda53326aae8255e7b676f877ee6"
 dependencies = [
  "bitvec",
  "ff 0.14.0",
@@ -7907,9 +7907,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-keys"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9821f05289f696c0a6ae8586facd324da5b0297ff6705a16d6f50ddcfd8de73f"
+checksum = "5f301a02dd34dbc50d9ceb59b552501b73f74c47a137f58eba59c9415febf2bd"
 dependencies = [
  "bech32",
  "bip32",
@@ -7934,9 +7934,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-orchard"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5ef84c9e8dfa576e80f7be5aff3449741b57900d78fcbf4f536b42ce909fd6"
+checksum = "6ff7912c408024e03ec9c731e62cf848231fcbd0b7385e9032540d53ebc9a665"
 dependencies = [
  "aes",
  "bitvec",
@@ -7948,6 +7948,7 @@ dependencies = [
  "group 0.14.0",
  "hex",
  "incrementalmerkletree",
+ "maybe-rayon",
  "memuse",
  "nonempty",
  "once_cell",
@@ -7971,18 +7972,18 @@ dependencies = [
 
 [[package]]
 name = "zakura-pairing"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4070556df188aa068ff09235a43c367cb171de10f74902923da8c84ce0aaeb"
+checksum = "5bb93e2fa3d808aee507f0ce5167b2819f692d9c915b2d543eab820050deef73"
 dependencies = [
  "group 0.14.0",
 ]
 
 [[package]]
 name = "zakura-pasta-curves"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b11ea111779520b119485fdb0fd69c3ec96b6eaab0e1bfbfb3f9cb67c55815a"
+checksum = "33817e907eaf89e5871ab0cdfc1054907ec0b3a86759c7a9d41875690f6fd9f4"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -7997,9 +7998,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-pczt"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc78b3e1d6fe525d7e1a7fb17bc07bcc580a21f07ce1aa205cbc29b09f72d30"
+checksum = "e4f816936d17f64f02008363aec6dc46ff1ede6d1e227d2037561c14763b52f2"
 dependencies = [
  "blake2b_simd",
  "document-features",
@@ -8027,9 +8028,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-primitives"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5c71f57ec127e0429928795354ec3971fc58151603657a4a6f1ffd9f4e0d67"
+checksum = "f6d512f69295e815987e4c2802da5a3f37fa86418acca9e35d75f3ba8dc34a5d"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8058,9 +8059,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-proofs"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83174f4acaf7e5eebd3438628a92f0c59e24f856de37ea4a18b2cfbb3ac5c9fb"
+checksum = "dddd09d8b3deb3be91a83ca16325778595a345460cf2e33ec9b05d7c9114f9da"
 dependencies = [
  "blake2b_simd",
  "document-features",
@@ -8080,9 +8081,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-reddsa"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6341ee8bb195dbfb00be64d2e8121d7cc8e7ae14878b4b6724c674b3abb95d7"
+checksum = "23f5849526a1f308f3c522ebdcccd49e4add198d7b31297dedcfce9ff392c9e4"
 dependencies = [
  "blake2b_simd",
  "frost-rerandomized",
@@ -8098,9 +8099,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-redjubjub"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de3e8fc50ba4a6e608c71ae636a120b9e6427e3151252ab855e526040146893"
+checksum = "0ff05cf4b8580b495f180942e702c0f9ecf92346e1204b3b2f8ceb71f98b55b5"
 dependencies = [
  "rand_core 0.10.1",
  "thiserror 2.0.20",
@@ -8110,9 +8111,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-sapling-crypto"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a0158acd9219ba07630d53cf2463b73d222f55a270fadc5b3ccf2ec2a1b277"
+checksum = "cdfa36cec0a3b20da86caee7931f636a80071e27077fff2da7ca03536848d05c"
 dependencies = [
  "aes",
  "bitvec",
@@ -8144,9 +8145,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-sinsemilla"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef987ae2e927d3e53711e93b44c3030df0f430ff44865a06195573eaca5d10a"
+checksum = "ad8f2ee21b5341be7586c4b5ed7d4e114cf85a576837ed68a2da72f4434d26b7"
 dependencies = [
  "group 0.14.0",
  "once_cell",
@@ -8156,9 +8157,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-wallet-lib"
-version = "0.1.0-rc4"
+version = "0.1.0-rc5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a1fc54320ff537b9086e618901d1725fe45a9e898d2a953236deda4fcd4421"
+checksum = "e4fd4845e34f1d3fcb93a811bfe0e2f84c28b2a2f884c531e6ed504dcd958f0e"
 dependencies = [
  "zakura-bellman",
  "zakura-bls12-381",
@@ -8285,8 +8286,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "3.1.0-rc.16"
-source = "git+https://github.com/valargroup/zcash_voting.git?tag=v3.1.0-rc.16#46ef27bd637ad8ef3f8f25f87cab5a4b42be0b34"
+version = "3.1.0"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=806fb8fa5d24b75a797a0560e4f1455f836fba8d#806fb8fa5d24b75a797a0560e4f1455f836fba8d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,15 +10,15 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 flutter_rust_bridge = "=2.11.1"
 
 zcash_script = "0.4.3"
-voting-crypto-deps = { version = "=0.2.2" }
-sapling-crypto = { package = "zakura-sapling-crypto", version = "=1.0.0", default-features = false, features = ["circuit"] }
+voting-crypto-deps = { version = "=0.2.3" }
+sapling-crypto = { package = "zakura-sapling-crypto", version = "=1.2.0", default-features = false, features = ["circuit"] }
 uuid = "1.1"
 zip32 = "0.2"
-pasta_curves = { package = "zakura-pasta-curves", version = "=1.0.0" }
+pasta_curves = { package = "zakura-pasta-curves", version = "=1.2.0" }
 ff = "0.14"
 # Required by no-op Sapling prover trait impls
-jubjub = { package = "zakura-jubjub", version = "=1.0.0" }
-bls12_381 = { package = "zakura-bls12-381", version = "=1.0.0" }
+jubjub = { package = "zakura-jubjub", version = "=1.2.0" }
+bls12_381 = { package = "zakura-bls12-381", version = "=1.2.0" }
 rand_core = "0.6"
 
 # Key generation
@@ -85,14 +85,14 @@ tendermint-light-client-verifier = "0.40.4"
 # `use orchard` / `use zcash_client_backend` keep working.
 [dependencies.zcash_primitives]
 package = "zakura-primitives"
-version = "=1.0.0"
+version = "=1.2.0"
 
 [dependencies.zcash_address]
 version = "0.13.0"
 
 [dependencies.zcash_keys]
 package = "zakura-keys"
-version = "=1.0.0"
+version = "=1.2.0"
 features = ["orchard"]
 
 [dependencies.zcash_protocol]
@@ -104,7 +104,7 @@ version = "0.10.0"
 
 [dependencies.zcash_client_backend]
 package = "zakura-client-backend"
-version = "=0.1.0-rc4"
+version = "=0.1.0-rc5"
 features = [
     "orchard",
     "transparent-inputs",
@@ -117,25 +117,25 @@ features = [
 
 [dependencies.zcash_client_sqlite]
 package = "zakura-client-sqlite"
-version = "=0.1.0-rc4"
+version = "=0.1.0-rc5"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 [dependencies.zcash_voting]
 git = "https://github.com/valargroup/zcash_voting.git"
-tag = "v3.1.0-rc.16"
+rev = "806fb8fa5d24b75a797a0560e4f1455f836fba8d"
 
 [dependencies.orchard]
 package = "zakura-orchard"
-version = "=1.0.0"
+version = "=1.2.0"
 
 [dependencies.zcash_proofs]
 package = "zakura-proofs"
-version = "=1.0.0"
+version = "=1.2.0"
 features = ["local-prover"]
 
 [dependencies.pczt]
 package = "zakura-pczt"
-version = "=0.1.0-rc2"
+version = "=0.1.0-rc3"
 features = [
     "orchard",
     "io-finalizer",
@@ -172,13 +172,13 @@ zcash_note_encryption = "0.4"
 
 [dev-dependencies.zcash_voting]
 git = "https://github.com/valargroup/zcash_voting.git"
-tag = "v3.1.0-rc.16"
+rev = "806fb8fa5d24b75a797a0560e4f1455f836fba8d"
 features = ["test-fixtures"]
 
 [dev-dependencies.vote-commitment-tree]
-version = "=0.6.0"
+version = "=0.6.1"
 git = "https://github.com/valargroup/zcash_voting.git"
-tag = "v3.1.0-rc.16"
+rev = "806fb8fa5d24b75a797a0560e4f1455f836fba8d"
 default-features = false
 features = ["zakura"]
 

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -225,18 +225,28 @@ void main() {
     );
   });
 
-  test('proposal parser rejects ids outside Rust vote protocol range', () {
+  test('proposal parser accepts ids through 50', () {
+    final proposals = proposalsFromJson({
+      'proposals': [
+        {'id': 50, 'title': 'Maximum id'},
+      ],
+    });
+
+    expect(proposals.single.id, 50);
+  });
+
+  test('proposal parser rejects ids outside supported range', () {
     expect(
       () => proposalsFromJson({
         'proposals': [
-          {'id': 0, 'title': 'Zero'},
+          {'id': 51, 'title': 'Too high'},
         ],
       }),
       throwsA(
         isA<FormatException>().having(
           (error) => error.message,
           'message',
-          'id must be 1..15, got 0',
+          'id must be 1..50, got 51',
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- update `zcash_voting` from `v3.1.0-rc.16` to the 3.1.0 dependency revision and align the required Zakura/PIR crate versions
- accept voting proposal IDs from 1 through 50
- add regression coverage for the new upper boundary and rejection above it

## Motivation / Why
Voting rounds can now contain up to 50 proposals. The previous Dart parser rejected proposal 16 and prevented those rounds from loading.

## Impact
- user-visible: voting rounds with proposal IDs 16–50 can load
- wallet state/migrations: no changes
- security/privacy/network behavior: no intended changes
- cross-platform: shared Dart and Rust dependency changes apply to all platforms

## Tests
- `fvm flutter test test/features/voting/voting_flow_models_test.dart`
- macOS Debug testnet build

Full Flutter and Rust suites were not run to keep this initial review iteration fast; the PR remains a draft.