### PR TITLE
Recover interrupted votes without a stale retry error

### DIFF
--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -371,6 +371,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     if (current == null) return;
     state = AsyncData(
       current.copyWith(
+        phase: current.phase == VotingSessionPhase.error
+            ? _phaseForPlans(current.roundPlan)
+            : current.phase,
         clearVoteSubmissionProgress: true,
         clearCurrentVoteKey: true,
         clearError: true,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7072,7 +7072,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.6.1"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=9f3bb4812a418af805742303f1a41b065a4d38fc#9f3bb4812a418af805742303f1a41b065a4d38fc"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=38bd8ebd9945d60317ccc1f96f8bf829abe09438#38bd8ebd9945d60317ccc1f96f8bf829abe09438"
 dependencies = [
  "anyhow",
  "imt-tree",
@@ -7086,7 +7086,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.8.1"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=9f3bb4812a418af805742303f1a41b065a4d38fc#9f3bb4812a418af805742303f1a41b065a4d38fc"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=38bd8ebd9945d60317ccc1f96f8bf829abe09438#38bd8ebd9945d60317ccc1f96f8bf829abe09438"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -8288,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "4.0.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=9f3bb4812a418af805742303f1a41b065a4d38fc#9f3bb4812a418af805742303f1a41b065a4d38fc"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=38bd8ebd9945d60317ccc1f96f8bf829abe09438#38bd8ebd9945d60317ccc1f96f8bf829abe09438"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -184,10 +184,10 @@ default-features = false
 features = ["zakura"]
 
 [patch.crates-io]
-# Pinned to #329, which allows fifty concurrent helper share deliveries.
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "9f3bb4812a418af805742303f1a41b065a4d38fc" }
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "9f3bb4812a418af805742303f1a41b065a4d38fc" }
-vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "9f3bb4812a418af805742303f1a41b065a4d38fc" }
+# Includes recovery of interrupted submission reservations in the first resumed pass.
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "38bd8ebd9945d60317ccc1f96f8bf829abe09438" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting.git", rev = "38bd8ebd9945d60317ccc1f96f8bf829abe09438" }
+vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting.git", rev = "38bd8ebd9945d60317ccc1f96f8bf829abe09438" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)', 'cfg(ironwood_masquerade)'] }

--- a/test/features/voting/mobile_voting_retry_recovery_test.dart
+++ b/test/features/voting/mobile_voting_retry_recovery_test.dart
@@ -1,0 +1,21 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/voting/screens/mobile/mobile_voting_screens.dart';
+
+import 'voting_retry_recovery_test_utils.dart';
+
+void main() {
+  testWidgets(
+    'mobile retry leaves the error screen before asynchronous recovery',
+    (tester) async {
+      await expectVotingRetryClearsError(
+        tester,
+        screenBuilder: (roundId) => MobileVotingStatusScreen(roundId: roundId),
+        surfaceSize: const Size(390, 844),
+      );
+    },
+  );
+}

--- a/test/features/voting/voting_retry_recovery_test_utils.dart
+++ b/test/features/voting/voting_retry_recovery_test_utils.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_submission_job_provider.dart';
+import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
+    as rust_wire;
+
+import 'round_plan_test_utils.dart';
+
+const _roundId =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+const _message =
+    'an unclassified submission reservation survived process interruption';
+
+/// Exercises the real Retry path while wallet readiness remains pending.
+Future<void> expectVotingRetryClearsError(
+  WidgetTester tester, {
+  required Widget Function(String roundId) screenBuilder,
+  required Size surfaceSize,
+}) async {
+  final readiness = Completer<void>();
+  final session = _RetryRecoveryVotingSessionNotifier(_key, readiness);
+  final container = ProviderContainer(
+    overrides: [
+      votingSubmissionJobsProvider.overrideWith(_InterruptedSubmissionJobs.new),
+      votingSubmissionJobProvider(
+        _key,
+      ).overrideWith(() => _InterruptedSubmissionJob(_key)),
+      votingSubmissionSessionProvider(_key).overrideWith(() => session),
+      votingDraftPersistenceProvider.overrideWithValue(
+        _EmptyDraftPersistence(),
+      ),
+    ],
+  );
+  addTearDown(() {
+    container.dispose();
+    readiness.complete();
+  });
+  final router = GoRouter(
+    initialLocation: '/voting/poll/$_roundId/status',
+    routes: [
+      GoRoute(
+        path: '/voting/poll/:roundId/status',
+        builder: (_, state) => screenBuilder(state.pathParameters['roundId']!),
+      ),
+    ],
+  );
+  addTearDown(router.dispose);
+  await tester.binding.setSurfaceSize(surfaceSize);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        routerConfig: router,
+        builder: (_, child) =>
+            AppTheme(data: AppThemeData.light, child: child!),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  expect(find.text(_message), findsOneWidget);
+
+  await tester.tap(find.text('Retry'));
+  // Observe the first frame while the next attempt is blocked on readiness.
+  await tester.pump();
+  expect(session.readinessRequested, isTrue);
+  expect(find.text('Voting failed.'), findsNothing);
+  expect(find.text(_message), findsNothing);
+  expect(find.text('Retry'), findsNothing);
+  expect(
+    container.read(votingSubmissionJobProvider(_key)).status,
+    VotingSubmissionJobStatus.running,
+  );
+  expect(
+    container.read(votingSubmissionSessionProvider(_key)).value!.phase,
+    VotingSessionPhase.readyToVote,
+  );
+  await tester.pump(const Duration(milliseconds: 200));
+  expect(find.text('Voting failed.'), findsNothing);
+}
+
+class _InterruptedSubmissionJob extends VotingSubmissionJobNotifier {
+  _InterruptedSubmissionJob(super.key);
+
+  @override
+  VotingSubmissionJobState build() => const VotingSubmissionJobState(
+    key: _key,
+    status: VotingSubmissionJobStatus.error,
+    errorMessage: _message,
+  );
+}
+
+class _InterruptedSubmissionJobs extends VotingSubmissionJobsNotifier {
+  @override
+  VotingSubmissionJobsState build() =>
+      const VotingSubmissionJobsState(jobKeys: [_key]);
+
+  @override
+  Future<VotingSessionKey?> start(
+    String roundId, {
+    String? accountUuid,
+  }) async => _key;
+}
+
+class _RetryRecoveryVotingSessionNotifier
+    extends VotingSubmissionSessionNotifier {
+  _RetryRecoveryVotingSessionNotifier(super.key, this._readiness);
+
+  final Completer<void> _readiness;
+  bool readinessRequested = false;
+
+  @override
+  Future<VotingSessionState> build() async => VotingSessionState(
+    roundId: _roundId,
+    accountUuid: _key.accountUuid,
+    phase: VotingSessionPhase.error,
+    error: const VotingSessionError(message: _message),
+    roundPlan: apiRoundPlan(
+      roundId: _roundId,
+      primaryAction: rust_wire.RoundPlanActionKind.vote,
+      allDecided: true,
+      pendingRecovery: true,
+      blockingRecovery: true,
+      openProposals: Uint32List(0),
+      nextSteps: const [
+        rust_wire.NextStepView(
+          kind: rust_wire.NextStepKind.advanceVote,
+          bundleIndex: 0,
+          proposalId: 1,
+          choice: 0,
+          shareIndex: 0,
+        ),
+      ],
+    ),
+    eligibleWeightZatoshi: BigInt.from(100),
+    round: VotingRoundDetails(
+      roundId: _roundId,
+      title: 'Test round',
+      status: 'active',
+      snapshotHeight: 3359740,
+      eaPk: Uint8List(32),
+      ncRoot: Uint8List(32),
+      nullifierImtRoot: Uint8List(32),
+      rawJson: const {
+        'vote_end_time': 4102444800,
+        'proposals': [
+          {'id': 1, 'title': 'Test proposal'},
+        ],
+      },
+    ),
+  );
+
+  @override
+  Future<void> ensureWalletReadyForVoting() {
+    readinessRequested = true;
+    return _readiness.future;
+  }
+}
+
+class _EmptyDraftPersistence implements VotingDraftPersistence {
+  @override
+  Future<VotingDraftState> load(VotingSessionKey key) async =>
+      const VotingDraftState();
+
+  @override
+  Future<void> save(VotingSessionKey key, VotingDraftState draft) async {}
+
+  @override
+  Future<void> deleteForAccount(String accountUuid) async {}
+}

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -17,7 +17,6 @@ import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
-import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
 import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_provider.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
@@ -68,6 +67,7 @@ import 'package:zcash_wallet/src/services/voting/pir_snapshot_resolver.dart';
 
 import 'fake_voting_round_session.dart';
 import 'round_plan_test_utils.dart';
+import 'voting_retry_recovery_test_utils.dart';
 import '../../services/voting/fake_voting_http.dart';
 import 'fake_round_recovery_state.dart';
 
@@ -664,105 +664,11 @@ void main() {
   testWidgets('retry leaves the error screen before asynchronous recovery', (
     tester,
   ) async {
-    const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
-    const message =
-        'an unclassified submission reservation survived process interruption';
-    final readiness = Completer<void>();
-    final roundPlan = apiRoundPlan(
-      roundId: _roundId,
-      primaryAction: rust_frb_types.RoundPlanActionKind.vote,
-      allDecided: true,
-      pendingRecovery: true,
-      blockingRecovery: true,
-      openProposals: Uint32List(0),
-      nextSteps: const [
-        rust_wire.NextStepView(
-          kind: rust_frb_types.NextStepKind.advanceVote,
-          bundleIndex: 0,
-          proposalId: 1,
-          choice: 0,
-          shareIndex: 0,
-        ),
-      ],
+    await expectVotingRetryClearsError(
+      tester,
+      screenBuilder: (roundId) => VotingStatusView(roundId: roundId),
+      surfaceSize: const Size(1512, 982),
     );
-    final container = _statusContainer(
-      accountOverride: _MnemonicAccountNotifier.new,
-      overrides: [
-        votingSubmissionJobsProvider.overrideWith(
-          () => _StaticVotingSubmissionJobsNotifier(
-            const VotingSubmissionJobsState(jobKeys: [key]),
-          ),
-        ),
-        votingSubmissionJobProvider(key).overrideWith(
-          () => _StaticVotingSubmissionJobNotifier(
-            key,
-            const VotingSubmissionJobState(
-              key: key,
-              status: VotingSubmissionJobStatus.error,
-              errorMessage: message,
-            ),
-          ),
-        ),
-        votingSubmissionSessionProvider(key).overrideWith(
-          () => _RetryRecoveryVotingSessionNotifier(
-            key,
-            VotingSessionState(
-              roundId: _roundId,
-              accountUuid: key.accountUuid,
-              phase: VotingSessionPhase.error,
-              error: const VotingSessionError(message: message),
-              roundPlan: roundPlan,
-              eligibleWeightZatoshi: BigInt.from(100),
-              round: VotingRoundDetails(
-                roundId: _roundId,
-                title: 'Test round',
-                status: 'active',
-                snapshotHeight: 3359740,
-                eaPk: Uint8List(32),
-                ncRoot: Uint8List(32),
-                nullifierImtRoot: Uint8List(32),
-                rawJson: _roundStatusJson(),
-              ),
-            ),
-            readiness,
-          ),
-        ),
-      ],
-    );
-    addTearDown(() {
-      container.dispose();
-      readiness.complete();
-    });
-    final mobile = kAppFormFactor == AppFormFactor.mobile;
-    await tester.binding.setSurfaceSize(
-      mobile ? const Size(390, 844) : const Size(1512, 982),
-    );
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-    await tester.pumpWidget(
-      UncontrolledProviderScope(
-        container: container,
-        child: _statusHarness(mobile: mobile),
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(find.text(message), findsOneWidget);
-
-    await tester.tap(find.text('Retry'));
-    // Observe the first frame while the next attempt is blocked on readiness.
-    await tester.pump();
-    expect(find.text('Voting failed.'), findsNothing);
-    expect(find.text(message), findsNothing);
-    expect(find.text('Retry'), findsNothing);
-    expect(
-      container.read(votingSubmissionJobProvider(key)).status,
-      VotingSubmissionJobStatus.running,
-    );
-    expect(
-      container.read(votingSubmissionSessionProvider(key)).value!.phase,
-      VotingSessionPhase.readyToVote,
-    );
-    await tester.pump(const Duration(milliseconds: 200));
-    expect(find.text('Voting failed.'), findsNothing);
   });
 
   testWidgets('status screen retry keeps setup errors specific', (
@@ -4505,22 +4411,16 @@ Widget _mobileProposalApp(GoRouter router) {
 Widget _statusHarness({
   List<int>? keystoneScanResult,
   String? initialLocation,
-  bool mobile = false,
 }) {
   final router = GoRouter(
     initialLocation: initialLocation ?? '/voting/poll/$_roundId/status',
     routes: [
       GoRoute(
         path: '/voting/poll/:roundId/status',
-        builder: (_, state) => mobile
-            ? MobileVotingStatusScreen(
-                roundId: state.pathParameters['roundId']!,
-                accountUuid: state.uri.queryParameters['account'],
-              )
-            : VotingStatusScreen(
-                roundId: state.pathParameters['roundId']!,
-                accountUuid: state.uri.queryParameters['account'],
-              ),
+        builder: (_, state) => VotingStatusScreen(
+          roundId: state.pathParameters['roundId']!,
+          accountUuid: state.uri.queryParameters['account'],
+        ),
       ),
       GoRoute(
         path: '/voting/poll/:roundId/submitted',
@@ -5095,24 +4995,6 @@ class _BlockingVotingSessionNotifier extends VotingSessionNotifier {
 
   @override
   Future<VotingSessionState> build() => _future;
-}
-
-class _RetryRecoveryVotingSessionNotifier
-    extends VotingSubmissionSessionNotifier {
-  _RetryRecoveryVotingSessionNotifier(
-    super.key,
-    this._initial,
-    this._readiness,
-  );
-
-  final VotingSessionState _initial;
-  final Completer<void> _readiness;
-
-  @override
-  Future<VotingSessionState> build() async => _initial;
-
-  @override
-  Future<void> ensureWalletReadyForVoting() => _readiness.future;
 }
 
 class _BlockedRefreshVotingSubmissionSessionNotifier

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:zcash_wallet/src/core/security/software_wallet_secret.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
 import 'package:zcash_wallet/src/core/navigation/payment_uri_busy_surface_provider.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
@@ -658,6 +659,110 @@ void main() {
     expect(find.text(message), findsOneWidget);
     expect(find.text('submission confirmed route'), findsNothing);
     expect(rust.eligibilityCheckCalls, 1);
+  });
+
+  testWidgets('retry leaves the error screen before asynchronous recovery', (
+    tester,
+  ) async {
+    const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+    const message =
+        'an unclassified submission reservation survived process interruption';
+    final readiness = Completer<void>();
+    final roundPlan = apiRoundPlan(
+      roundId: _roundId,
+      primaryAction: rust_frb_types.RoundPlanActionKind.vote,
+      allDecided: true,
+      pendingRecovery: true,
+      blockingRecovery: true,
+      openProposals: Uint32List(0),
+      nextSteps: const [
+        rust_wire.NextStepView(
+          kind: rust_frb_types.NextStepKind.advanceVote,
+          bundleIndex: 0,
+          proposalId: 1,
+          choice: 0,
+          shareIndex: 0,
+        ),
+      ],
+    );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSubmissionJobsProvider.overrideWith(
+          () => _StaticVotingSubmissionJobsNotifier(
+            const VotingSubmissionJobsState(jobKeys: [key]),
+          ),
+        ),
+        votingSubmissionJobProvider(key).overrideWith(
+          () => _StaticVotingSubmissionJobNotifier(
+            key,
+            const VotingSubmissionJobState(
+              key: key,
+              status: VotingSubmissionJobStatus.error,
+              errorMessage: message,
+            ),
+          ),
+        ),
+        votingSubmissionSessionProvider(key).overrideWith(
+          () => _RetryRecoveryVotingSessionNotifier(
+            key,
+            VotingSessionState(
+              roundId: _roundId,
+              accountUuid: key.accountUuid,
+              phase: VotingSessionPhase.error,
+              error: const VotingSessionError(message: message),
+              roundPlan: roundPlan,
+              eligibleWeightZatoshi: BigInt.from(100),
+              round: VotingRoundDetails(
+                roundId: _roundId,
+                title: 'Test round',
+                status: 'active',
+                snapshotHeight: 3359740,
+                eaPk: Uint8List(32),
+                ncRoot: Uint8List(32),
+                nullifierImtRoot: Uint8List(32),
+                rawJson: _roundStatusJson(),
+              ),
+            ),
+            readiness,
+          ),
+        ),
+      ],
+    );
+    addTearDown(() {
+      container.dispose();
+      readiness.complete();
+    });
+    final mobile = kAppFormFactor == AppFormFactor.mobile;
+    await tester.binding.setSurfaceSize(
+      mobile ? const Size(390, 844) : const Size(1512, 982),
+    );
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _statusHarness(mobile: mobile),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text(message), findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    // Observe the first frame while the next attempt is blocked on readiness.
+    await tester.pump();
+    expect(find.text('Voting failed.'), findsNothing);
+    expect(find.text(message), findsNothing);
+    expect(find.text('Retry'), findsNothing);
+    expect(
+      container.read(votingSubmissionJobProvider(key)).status,
+      VotingSubmissionJobStatus.running,
+    );
+    expect(
+      container.read(votingSubmissionSessionProvider(key)).value!.phase,
+      VotingSessionPhase.readyToVote,
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text('Voting failed.'), findsNothing);
   });
 
   testWidgets('status screen retry keeps setup errors specific', (
@@ -4400,16 +4505,22 @@ Widget _mobileProposalApp(GoRouter router) {
 Widget _statusHarness({
   List<int>? keystoneScanResult,
   String? initialLocation,
+  bool mobile = false,
 }) {
   final router = GoRouter(
     initialLocation: initialLocation ?? '/voting/poll/$_roundId/status',
     routes: [
       GoRoute(
         path: '/voting/poll/:roundId/status',
-        builder: (_, state) => VotingStatusScreen(
-          roundId: state.pathParameters['roundId']!,
-          accountUuid: state.uri.queryParameters['account'],
-        ),
+        builder: (_, state) => mobile
+            ? MobileVotingStatusScreen(
+                roundId: state.pathParameters['roundId']!,
+                accountUuid: state.uri.queryParameters['account'],
+              )
+            : VotingStatusScreen(
+                roundId: state.pathParameters['roundId']!,
+                accountUuid: state.uri.queryParameters['account'],
+              ),
       ),
       GoRoute(
         path: '/voting/poll/:roundId/submitted',
@@ -4984,6 +5095,24 @@ class _BlockingVotingSessionNotifier extends VotingSessionNotifier {
 
   @override
   Future<VotingSessionState> build() => _future;
+}
+
+class _RetryRecoveryVotingSessionNotifier
+    extends VotingSubmissionSessionNotifier {
+  _RetryRecoveryVotingSessionNotifier(
+    super.key,
+    this._initial,
+    this._readiness,
+  );
+
+  final VotingSessionState _initial;
+  final Completer<void> _readiness;
+
+  @override
+  Future<VotingSessionState> build() async => _initial;
+
+  @override
+  Future<void> ensureWalletReadyForVoting() => _readiness.future;
 }
 
 class _BlockedRefreshVotingSubmissionSessionNotifier


### PR DESCRIPTION
Killing the app during vote submission could make the first resumed attempt stop with an interrupted-reservation error. Retrying then briefly showed “Voting failed.” before recovery succeeded. Update the voting SDK pin so the first resumed attempt checks the chain for the saved submission before considering another POST. Reset the session's error phase when Retry starts so asynchronous readiness checks show progress immediately.

Targets #625's branch. The SDK change preserves durable reservations and blocks retransmission until recovery establishes it is safe. Desktop and mobile tests share a fixture that holds readiness pending and checks the first retry frame. The mobile case lives in a mobile-tagged file so the normal mobile lane includes it.

Validation passed with these commands. Rust checks used the installed Rust 1.97.0 toolchain.

- `fvm dart format --output=none --set-exit-if-changed lib/src/providers/voting/voting_session_provider.dart test/features/voting/voting_status_screen_test.dart test/features/voting/mobile_voting_retry_recovery_test.dart test/features/voting/voting_retry_recovery_test_utils.dart`
- `fvm flutter analyze --no-pub`
- `fvm flutter test --no-pub`: 3,825 passed, 115 skipped.
- `fvm flutter test --no-pub --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/voting/mobile_voting_retry_recovery_test.dart`: passed. Removing the phase reset makes this tagged test fail with the stale “Voting failed.” text.
- `RUSTUP_TOOLCHAIN=1.97.0 cargo fmt --manifest-path rust/Cargo.toml --check`
- `RUSTUP_TOOLCHAIN=1.97.0 CARGO_TARGET_DIR=/Users/czstudio/.codex/worktrees/6739/zcash_voting/target/zakura cargo test --manifest-path rust/Cargo.toml --locked --lib`: 750 passed, 4 ignored.

The earlier full mobile run, `fvm flutter test --no-pub --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`, had 1,340 passing tests and 20 failures. All 20 failures also reproduce without this change in the same five unrelated test files. No iOS device build, force-quit rehearsal, or stage end-to-end test was run. Validation uses the SDK's persisted restart tests and Vizor's widget and Rust unit tests.

