### PR TITLE
Recover inconsistent lightwalletd scan batches

### DIFF
--- a/rust/src/wallet/sync_engine/block_source.rs
+++ b/rust/src/wallet/sync_engine/block_source.rs
@@ -52,6 +52,29 @@ impl MemoryBlockSource {
                 .all(|(offset, block)| block.height == u64::from(start) + offset as u64)
     }
 
+    pub(super) fn first_block_prev_hash(&self) -> Option<Vec<u8>> {
+        self.blocks.first().map(|block| block.prev_hash.clone())
+    }
+
+    /// Whether the preceding tree state and first compact block satisfy the
+    /// same commitment-count invariant that `put_blocks` enforces.
+    pub(super) fn starts_after(&self, from_state: &chain::ChainState) -> bool {
+        self.blocks.first().is_some_and(|block| {
+            let metadata = block.chain_metadata.unwrap_or_default();
+            let sapling_commitments: usize = block.vtx.iter().map(|tx| tx.outputs.len()).sum();
+            let orchard_commitments: usize = block.vtx.iter().map(|tx| tx.actions.len()).sum();
+            let ironwood_commitments: usize =
+                block.vtx.iter().map(|tx| tx.ironwood_actions.len()).sum();
+
+            from_state.final_sapling_tree().tree_size() + sapling_commitments as u64
+                == metadata.sapling_commitment_tree_size as u64
+                && from_state.final_orchard_tree().tree_size() + orchard_commitments as u64
+                    == metadata.orchard_commitment_tree_size as u64
+                && from_state.final_ironwood_tree().tree_size() + ironwood_commitments as u64
+                    == metadata.ironwood_commitment_tree_size as u64
+        })
+    }
+
     /// Returns the block heights that scanning will add as Orchard subtree
     /// checkpoints before Orchard checkpoint pruning runs.
     pub(super) fn orchard_checkpoint_heights(&self) -> BTreeSet<u32> {
@@ -115,6 +138,7 @@ impl chain::BlockSource for MemoryBlockSource {
 mod tests {
     use super::*;
     use zcash_client_backend::proto::compact_formats::{CompactOrchardAction, CompactTx};
+    use zcash_primitives::block::BlockHash;
 
     #[test]
     fn orchard_checkpoint_heights_exclude_later_cross_pool_checkpoints() {
@@ -164,5 +188,36 @@ mod tests {
         assert!(!blocks(&[10, 12]).contains_exact_range(10, 13));
         assert!(!blocks(&[10, 11, 12, 13]).contains_exact_range(10, 13));
         assert!(!blocks(&[11, 10, 12]).contains_exact_range(10, 13));
+    }
+
+    #[test]
+    fn first_block_must_extend_every_commitment_tree() {
+        let from_state = chain::ChainState::empty(BlockHeight::from_u32(9), BlockHash([0u8; 32]));
+        let mut block = CompactBlock {
+            height: 10,
+            prev_hash: vec![0u8; 32],
+            chain_metadata: Some(Default::default()),
+            vtx: vec![CompactTx {
+                outputs: vec![Default::default()],
+                actions: vec![CompactOrchardAction::default()],
+                ironwood_actions: vec![CompactOrchardAction::default()],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let metadata = block.chain_metadata.as_mut().unwrap();
+        metadata.sapling_commitment_tree_size = 1;
+        metadata.orchard_commitment_tree_size = 1;
+        metadata.ironwood_commitment_tree_size = 1;
+
+        assert!(MemoryBlockSource::new(vec![block.clone()]).starts_after(&from_state));
+
+        block
+            .chain_metadata
+            .as_mut()
+            .unwrap()
+            .orchard_commitment_tree_size = 0;
+        assert!(!MemoryBlockSource::new(vec![block]).starts_after(&from_state));
+        assert!(!MemoryBlockSource::new(vec![]).starts_after(&from_state));
     }
 }

--- a/rust/src/wallet/sync_engine/block_source.rs
+++ b/rust/src/wallet/sync_engine/block_source.rs
@@ -56,8 +56,9 @@ impl MemoryBlockSource {
         self.blocks.first().map(|block| block.prev_hash.clone())
     }
 
-    /// Whether the preceding tree state and first compact block satisfy the
-    /// same commitment-count invariant that `put_blocks` enforces.
+    /// Whether the preceding tree state and first compact block have matching
+    /// identities and satisfy the commitment-count invariant that `put_blocks`
+    /// enforces. The zero hash identifies the synthetic pre-activation state.
     pub(super) fn starts_after(&self, from_state: &chain::ChainState) -> bool {
         self.blocks.first().is_some_and(|block| {
             let metadata = block.chain_metadata.unwrap_or_default();
@@ -65,9 +66,13 @@ impl MemoryBlockSource {
             let orchard_commitments: usize = block.vtx.iter().map(|tx| tx.actions.len()).sum();
             let ironwood_commitments: usize =
                 block.vtx.iter().map(|tx| tx.ironwood_actions.len()).sum();
+            let from_hash = from_state.block_hash().0;
+            let predecessor_matches =
+                from_hash == [0u8; 32] || block.prev_hash.as_slice() == from_hash;
 
-            from_state.final_sapling_tree().tree_size() + sapling_commitments as u64
-                == metadata.sapling_commitment_tree_size as u64
+            predecessor_matches
+                && from_state.final_sapling_tree().tree_size() + sapling_commitments as u64
+                    == metadata.sapling_commitment_tree_size as u64
                 && from_state.final_orchard_tree().tree_size() + orchard_commitments as u64
                     == metadata.orchard_commitment_tree_size as u64
                 && from_state.final_ironwood_tree().tree_size() + ironwood_commitments as u64
@@ -211,6 +216,12 @@ mod tests {
         metadata.ironwood_commitment_tree_size = 1;
 
         assert!(MemoryBlockSource::new(vec![block.clone()]).starts_after(&from_state));
+
+        let identified_state =
+            chain::ChainState::empty(BlockHeight::from_u32(9), BlockHash([1u8; 32]));
+        assert!(!MemoryBlockSource::new(vec![block.clone()]).starts_after(&identified_state));
+        block.prev_hash = vec![1u8; 32];
+        assert!(MemoryBlockSource::new(vec![block.clone()]).starts_after(&identified_state));
 
         block
             .chain_metadata

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -360,16 +360,40 @@ pub(super) async fn get_tree_state(
     client: &mut CompactTxStreamerClient<Channel>,
     height: u64,
 ) -> Result<TreeState, SyncError> {
+    request_tree_state(
+        client,
+        BlockId {
+            height,
+            hash: vec![],
+        },
+    )
+    .await
+}
+
+/// Return the note commitment tree state for an exact block identity. Pinning
+/// by hash prevents a load-balanced lightwalletd from pairing compact blocks
+/// from one reorg branch with a same-height tree state from another.
+pub(super) async fn get_tree_state_for_block(
+    client: &mut CompactTxStreamerClient<Channel>,
+    mut hash: Vec<u8>,
+) -> Result<TreeState, SyncError> {
+    // CompactBlock hashes use protocol byte order. The reference Go
+    // lightwalletd GetTreeState implementation expects display byte order for
+    // hash-only lookups, and gives height precedence whenever both fields are
+    // populated. Reverse the hash and leave height unset so this lookup is
+    // actually pinned to the compact block's predecessor.
+    hash.reverse();
+    request_tree_state(client, BlockId { height: 0, hash }).await
+}
+
+async fn request_tree_state(
+    client: &mut CompactTxStreamerClient<Channel>,
+    block: BlockId,
+) -> Result<TreeState, SyncError> {
     await_tonic_response(
         "get_tree_state",
         LIGHTWALLETD_UNARY_RPC_TIMEOUT,
-        client.get_tree_state(timed_request(
-            BlockId {
-                height,
-                hash: vec![],
-            },
-            LIGHTWALLETD_UNARY_RPC_TIMEOUT,
-        )),
+        client.get_tree_state(timed_request(block, LIGHTWALLETD_UNARY_RPC_TIMEOUT)),
     )
     .await
     .map_err(|e| status_to_network_error("get_tree_state", e))

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -2083,12 +2083,17 @@ fn validate_scan_batch(
         )));
     }
     if !block_source.starts_after(from_state) {
-        return Err(SyncError::other(
-            "downloaded compact blocks and preceding tree state are inconsistent",
-        ));
+        return Err(inconsistent_scan_batch_error(start));
     }
 
     Ok(())
+}
+
+fn inconsistent_scan_batch_error(start: BlockHeight) -> SyncError {
+    SyncError::net(format!(
+        "lightwalletd returned an inconsistent compact block/tree-state tuple while scanning from {}",
+        u32::from(start),
+    ))
 }
 
 struct Prefetch<T> {
@@ -2513,6 +2518,9 @@ async fn run_payment_link_claim_sync_once(
                     }
                     ChainError::Wallet(SqliteClientError::BlockConflict(at)) => {
                         SyncError::continuity(u32::from(at) as u64, "payment-link block conflict")
+                    }
+                    ChainError::Wallet(SqliteClientError::NonSequentialBlocks) => {
+                        inconsistent_scan_batch_error(start)
                     }
                     ChainError::Wallet(wallet_error)
                         if is_commitment_tree_root_conflict(&wallet_error) =>
@@ -3429,11 +3437,7 @@ async fn run_sync_impl(
                     )
                 }
                 ChainError::Wallet(SqliteClientError::NonSequentialBlocks) => {
-                    let at_height = u32::from(start) as u64;
-                    SyncError::other(format!(
-                        "non-sequential compact block batch while scanning from {at_height}; \
-                         retrying with a fresh block/tree-state tuple"
-                    ))
+                    inconsistent_scan_batch_error(start)
                 }
                 ChainError::Wallet(wallet_err) if is_commitment_tree_root_conflict(&wallet_err) => {
                     let at_height = u32::from(start) as u64;
@@ -4904,6 +4908,18 @@ mod tests {
                 "{name}: {error}"
             );
         }
+    }
+
+    #[test]
+    fn inconsistent_scan_batches_are_retryable_network_failures() {
+        let error = inconsistent_scan_batch_error(block_height(10));
+
+        assert!(matches!(error, SyncError::Network(_)));
+        assert_eq!(
+            error.recovery_strategy(),
+            RecoveryStrategy::RetryWithBackoff,
+        );
+        assert!(error.to_string().starts_with("network:"));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -56,7 +56,7 @@ pub(crate) use error::SyncError;
 use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN};
 use lwd::{
     download_blocks, download_subtree_roots, get_address_utxos_stream, get_compact_block_hash,
-    get_tree_state,
+    get_tree_state, get_tree_state_for_block,
 };
 pub(crate) use lwd::{
     get_latest_block, get_taddress_txids, get_transaction, next_stream_message,
@@ -2013,8 +2013,8 @@ where
 }
 
 /// Downloads one compact-block batch and its preceding chain state in
-/// parallel. The requests are independent, and cloned tonic clients share the
-/// underlying HTTP/2 connection.
+/// parallel. If independently served responses do not form one sequence, the
+/// tree state is fetched again by the first block's exact predecessor hash.
 async fn download_scan_batch(
     client: &mut CompactTxStreamerClient<Channel>,
     start: BlockHeight,
@@ -2027,15 +2027,36 @@ async fn download_scan_batch(
         if use_empty_state {
             Ok(chain::ChainState::empty(start - 1, BlockHash([0u8; 32])))
         } else {
-            let state =
-                get_tree_state(&mut tree_state_client, u64::from(u32::from(start - 1))).await?;
-            state
+            get_tree_state(&mut tree_state_client, u64::from(u32::from(start - 1)))
+                .await?
                 .to_chain_state()
                 .map_err(|e| SyncError::parse(format!("parse tree state: {e}")))
         }
     };
 
-    join_scan_batch_inputs(download_blocks(client, start, end, network), tree_state).await
+    let (block_source, from_state) =
+        join_scan_batch_inputs(download_blocks(client, start, end, network), tree_state).await?;
+    if block_source.starts_after(&from_state) {
+        return Ok((block_source, from_state));
+    }
+
+    let predecessor_hash = match block_source
+        .first_block_prev_hash()
+        .filter(|hash| !hash.is_empty())
+    {
+        Some(hash) => hash,
+        None => {
+            let BlockHash(hash) =
+                get_compact_block_hash(client, u64::from(u32::from(start - 1))).await?;
+            hash.to_vec()
+        }
+    };
+    let pinned_state = get_tree_state_for_block(client, predecessor_hash)
+        .await?
+        .to_chain_state()
+        .map_err(|e| SyncError::parse(format!("parse hash-pinned tree state: {e}")))?;
+
+    Ok((block_source, pinned_state))
 }
 
 fn validate_scan_batch(
@@ -2060,6 +2081,11 @@ fn validate_scan_batch(
             "downloaded tree state height {} does not match scan frontier {frontier_height}",
             u32::from(from_state.block_height()),
         )));
+    }
+    if !block_source.starts_after(from_state) {
+        return Err(SyncError::other(
+            "downloaded compact blocks and preceding tree state are inconsistent",
+        ));
     }
 
     Ok(())
@@ -3401,6 +3427,13 @@ async fn run_sync_impl(
                         at_height,
                         format!("BlockConflict at {at_height}: wallet rewind required"),
                     )
+                }
+                ChainError::Wallet(SqliteClientError::NonSequentialBlocks) => {
+                    let at_height = u32::from(start) as u64;
+                    SyncError::other(format!(
+                        "non-sequential compact block batch while scanning from {at_height}; \
+                         retrying with a fresh block/tree-state tuple"
+                    ))
                 }
                 ChainError::Wallet(wallet_err) if is_commitment_tree_root_conflict(&wallet_err) => {
                     let at_height = u32::from(start) as u64;


### PR DESCRIPTION
## Summary

Recover compact-block scan batches when independently served lightwalletd responses do not describe one sequential chain state.

- Keep compact-block and predecessor tree-state requests concurrent on the normal path.
- Validate the first block against the supplied Sapling, Orchard, and Ironwood frontiers before scanning.
- If the tuple is inconsistent, fetch the predecessor tree state again using the first compact block's exact `prev_hash`.
- Validate the recovered tuple before any wallet write.
- Treat a remaining `NonSequentialBlocks` result as retryable rather than as fatal database corruption.

## Bug

A scan batch combines compact blocks beginning at height `N` with the commitment-tree state after block `N - 1`. These are independent lightwalletd requests. The tree-state request previously identified its block only by height.

During a reorg, or when a load-balanced endpoint serves requests from replicas with different chain views, the block range can come from one branch while the same-height tree state comes from another. The heights still pass validation, but the predecessor frontier plus the first block's commitments does not equal that block's advertised final tree size. librustzcash then rejects the batch from `put_blocks` as `NonSequentialBlocks`.

This has been reproduced repeatedly on testnet, including from the physical iOS test flow, with the sync failing on:

> `put_blocks` requires that the provided block range be sequential

The compact block heights themselves were ordered. The non-sequential transition was between the independently fetched predecessor tree state and the first compact block. The old generic mapping also presented this transient response inconsistency as a fatal wallet storage error.

## Alternatives considered

### Always request tree state by hash

Downloading the first block, reading its `prev_hash`, and then requesting tree state by that hash is the simplest correctness model. It serializes the block download and tree-state request, however, adding approximately one lightwalletd round trip to every batch. That is most visible on first batches, small tip updates, and prefetch misses.

### Retry `NonSequentialBlocks` without validating inputs

Classifying the error as retryable prevents a false storage failure, but does not address the source of the mismatch. A retry can receive the same inconsistent pair again and wastes a complete scan attempt before detecting it.

### Carry tree state locally across an entire scan range

Fetching one hash-pinned frontier at the start of a contiguous range and advancing it locally between batches would remove repeated tree-state requests. This is potentially the best long-term architecture, but it is a substantially larger change to frontier ownership, range transitions, prefetching, and reorg recovery.

## Why this solution

The selected approach preserves the existing pipelined fast path. Blocks and height-based tree state still arrive concurrently, and matching responses incur no additional RPC.

The continuity predicate mirrors the invariant enforced by librustzcash `put_blocks` for all three shielded pools. Only a mismatched tuple takes the slower path, where the tree-state lookup is pinned to the exact predecessor hash advertised by the downloaded blocks. A final pre-scan validation prevents inconsistent data from reaching the wallet database, while retryable handling remains as a defensive fallback.

This keeps the change focused, avoids schema or API changes, does not alter valid wallet state, and applies equally across platforms because synchronization is owned by the Rust core.

## Tests

- `cd rust && cargo fmt --check`
- `cd rust && cargo test --locked wallet::sync_engine --lib`
  - 114 passed; 0 failed

A deterministic unit test covers matching Sapling, Orchard, and Ironwood commitment sizes, an inconsistent Orchard frontier, and an empty block source.

The heavy regtest suites were not run; reproducing disagreement between independently served testnet replicas is not deterministic in the local single-chain regtest environment.
